### PR TITLE
Code review: downloader robustness (Range GET probe, fallback retry) + advanced tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## v0.2.0 - 2025-08-29
+- Feature: Model-aware default filenames for CivitAI downloads
+  - Resolver returns model/version metadata and SuggestedFilename
+  - CivitAI resolver computes `<ModelName> - <OriginalFileName>` (sanitized)
+  - CLI uses SuggestedFilename when `--dest` is omitted for `civitai://` URIs
+  - Collision handling via `(v<versionId>)` or numeric suffixes `(2)`, `(3)`, etc.
+- Utilities: Added `util.SafeFileName` and `util.UniquePath` helpers
+- Tests: Updated downloader tests; added tests for util helpers; assertions for SuggestedFilename in resolver tests
+- Docs: Updated README.md, docs/RESOLVERS.md, docs/BATCH.md; added docs/TODO.md plan
+
+## v0.1.0 - 2025-08-29
+- Initial MVP with:
+  - hf:// and civitai:// resolvers
+  - Chunked and single-stream downloaders with resume
+  - SHA256 verification, state DB, TUI skeleton, placement engine
+

--- a/README.md
+++ b/README.md
@@ -66,45 +66,50 @@ Configuration
   ```
 - See docs/CONFIG.md for full schema.
 
-User guide
+User guide (see docs/USER_GUIDE.md for full guide)
 - Validate config:
-  ```
+  
   modfetch config validate --config /path/to/config.yml
-  ```
+  
 - Download with live progress (CLI shows progress bar, speed, ETA):
-  ```
+  
   modfetch download --config /path/to/config.yml --url 'https://proof.ovh.net/files/1Mb.dat'
   modfetch download --config /path/to/config.yml --url 'hf://gpt2/README.md?rev=main'
   modfetch download --config /path/to/config.yml --url 'civitai://model/123456?file=vae'
-  ```
+  
   - Quiet mode (suppress progress/info logs): add `--quiet`
   - On completion, a summary is printed (dest, size, SHA256, duration, average speed)
 - Place artifacts into apps:
-  ```
+  
   modfetch place --config /path/to/config.yml --path /path/to/model.safetensors
-  ```
+  
 - Batch downloads from YAML (optionally place after):
-  ```
+  
   modfetch download --config /path/to/config.yml --batch /path/to/jobs.yml --place
-  ```
+  
   - See docs/BATCH.md for full batch schema and examples
 - TUI dashboard (live status, filter, per-row speed/ETA):
-  ```
+  
   modfetch tui --config /path/to/config.yml
-  ```
-  - Keys: q (quit), r (refresh), j/k (select), d (details), / (filter)
-- Verify checksums:
-  ```
+  
+  - Keys: q (quit), r (refresh), j/k (select), d (details), / (filter), s (sort by speed), e (sort by ETA)
+- Verify checksums in state:
+  
   modfetch verify --config /path/to/config.yml --all
-  ```
+  
+- Deep-verify safetensors and scan/repair a directory:
+  
+  modfetch verify --config /path/to/config.yml --scan-dir /path/to/models --safetensors-deep
+  modfetch verify --config /path/to/config.yml --scan-dir /path/to/models --safetensors-deep --repair --quarantine-incomplete
+  
 - JSON summary (for scripting/CI):
-  ```
+  
   modfetch download --config /path/to/config.yml --url 'https://proof.ovh.net/files/1Mb.dat' --summary-json
-  ```
+  
 - Placement dry-run:
-  ```
+  
   modfetch place --config /path/to/config.yml --path /path/to/model.safetensors --dry-run
-  ```
+  
 
 Resolvers
 - See docs/RESOLVERS.md for hf:// and civitai:// formats, examples, and auth via env tokens.

--- a/README.md
+++ b/README.md
@@ -100,11 +100,13 @@ User guide (see docs/USER_GUIDE.md for full guide)
   
   modfetch verify --config /path/to/config.yml --all
   
+  - Use `--only-errors` to show only problematic files; add `--summary` for totals and paths
 - Deep-verify safetensors and scan/repair a directory:
   
   modfetch verify --config /path/to/config.yml --scan-dir /path/to/models --safetensors-deep
   modfetch verify --config /path/to/config.yml --scan-dir /path/to/models --safetensors-deep --repair --quarantine-incomplete
   
+  - Only errors + summary: add `--only-errors --summary`
 - JSON summary (for scripting/CI):
   
   modfetch download --config /path/to/config.yml --url 'https://proof.ovh.net/files/1Mb.dat' --summary-json

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ User guide (see docs/USER_GUIDE.md for full guide)
   modfetch download --config /path/to/config.yml --url 'hf://gpt2/README.md?rev=main'
   modfetch download --config /path/to/config.yml --url 'civitai://model/123456?file=vae'
   
+  - URL forms:
+    - civitai://model/{id}[?version=...] is supported; base page URLs like https://civitai.com/models/{id} are auto-resolved to the latest version’s primary file
+    - hf://org/repo/path?rev=... is supported
   - Default filename:
     - civitai:// uses `<ModelName> - <OriginalFileName>` if `--dest` is omitted (with collision-safe suffixes)
     - others use the basename of the resolved URL
@@ -95,7 +98,15 @@ User guide (see docs/USER_GUIDE.md for full guide)
   
   modfetch tui --config /path/to/config.yml
   
-  - Keys: q (quit), r (refresh), j/k (select), d (details), / (filter), s (sort by speed), e (sort by ETA)
+  - Keys:
+    - Navigation: j/k (select), / (filter), m (menu), h/? (help)
+    - Sorting: s (sort by speed), e (sort by ETA), o (clear sort)
+    - Actions: n (new), r (refresh), d (details), g (group by status), t (toggle columns)
+    - Per-row actions: p (pause/cancel), y (retry), C (copy path), U (copy URL), O (open/reveal), D (delete staged), X (clear row)
+  - Behavior:
+    - Shows a resolving spinner row immediately after starting a download and transitions to planning → running
+    - Live speed and ETA for both chunked and single-stream fallback downloads
+    - Accepts CivitAI model page URLs (https://civitai.com/models/ID) and rewrites them internally to the correct direct download URL
 - Verify checksums in state:
   
   modfetch verify --config /path/to/config.yml --all

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ User guide (see docs/USER_GUIDE.md for full guide)
   modfetch download --config /path/to/config.yml --url 'hf://gpt2/README.md?rev=main'
   modfetch download --config /path/to/config.yml --url 'civitai://model/123456?file=vae'
   
+  - Default filename:
+    - civitai:// uses `<ModelName> - <OriginalFileName>` if `--dest` is omitted (with collision-safe suffixes)
+    - others use the basename of the resolved URL
   - Quiet mode (suppress progress/info logs): add `--quiet`
   - On completion, a summary is printed (dest, size, SHA256, duration, average speed)
 - Place artifacts into apps:

--- a/assets/sample-config/config.example.yml
+++ b/assets/sample-config/config.example.yml
@@ -6,6 +6,8 @@ general:
   quarantine: true
   allow_overwrite: false
   dry_run: false
+  stage_partials: true           # write .part files under download_root/.parts (recommended)
+  always_no_resume: false        # force fresh downloads by default (can override with CLI)
 
 network:
   timeout_seconds: 60

--- a/assets/sample-config/config.example.yml
+++ b/assets/sample-config/config.example.yml
@@ -104,4 +104,5 @@ metrics:
 validation:
   require_sha256: true
   accept_md5_sha1_if_provided: false
+  safetensors_deep_verify_after_download: true   # verify coverage/length for .safetensors after download; fail if not exact
 

--- a/assets/sample-config/config.example.yml
+++ b/assets/sample-config/config.example.yml
@@ -2,6 +2,7 @@ version: 1
 general:
   data_root: "~/modfetch-data"
   download_root: "~/Downloads/modfetch"
+  partials_root: "~/Downloads/modfetch/.parts"   # optional override; else defaults to download_root/.parts
   placement_mode: "symlink"     # symlink | hardlink | copy
   quarantine: true
   allow_overwrite: false

--- a/assets/sample-config/config.example.yml
+++ b/assets/sample-config/config.example.yml
@@ -4,7 +4,7 @@ general:
   download_root: "~/Downloads/modfetch"
   partials_root: "~/Downloads/modfetch/.parts"   # optional override; else defaults to download_root/.parts
   placement_mode: "symlink"     # symlink | hardlink | copy
-  quarantine: true
+  quarantine: false
   allow_overwrite: false
   dry_run: false
   stage_partials: true           # write .part files under download_root/.parts (recommended)
@@ -12,13 +12,13 @@ general:
 
 network:
   timeout_seconds: 60
-  max_redirects: 10
+  max_redirects: 5
   tls_verify: true
   user_agent: "modfetch/0.1"
 
 concurrency:
   global_files: 4
-  per_file_chunks: 8
+  per_file_chunks: 4
   per_host_requests: 8
   chunk_size_mb: 8
   max_retries: 8
@@ -93,7 +93,7 @@ logging:
   level: "info"
   format: "human"
   file:
-    enabled: true
+    enabled: false
     path: "~/modfetch-data/logs/modfetch.log"
     max_megabytes: 50
     max_backups: 3
@@ -101,11 +101,11 @@ logging:
 
 metrics:
   prometheus_textfile:
-    enabled: true
-    path: "~/modfetch-data/metrics/prometheus.prom"
+    enabled: false
+    path: ""
 
 validation:
-  require_sha256: true
+  require_sha256: false
   accept_md5_sha1_if_provided: false
   safetensors_deep_verify_after_download: true   # verify coverage/length for .safetensors after download; fail if not exact
 

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"os"
 )
 
 func handleCompletion(args []string) error {

--- a/cmd/modfetch/download_progress.go
+++ b/cmd/modfetch/download_progress.go
@@ -98,14 +98,15 @@ func startProgressLoop(ctx context.Context, st *state.DB, url, dest string) func
 					if r.URL == url && r.Dest == dest { retries = r.Retries; break }
 				}
 				// Bar
-				bar := renderBar(completed, total, 30)
+				bar := renderBar(completed, max64(total, completed), 30)
+				den := max64(total, completed)
 				fmt.Fprintf(os.Stderr, "\r%s %6.2f%%  %8s/s  ETA %s  %s/%s  C %d/%d A %d  R %d",
 					bar,
-					pct(completed, total),
+					pct(completed, den),
 					ifnz(rate, "-"),
 					eta,
 					humanize.Bytes(uint64(completed)),
-					humanize.Bytes(uint64(max64(total, completed))),
+					humanize.Bytes(uint64(den)),
 					cDone, cTotal, cRun,
 					retries,
 				)

--- a/cmd/modfetch/download_progress.go
+++ b/cmd/modfetch/download_progress.go
@@ -31,7 +31,7 @@ func startProgressLoop(ctx context.Context, st *state.DB, url, dest string) func
 		for {
 			select {
 			case <-stop:
-				fmt.Print("\r")
+				fmt.Fprint(os.Stderr, "\r")
 				return
 			case <-time.After(250 * time.Millisecond):
 				// Fetch total size from downloads table
@@ -99,7 +99,7 @@ func startProgressLoop(ctx context.Context, st *state.DB, url, dest string) func
 				}
 				// Bar
 				bar := renderBar(completed, total, 30)
-				fmt.Printf("\r%s %6.2f%%  %8s/s  ETA %s  %s/%s  C %d/%d A %d  R %d",
+				fmt.Fprintf(os.Stderr, "\r%s %6.2f%%  %8s/s  ETA %s  %s/%s  C %d/%d A %d  R %d",
 					bar,
 					pct(completed, total),
 					ifnz(rate, "-"),

--- a/cmd/modfetch/download_progress.go
+++ b/cmd/modfetch/download_progress.go
@@ -164,7 +164,13 @@ func max64(a, b int64) int64 { if a > b { return a }; return b }
 
 // stagedPartPath mirrors downloader.stagePartPath hashing to locate .part for progress
 func stagedPartPath(cfg *config.Config, url, dest string) string {
-	partsDir := filepath.Join(cfg.General.DownloadRoot, ".parts")
+	if cfg != nil && !cfg.General.StagePartials {
+		return dest + ".part"
+	}
+	partsDir := cfg.General.PartialsRoot
+	if strings.TrimSpace(partsDir) == "" {
+		partsDir = filepath.Join(cfg.General.DownloadRoot, ".parts")
+	}
 	keySrc := url + "|" + dest
 	h := sha1.Sum([]byte(keySrc))
 	key := hex.EncodeToString(h[:])[:12]

--- a/cmd/modfetch/hostcaps.go
+++ b/cmd/modfetch/hostcaps.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"modfetch/internal/config"
+	"modfetch/internal/state"
+)
+
+func handleHostCaps(args []string) error {
+	fs := flag.NewFlagSet("hostcaps", flag.ContinueOnError)
+	cfgPath := fs.String("config", "", "Path to YAML config file")
+	list := fs.Bool("list", false, "List cached host capabilities")
+	clear := fs.String("clear", "", "Clear cache for a specific host")
+	clearAll := fs.Bool("clear-all", false, "Clear cache for all hosts")
+	jsonOut := fs.Bool("json", false, "JSON output")
+	if err := fs.Parse(args); err != nil { return err }
+	if *cfgPath == "" { if env := os.Getenv("MODFETCH_CONFIG"); env != "" { *cfgPath = env } }
+	if *cfgPath == "" { return errors.New("--config is required or set MODFETCH_CONFIG") }
+	c, err := config.Load(*cfgPath)
+	if err != nil { return err }
+	st, err := state.Open(c)
+	if err != nil { return err }
+	defer st.SQL.Close()
+	if *clearAll {
+		if err := st.ClearHostCaps(); err != nil { return err }
+		fmt.Println("hostcaps: cleared all")
+		return nil
+	}
+	if *clear != "" {
+		h := strings.ToLower(strings.TrimSpace(*clear))
+		if err := st.DeleteHostCaps(h); err != nil { return err }
+		fmt.Printf("hostcaps: cleared %s\n", h)
+		return nil
+	}
+	if *list || fs.NArg() == 0 {
+		hc, err := st.ListHostCaps()
+		if err != nil { return err }
+		if *jsonOut {
+			enc := json.NewEncoder(os.Stdout); enc.SetIndent("", "  ")
+			return enc.Encode(hc)
+		}
+		for _, h := range hc {
+			fmt.Printf("%s\thead_ok=%v\taccept_ranges=%v\n", h.Host, h.HeadOK, h.AcceptRanges)
+		}
+		return nil
+	}
+	return errors.New("no action provided; use --list, --clear HOST, or --clear-all")
+}

--- a/cmd/modfetch/hostcaps.go
+++ b/cmd/modfetch/hostcaps.go
@@ -22,6 +22,7 @@ func handleHostCaps(args []string) error {
 	if err := fs.Parse(args); err != nil { return err }
 	if *cfgPath == "" { if env := os.Getenv("MODFETCH_CONFIG"); env != "" { *cfgPath = env } }
 	if *cfgPath == "" { return errors.New("--config is required or set MODFETCH_CONFIG") }
+	if _, err := os.Stat(*cfgPath); err != nil { return fmt.Errorf("config file not found: %s", *cfgPath) }
 	c, err := config.Load(*cfgPath)
 	if err != nil { return err }
 	st, err := state.Open(c)

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -243,12 +243,12 @@ func handleDownload(args []string) error {
 			if headers == nil { headers = map[string]string{} }
 			if strings.HasSuffix(h, "civitai.com") && c.Sources.CivitAI.Enabled {
 				if env := strings.TrimSpace(c.Sources.CivitAI.TokenEnv); env != "" {
-					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" { headers["Authorization"] = "Bearer " + tok }
+					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" { headers["Authorization"] = "Bearer " + tok } else { log.Warnf("CivitAI token env %s is not set; gated content will return 401. Export %s.", env, env) }
 				}
 			}
 			if strings.HasSuffix(h, "huggingface.co") && c.Sources.HuggingFace.Enabled {
 				if env := strings.TrimSpace(c.Sources.HuggingFace.TokenEnv); env != "" {
-					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" { headers["Authorization"] = "Bearer " + tok }
+					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" { headers["Authorization"] = "Bearer " + tok } else { log.Warnf("Hugging Face token env %s is not set; gated repos will return 401. Export %s and accept the repo license.", env, env) }
 				}
 			}
 		}

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -60,6 +60,8 @@ func run(args []string) error {
 		return nil
 	case "completion":
 		return handleCompletion(args[1:])
+	case "hostcaps":
+		return handleHostCaps(args[1:])
 	case "help", "-h", "--help":
 		usage()
 		return nil
@@ -87,6 +89,7 @@ Commands:
   version           Print version
   help              Show this help
   completion        Generate shell completion scripts (bash|zsh|fish)
+  hostcaps          Manage host capability cache (list/clear)
 
 Flags:
   --config PATH     Path to YAML config file (or MODFETCH_CONFIG env var)

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -106,6 +106,7 @@ func handleStatus(args []string) error {
 	if err := fs.Parse(args); err != nil { return err }
 	if *cfgPath == "" { if env := os.Getenv("MODFETCH_CONFIG"); env != "" { *cfgPath = env } }
 	if *cfgPath == "" { return errors.New("--config is required or set MODFETCH_CONFIG") }
+	if _, err := os.Stat(*cfgPath); err != nil { return fmt.Errorf("config file not found: %s", *cfgPath) }
 	c, err := config.Load(*cfgPath)
 	if err != nil { return err }
 	_ = c // currently unused; reserved for future filters
@@ -167,6 +168,7 @@ func handleDownload(args []string) error {
 		if env := os.Getenv("MODFETCH_CONFIG"); env != "" { *cfgPath = env }
 	}
 	if *cfgPath == "" { return errors.New("--config is required or set MODFETCH_CONFIG") }
+	if _, err := os.Stat(*cfgPath); err != nil { return fmt.Errorf("config file not found: %s", *cfgPath) }
 	c, err := config.Load(*cfgPath)
 	if err != nil { return err }
 	// quiet forces log level to error unless JSON is requested
@@ -334,6 +336,7 @@ func configOp(args []string, fn func(*config.Config, *logging.Logger) error) err
 	if *cfgPath == "" {
 		return errors.New("--config is required or set MODFETCH_CONFIG")
 	}
+	if _, err := os.Stat(*cfgPath); err != nil { return fmt.Errorf("config file not found: %s", *cfgPath) }
 	c, err := config.Load(*cfgPath)
 	if err != nil {
 		return err

--- a/cmd/modfetch/verify.go
+++ b/cmd/modfetch/verify.go
@@ -34,6 +34,7 @@ func handleVerify(args []string) error {
 	if err := fs.Parse(args); err != nil { return err }
 	if *cfgPath == "" { if env := os.Getenv("MODFETCH_CONFIG"); env != "" { *cfgPath = env } }
 	if *cfgPath == "" { return errors.New("--config is required or set MODFETCH_CONFIG") }
+	if _, err := os.Stat(*cfgPath); err != nil { return fmt.Errorf("config file not found: %s", *cfgPath) }
 	c, err := config.Load(*cfgPath)
 	if err != nil { return err }
 	_ = logging.New(*logLevel, *jsonOut)

--- a/cmd/modfetch/verify.go
+++ b/cmd/modfetch/verify.go
@@ -29,6 +29,10 @@ func handleVerify(args []string) error {
 	pathFlag := fs.String("path", "", "Specific file to verify (optional)")
 	all := fs.Bool("all", false, "Verify all completed downloads")
 	checkST := fs.Bool("safetensors", false, "Sanity-check .safetensors structure")
+	checkSTDeep := fs.Bool("safetensors-deep", false, "Deep-verify .safetensors: header coverage and offsets")
+	scanDir := fs.String("scan-dir", "", "Recursively scan a directory for .safetensors and verify")
+	repair := fs.Bool("repair", false, "When used with --scan-dir and --safetensors-deep: trim extra trailing bytes to declared size")
+	quarantineIncomplete := fs.Bool("quarantine-incomplete", false, "When used with --scan-dir: move incomplete files to .incomplete")
 	logLevel := fs.String("log-level", "info", "log level")
 	jsonOut := fs.Bool("json", false, "json logs")
 	if err := fs.Parse(args); err != nil { return err }
@@ -38,9 +42,14 @@ func handleVerify(args []string) error {
 	c, err := config.Load(*cfgPath)
 	if err != nil { return err }
 	_ = logging.New(*logLevel, *jsonOut)
-	st, err := state.Open(c)
-	if err != nil { return err }
-	defer st.SQL.Close()
+	// If scanning an arbitrary directory, DB is not required; open only for state-backed modes.
+	var st *state.DB
+	if *scanDir == "" {
+		var err error
+		st, err = state.Open(c)
+		if err != nil { return err }
+		defer st.SQL.Close()
+	}
 
 	report := map[string]any{}
 	verifyOne := func(row state.DownloadRow) error {
@@ -61,11 +70,23 @@ func handleVerify(args []string) error {
 			res["safetensors_ok"] = ok
 			if herr != nil { res["safetensors_error"] = herr.Error() }
 		}
+		if *checkSTDeep && (filepath.Ext(row.Dest) == ".safetensors" || filepath.Ext(row.Dest) == ".sft") {
+			ok, need, derr := deepVerifySafeTensors(row.Dest)
+			res["safetensors_deep_ok"] = ok
+			res["safetensors_declared_size"] = need
+			if derr != nil { res["safetensors_deep_error"] = derr.Error() }
+		}
 		report[row.Dest] = res
 		return nil
 	}
 
-	if *pathFlag != "" {
+	if *scanDir != "" {
+		// directory scan mode (no DB required)
+		res, err := scanSafetensorsDir(*scanDir, *checkSTDeep, *repair, *quarantineIncomplete)
+		if err != nil { return err }
+		// merge results into report
+		for k, v := range res { report[k] = v }
+	} else if *pathFlag != "" {
 		rows, err := st.ListDownloads()
 		if err != nil { return err }
 		var found *state.DownloadRow
@@ -81,7 +102,7 @@ func handleVerify(args []string) error {
 			}
 		}
 	} else {
-		return errors.New("use --path or --all")
+		return errors.New("use --scan-dir or --path or --all")
 	}
 
 	if *jsonOut {
@@ -90,8 +111,21 @@ func handleVerify(args []string) error {
 	}
 	for _, v := range report {
 		m := v.(map[string]any)
-		fmt.Printf("%s size=%d sha256=%s status=%s\n", m["path"], m["size"], m["sha256"], m["status"])
-		if *checkST { fmt.Printf("  safetensors_ok=%v error=%v\n", m["safetensors_ok"], m["safetensors_error"]) }
+		path := m["path"]
+		if _, hasSize := m["size"]; hasSize {
+			fmt.Printf("%s size=%v sha256=%v status=%v\n", path, m["size"], m["sha256"], m["status"])
+		} else {
+			fmt.Printf("%s\n", path)
+		}
+		if *checkST {
+			fmt.Printf("  safetensors_ok=%v error=%v\n", m["safetensors_ok"], m["safetensors_error"])
+		}
+		if *checkSTDeep {
+			fmt.Printf("  safetensors_deep_ok=%v declared_size=%v error=%v", m["safetensors_deep_ok"], m["safetensors_declared_size"], m["safetensors_deep_error"])
+			if rv, ok := m["repaired"]; ok { fmt.Printf(" repaired=%v", rv) }
+			if qv, ok := m["quarantined"]; ok { fmt.Printf(" quarantined=%v", qv) }
+			fmt.Print("\n")
+		}
 	}
 	return nil
 }
@@ -110,6 +144,139 @@ func sanityCheckSafeTensors(p string) (bool, error) {
 	var js any
 	if err := json.Unmarshal(hdr, &js); err != nil { return false, err }
 	return true, nil
+}
+
+// deepVerifySafeTensors performs coverage and offsets validation.
+// Returns ok, declared_total_size, error (nil if ok)
+func deepVerifySafeTensors(p string) (bool, int64, error) {
+	f, err := os.Open(p)
+	if err != nil { return false, 0, err }
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil { return false, 0, err }
+	if fi.Size() < 8 { return false, 0, fmt.Errorf("file too small: %d", fi.Size()) }
+	var hdrLen uint64
+	if err := binary.Read(f, binary.LittleEndian, &hdrLen); err != nil { return false, 0, err }
+	if hdrLen == 0 || hdrLen > uint64(fi.Size()-8) || hdrLen > 64*1024*1024 {
+		return false, 0, fmt.Errorf("invalid safetensors header length: %d", hdrLen)
+	}
+	hdr := make([]byte, hdrLen)
+	if _, err := io.ReadFull(f, hdr); err != nil { return false, 0, err }
+	var meta map[string]any
+	if err := json.Unmarshal(hdr, &meta); err != nil { return false, 0, fmt.Errorf("header json: %w", err) }
+	dataLen := fi.Size() - 8 - int64(hdrLen)
+	if dataLen < 0 { return false, 0, fmt.Errorf("negative data length") }
+	var maxEnd int64
+	for k, v := range meta {
+		lk := strings.ToLower(k)
+		if lk == "metadata" || lk == "__metadata__" { continue }
+		m, ok := v.(map[string]any)
+		if !ok { continue }
+		off, ok := m["data_offsets"].([]any)
+		if !ok || len(off) != 2 { continue }
+		start, ok1 := toInt64(off[0])
+		end, ok2 := toInt64(off[1])
+		if !ok1 || !ok2 { return false, 0, fmt.Errorf("tensor %q: invalid data_offsets", k) }
+		if start < 0 || end < 0 || end < start { return false, 0, fmt.Errorf("tensor %q: invalid range %d-%d", k, start, end) }
+		if end > dataLen { return false, 0, fmt.Errorf("tensor %q: data end %d beyond data length %d", k, end, dataLen) }
+		// Optional: validate dtype/shape size if present
+		if dtRaw, ok := m["dtype"].(string); ok {
+			if shp, ok := m["shape"].([]any); ok {
+				exp := dtypeBytes(dtRaw)
+				if exp > 0 {
+					var cnt int64 = 1
+					for _, dim := range shp { d, ok := toInt64(dim); if !ok || d <= 0 { cnt = 0; break }; cnt *= d }
+					if cnt > 0 {
+						sz := end - start
+						if sz != cnt*exp { return false, 0, fmt.Errorf("tensor %q: size %d != %d*%d", k, sz, cnt, exp) }
+					}
+				}
+			}
+		}
+		if end > maxEnd { maxEnd = end }
+	}
+	declared := int64(8) + int64(hdrLen) + maxEnd
+	if fi.Size() < declared {
+		return false, declared, fmt.Errorf("incomplete: have=%d need=%d", fi.Size(), declared)
+	}
+	if fi.Size() > declared {
+		return false, declared, fmt.Errorf("extra bytes: have=%d need=%d", fi.Size(), declared)
+	}
+	return true, declared, nil
+}
+
+func dtypeBytes(dt string) int64 {
+	switch strings.ToUpper(strings.TrimSpace(dt)) {
+	case "F64": return 8
+	case "F32": return 4
+	case "F16", "BF16": return 2
+	case "F8", "F8_E4M3FN", "F8_E5M2": return 1
+	case "I64": return 8
+	case "I32": return 4
+	case "I16": return 2
+	case "I8", "U8", "BOOL": return 1
+	default: return 0
+	}
+}
+
+func toInt64(v any) (int64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return int64(x), true
+	case int64:
+		return x, true
+	case int:
+		return int64(x), true
+	default:
+		return 0, false
+	}
+}
+
+// Scan a directory recursively for .safetensors files and deep-verify them.
+// If repair is true, trims extra bytes to declared size when encountered.
+// If quarantineIncomplete is true, moves incomplete files to .incomplete.
+func scanSafetensorsDir(root string, deep bool, repair bool, quarantineIncomplete bool) (map[string]any, error) {
+	if root == "" { return nil, errors.New("scan-dir is empty") }
+	abs, err := filepath.Abs(root)
+	if err != nil { return nil, err }
+	out := map[string]any{}
+	walkErr := filepath.WalkDir(abs, func(p string, d os.DirEntry, err error) error {
+		if err != nil { return err }
+		if d.IsDir() { return nil }
+		low := strings.ToLower(p)
+		if !(strings.HasSuffix(low, ".safetensors") || strings.HasSuffix(low, ".sft")) { return nil }
+		ok, need, derr := deepVerifySafeTensors(p)
+		m := map[string]any{"path": p, "safetensors_deep_ok": ok, "safetensors_declared_size": need}
+		if derr != nil { m["safetensors_deep_error"] = derr.Error() }
+		// Attempt repair if requested
+		if deep && repair && derr != nil && strings.Contains(strings.ToLower(derr.Error()), "extra bytes") && need > 0 {
+			fi, statErr := os.Stat(p)
+			if statErr == nil && fi.Size() > need {
+				f, oerr := os.OpenFile(p, os.O_RDWR, 0)
+				if oerr == nil {
+					if terr := f.Truncate(need); terr == nil {
+						m["repaired"] = true
+						// re-run verify
+						ok2, need2, derr2 := deepVerifySafeTensors(p)
+						m["safetensors_deep_ok"] = ok2
+						m["safetensors_declared_size"] = need2
+						if derr2 != nil { m["safetensors_deep_error"] = derr2.Error() } else { delete(m, "safetensors_deep_error") }
+					}
+					_ = f.Close()
+				}
+			}
+		}
+		if deep && quarantineIncomplete && derr != nil && strings.Contains(strings.ToLower(derr.Error()), "incomplete") {
+			q := p + ".incomplete"
+			if rerr := os.Rename(p, q); rerr == nil {
+				m["quarantined"] = q
+			}
+		}
+		out[p] = m
+		return nil
+	})
+	if walkErr != nil { return nil, walkErr }
+	return out, nil
 }
 
 // equalFoldHex: case-insensitive hex compare

--- a/docs/BATCH.md
+++ b/docs/BATCH.md
@@ -17,7 +17,9 @@ BatchJob fields:
   - Direct HTTP(S) or resolver URI
   - Examples: `https://...`, `hf://owner/repo/path?rev=main`, `civitai://model/123456?version=42&file=vae`
 - dest: string (optional)
-  - Destination file path; if omitted, modfetch saves to `<general.download_root>/<basename-of-resolved-URL>`
+  - Destination file path. If omitted:
+    - For civitai:// URIs: modfetch saves to `<general.download_root>/<ModelName> - <OriginalFileName>` (sanitized), with collision-safe suffixes.
+    - For other URIs: modfetch saves to `<general.download_root>/<basename-of-resolved-URL>`.
 - sha256: string (optional)
   - Expected final SHA256 (hex). On mismatch, modfetch will re-hash chunks to identify and re-fetch the corrupted ones. If still mismatched, the job fails.
   - A `.sha256` sidecar file is always written on success.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -19,7 +19,8 @@ Quick start: interactive wizard
   - `placement_mode`: `symlink` | `hardlink` | `copy`
   - `quarantine`: true|false (quarantine until checksum verified)
   - `allow_overwrite`: true|false
-  - `stage_partials`: true|false (default true). When true, .part files are written under `download_root/.parts` and moved atomically on completion.
+  - `stage_partials`: true|false (default true). When true, .part files are written under `download_root/.parts` (or `partials_root` if set) and moved atomically on completion.
+  - `partials_root`: string (optional). Directory to store .part files instead of `download_root/.parts` (useful for a faster or larger filesystem).
   - `always_no_resume`: true|false (default false). When true, every download starts fresh (ignores any .part and clears chunk state) unless overridden by CLI.
 - `network`
   - `timeout_seconds`, `max_redirects`, `tls_verify`, `user_agent`

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -35,6 +35,7 @@ Quick start: interactive wizard
   - `prometheus_textfile`: `enabled`, `path`
 - `validation`
   - `require_sha256`, `accept_md5_sha1_if_provided`
+  - `safetensors_deep_verify_after_download`: when true, perform deep coverage/length verification of .safetensors files immediately after download; fail the command if invalid
 
 See `assets/sample-config/config.example.yml` for a full example.
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -19,6 +19,8 @@ Quick start: interactive wizard
   - `placement_mode`: `symlink` | `hardlink` | `copy`
   - `quarantine`: true|false (quarantine until checksum verified)
   - `allow_overwrite`: true|false
+  - `stage_partials`: true|false (default true). When true, .part files are written under `download_root/.parts` and moved atomically on completion.
+  - `always_no_resume`: true|false (default false). When true, every download starts fresh (ignores any .part and clears chunk state) unless overridden by CLI.
 - `network`
   - `timeout_seconds`, `max_redirects`, `tls_verify`, `user_agent`
 - `concurrency`

--- a/docs/RESOLVERS.md
+++ b/docs/RESOLVERS.md
@@ -34,7 +34,9 @@ CivitAI (civitai://)
   - The resolver queries the CivitAI API:
     - GET /api/v1/models/{modelId} to enumerate versions and files
     - or GET /api/v1/model-versions/{versionId}
-  - Returns the file.downloadUrl from the selected file.
+  - Returns the file.downloadUrl from the selected file and also provides metadata: model name, version name/id, original file name.
+- Default filename when --dest is omitted:
+  - For civitai:// URIs, modfetch will save to `<general.download_root>/<ModelName> - <OriginalFileName>` (sanitized). If a file with that name already exists, it tries appending `(v<versionId>)` before the extension, then numeric suffixes `(2)`, `(3)`, etc.
 - Authentication:
   - If sources.civitai.enabled is true and sources.civitai.token_env points to an environment variable (e.g., CIVITAI_TOKEN), an Authorization: Bearer <token> header is attached and used for both HEAD and GET requests.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,57 @@
+# TODO / Plan: CivitAI model-aware default filenames
+
+Goal
+- When downloading via civitai:// and no --dest is provided, default the destination filename to include the CivitAI model name so files are easy to recognize and organize.
+
+Default behavior
+- Pattern: "<ModelName> - <OriginalFileName>"
+  - Keep the original extension (it comes from CivitAI’s file name).
+  - Sanitize the final filename (replace path separators and disallowed chars with underscores).
+- Scope: Only applies when the user provides civitai:// URIs and omits --dest (and dest is empty in batch jobs). Direct https://civitai.com URLs retain the current behavior.
+- Collision policy: If the computed filename already exists under download_root, try adding version ID hint " (v<versionId>)"; if still collides, add numeric suffixes before the extension: " (2)", "(3)", etc.
+
+Implementation tasks
+1) Extend Resolved metadata
+   - internal/resolver/resolver.go: add optional fields to Resolved: ModelName, VersionName, VersionID, FileName, SuggestedFilename.
+   - HuggingFace resolver leaves these empty; CivitAI resolver populates them.
+
+2) Populate CivitAI metadata and suggested filename
+   - internal/resolver/civitai.go:
+     - Extend API structs to capture model/version names (e.g., civitModel.Name, civitVersion.Name, civitVersion.ModelID).
+     - If ?version is present, fetch version and (if needed) fetch model to obtain model name; else fetch model (contains versions) and pick latest version as today.
+     - Preserve existing file selection logic (file substring, primary, Model type, fallback first).
+     - After selecting a file, set: ModelName, VersionName, VersionID, FileName (file.Name).
+     - Compute SuggestedFilename = SafeFileName(ModelName + " - " + FileName).
+
+3) Shared helpers
+   - internal/util/paths.go (new):
+     - SafeFileName(name string) string — centralize filename sanitization.
+     - UniquePath(dir, base, versionHint string) (string, error) — returns a unique filename in dir, applying version hint and numeric suffixes.
+   - internal/downloader/chunked.go: switch to util.SafeFileName and remove duplicated local helper.
+
+4) Wire CLI to use SuggestedFilename
+   - cmd/modfetch/main.go:
+     - After resolver.Resolve for civitai://, when dest is empty and res.SuggestedFilename is set, compute dest = UniquePath(download_root, res.SuggestedFilename, res.VersionID).
+     - Use this dest for the progress display (so the .part path matches) and for the downloader.
+   - Batch mode: same behavior for jobs with empty dest.
+
+5) Tests
+   - internal/resolver/civitai_test.go: assert that resolver populates ModelName, VersionName, SuggestedFilename and still chooses the correct file.
+   - internal/util/paths_test.go: SafeFileName and UniquePath edge cases (illegal chars, collisions, suffix placement before extension).
+   - Update any outdated tests (e.g., downloader resolve tests) to reflect signatures and new behavior.
+
+6) Docs
+   - docs/RESOLVERS.md, docs/BATCH.md, README.md: document civitai default naming when dest is omitted, scope/limits, and collision policy.
+
+Acceptance criteria
+- Given civitai://model/{id} (with or without ?version) and no --dest, the final saved filename contains the model name following the pattern above and retains the correct extension.
+- When the computed name collides in download_root, a unique name is chosen via version hint or numeric suffix.
+- Progress bar reflects the chosen destination path from start to finish.
+- Behavior for hf:// and direct HTTP(S) downloads remains unchanged.
+- Unit tests for resolver metadata and helpers pass; existing tests remain green.
+- Docs updated to reflect the new behavior.
+
+Out of scope (for now)
+- Config/CLI knobs for naming patterns; can be added later if needed (proposal: sources.civitai.naming.pattern, include_version: bool).
+- Deriving model names for direct https://civitai.com links (non-civitai:// URIs).
+

--- a/docs/TODO_NEXT.md
+++ b/docs/TODO_NEXT.md
@@ -1,0 +1,143 @@
+# Next TODO (Improvements)
+
+Priority 1
+- Configurable naming patterns for resolvers
+  - Add `sources.civitai.naming.pattern` and `sources.huggingface.naming.pattern` with tokens: `{model_name}`, `{version_name}`, `{version_id}`, `{file_name}`, `{repo}`, `{path}`. CLI override `--naming-pattern`.
+- Preflight auth and early 401 detection
+  - Pre-download HEAD or 0–0 probe with Authorization; if 401 and token missing, fail early with guidance. `--no-auth-preflight` to disable.
+- TUI enhancements
+  - Sort by speed/ETA/remaining, actions (retry/cancel/details), warnings for missing token env, show SuggestedFilename/hostcaps, improve colors.
+
+Priority 2
+- Placement and classifier improvements
+  - Better SD/LLM heuristics, presets for ComfyUI/A1111, `place --write-paths` to generate extra_model_paths.yaml, diff in dry-run.
+- Batch runner improvements
+  - Per-job naming/placement overrides, global concurrency, batch summary JSON, retry policies, stop-on-failure.
+- Partials management polish
+  - `clean --parts-only`, `--older-than`, show reclaimed space, startup warnings when stale .part present; docs for partials_root.
+- Metrics expansion
+  - Counters for 401s, retries by host; gauges for active downloads, per-host throughput; include build version.
+- Logging and UX improvements
+  - Wider `--quiet`, consistent JSON fields, rigorous secret redaction, resolver debug toggles, global throttle of repeated warnings.
+
+Priority 3
+- Safetensors verification outputs
+  - `--json-out FILE` / `--csv-out FILE` for scan results; repaired/quarantined flags; non-zero exit on critical unless `--allow-partial`.
+- CI and release automation
+  - GitHub Actions: tests on Linux/macOS; build and attach artifacts on tag; publish SHA256SUMS. Consider goreleaser later.
+- Packaging: Homebrew formula
+  - Finalize formula/tap; validate arm64/amd64; completions installation.
+- Docs
+  - Examples for naming patterns and tokens; token setup; extra_model_paths.yaml recipes; 401/gated FAQ; v0.2.0 upgrade notes.
+- Test coverage expansion
+  - Auth preflight and warnings, naming token expansion, UniquePath edge cases, prealloc/progress interaction, placement dry-run.
+
+Exploratory
+- Extensible sources (design doc)
+  - Plan plugin-like resolvers for `s3://`, `gcs://`, `local://`; define minimal API and safety considerations.
+- Security hardening audit
+  - Review logs and error paths for token leakage; add central `redact()` helper used by logging; ensure headers are never logged.
+
+---
+
+CodeRabbit follow-ups (2025-08-30)
+
+Priority 1
+- TUI ephemerals keyed by URL|Dest and exact clearing
+  - Key resolving/preflight ephemerals by composite key url|dest to avoid collisions; clear only on matching DB row by URL or cleaned Dest; render resolving spinner based on the composite key.
+  - Add helper ephemeralKey(url, dest) and update all call sites (addEphemeral, View spinner check, refresh clearing, dlDone handling).
+  - Ensure dlDoneMsg includes both url and dest so ephemerals can be cleared precisely. [PR #8]
+- Consistent dest use when starting downloads from TUI
+  - When dest is blank, compute dg := destGuess(url, dest) once and use dg for preflight, addEphemeral, and startDownloadCmd so pause/cancel lookup keys match the eventual DB row. [PR #8]
+- Single-stream downloader: treat HTTP 416 as already complete
+  - If resuming and the server returns 416 Requested Range Not Satisfiable and local .part size >= reported size, finalize (fsync, rename/copy to final, adjust safetensors), recompute SHA, upsert DB row status=complete, and return success instead of error. [PR #8]
+- Sanitize destGuess and enforce containment
+  - Prevent path traversal and ensure computed default filenames stay under download_root. Reject unsafe basenames ("/", ".", ".."), clean and validate with filepath.Rel; fall back to a safe default when needed. [PR #8]
+
+Priority 2
+- TUI open/reveal: use Run() and surface errors
+  - Switch from exec.Command(...).Start() to .Run() so non-zero exit codes are caught; optionally wrap in an async command to avoid blocking UI; provide user-visible error on failure. [PR #8]
+- Metrics manager: guard writes when disabled
+  - Skip creating/writing Prometheus textfile metrics when enabled=false or path is empty to avoid os.CreateTemp failures; audit all write sites for guards. [PR #8]
+- Docstrings and tests
+  - Add docstrings for new TUI helpers (preflightForDownload, destGuess, addEphemeral, openInFileManager) and downloader changes.
+  - Unit tests: speed/ETA sampling behavior, ephemeral clearing logic, destGuess sanitation, and single-stream 416 finalize path.
+
+---
+
+Additional Backlog (MF-001..MF-039)
+
+1. CRITICAL PRIORITY ITEMS (Sprint 1-2)
+1.1 Code Quality & Testing
+
+- MF-001: Implement comprehensive unit test coverage for all resolver packages (target: >80% coverage)
+- MF-002: Refactor internal/tui/model.go to comply with single responsibility principle (max 200 lines per file)
+- MF-003: Establish integration test suite for all download scenarios
+- MF-004: Implement automated test execution in CI/CD pipeline
+
+1.2 Core Functionality
+
+- MF-005: Implement download progress persistence with automatic recovery
+- MF-006: Add bandwidth throttling capability with configurable limits per download
+- MF-007: Refactor fetchChunk method in chunked.go into composable, testable units
+
+2. HIGH PRIORITY ITEMS (Sprint 3-4)
+2.1 Feature Enhancements
+
+- MF-008: Implement mirror/fallback URL support for all resolver types
+- MF-009: Develop batch job scheduling system with cron-like syntax
+- MF-010: Add connection pooling for HTTP clients
+- MF-011: Implement streaming hash verification to reduce memory footprint
+
+2.2 Documentation
+
+- MF-012: Generate comprehensive godoc documentation for all public APIs
+- MF-013: Create Architecture Decision Records (ADR) for key technical decisions
+- MF-014: Develop Kubernetes deployment guide with Helm charts
+- MF-015: Establish API versioning and deprecation policy documentation
+
+3. MEDIUM PRIORITY ITEMS (Sprint 5-6)
+3.1 User Experience
+
+- MF-016: Implement mouse support in TUI interface
+- MF-017: Develop theme system with minimum dark/light mode options
+- MF-018: Enhance error messages with contextual guidance and resolution steps
+- MF-019: Create interactive configuration wizard for first-time setup
+
+3.2 Architecture
+
+- MF-020: Design and implement plugin architecture for custom resolvers
+- MF-021: Implement download queue with priority management
+- MF-022: Add automatic archive extraction post-download (zip, tar.gz, 7z)
+- MF-023: Refactor context propagation to use context-aware client pattern
+
+4. STANDARD PRIORITY ITEMS (Sprint 7-8)
+4.1 Security Enhancements
+
+- MF-024: Integrate with system keychain/secret managers for token storage
+- MF-025: Implement GPG/signature verification for downloaded artifacts
+- MF-026: Add audit logging for all download activities
+- MF-027: Implement rate limiting per source to prevent API abuse
+
+4.2 Performance Optimisation
+
+- MF-028: Optimise database queries with proper indexing strategy
+- MF-029: Implement adaptive chunk sizing based on network conditions
+- MF-030: Add metrics collection for performance monitoring
+- MF-031: Implement memory-mapped file operations for large downloads
+
+5. FUTURE CONSIDERATIONS (Backlog)
+5.1 Enterprise Features
+
+- MF-032: S3-compatible storage backend support
+- MF-033: LDAP/AD authentication integration
+- MF-034: Multi-tenant support with workspace isolation
+- MF-035: RESTful API for remote management
+
+5.2 Advanced Capabilities
+
+- MF-036: Distributed download coordination across multiple nodes
+- MF-037: Blockchain-based integrity verification
+- MF-038: AI-powered download scheduling optimisation
+- MF-039: GraphQL API implementation
+

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -9,6 +9,10 @@ Common errors and remedies
        
        modfetch verify --config ~/.config/modfetch/config.yml --scan-dir /path/to/checkpoints --safetensors-deep
        
+       - To focus only on problem files and get a quick count:
+         
+         modfetch verify --config ~/.config/modfetch/config.yml --scan-dir /path/to/checkpoints --safetensors-deep --only-errors --summary
+       
     2) If you see "extra bytes", repair is safe and lossless (truncate to declared size):
        
        modfetch verify --config ~/.config/modfetch/config.yml --scan-dir /path/to/checkpoints --safetensors-deep --repair

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -2,6 +2,29 @@
 
 Common errors and remedies
 
+- ComfyUI: Error while deserializing header: incomplete metadata, file not fully covered
+  - Meaning: the on-disk file size does not exactly match what the safetensors header declares (or the header/offsets are invalid).
+  - Fix:
+    1) Scan the directory and deep-verify all safetensors files:
+       
+       modfetch verify --config ~/.config/modfetch/config.yml --scan-dir /path/to/checkpoints --safetensors-deep
+       
+    2) If you see "extra bytes", repair is safe and lossless (truncate to declared size):
+       
+       modfetch verify --config ~/.config/modfetch/config.yml --scan-dir /path/to/checkpoints --safetensors-deep --repair
+       
+    3) If you see "incomplete", quarantine and re-download (data is missing):
+       
+       modfetch verify --config ~/.config/modfetch/config.yml --scan-dir /path/to/checkpoints --safetensors-deep --quarantine-incomplete
+       
+    4) Restart ComfyUI to ensure it loads the corrected file.
+  - Prevention: enable in your config
+    
+    validation:
+      safetensors_deep_verify_after_download: true
+    
+    This fails new downloads that don’t pass deep verification. Trailing extra bytes are already auto-trimmed on download finalize.
+
 - No space left on device
   - Message: "write failed: no space left on device"
   - Action: free disk space on the download filesystem; modfetch writes to general.download_root and uses a .part file before renaming.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,110 @@
+# User Guide
+
+This guide walks you through configuration, common workflows, and tips to get the most out of modfetch.
+
+- Build: `make build` (produces `./bin/modfetch`)
+- Config file path can be passed with `--config` or via the environment variable `MODFETCH_CONFIG`.
+
+## Configure
+
+Create a config file:
+
+1) Minimal example (see docs/CONFIG.md for full schema)
+
+version: 1
+general:
+  data_root: "~/modfetch-data"
+  download_root: "~/Downloads/modfetch"
+  placement_mode: "symlink"
+sources:
+  huggingface: { enabled: true, token_env: "HF_TOKEN" }
+  civitai:     { enabled: true, token_env: "CIVITAI_TOKEN" }
+validation:
+  safetensors_deep_verify_after_download: true
+
+2) Use the wizard
+
+modfetch config wizard --out ~/.config/modfetch/config.yml
+
+3) Export tokens (only if needed for gated content)
+
+export HF_TOKEN=...    # Hugging Face
+export CIVITAI_TOKEN=...  # CivitAI
+
+## Core workflows
+
+Set a default config if you like:
+
+export MODFETCH_CONFIG=~/.config/modfetch/config.yml
+
+### Download
+
+modfetch download --config ~/.config/modfetch/config.yml \
+  --url 'https://proof.ovh.net/files/1Mb.dat'
+
+- Shows a live progress bar with speed and ETA.
+- Supports resume (Range) and retries.
+- On completion, prints a summary and writes a .sha256 sidecar.
+
+For Hugging Face / CivitAI resolvers:
+
+modfetch download --config ~/.config/modfetch/config.yml \
+  --url 'hf://org/repo/path/to/file?rev=main'
+modfetch download --config ~/.config/modfetch/config.yml \
+  --url 'civitai://model/123456?file=myfile.safetensors'
+
+### Verify (state-based)
+
+Verify a specific previously downloaded item recorded in the DB:
+
+modfetch verify --config ~/.config/modfetch/config.yml --path /path/to/file
+
+Verify all completed downloads in state:
+
+modfetch verify --config ~/.config/modfetch/config.yml --all
+
+### Deep-verify safetensors and directory scan/repair
+
+Scan a directory of .safetensors/.sft for structural correctness and exact coverage:
+
+modfetch verify --config ~/.config/modfetch/config.yml \
+  --scan-dir /path/to/models --safetensors-deep
+
+Repair files with extra trailing bytes (safe, lossless) and quarantine incomplete ones:
+
+modfetch verify --config ~/.config/modfetch/config.yml \
+  --scan-dir /path/to/models --safetensors-deep --repair --quarantine-incomplete
+
+Notes:
+- Extra bytes: file is larger than the header-declared size; repair truncates to the exact declared size.
+- Incomplete: file is smaller than declared; cannot be repaired in place. Quarantine and re-download.
+- With validation.safetensors_deep_verify_after_download: true, deep verification runs right after each .safetensors download and fails the command if invalid.
+- Automatic trimming of trailing bytes is always applied to .safetensors files after download finalize.
+
+### Placement
+
+Place a downloaded artifact into your app’s directory per your mapping rules:
+
+modfetch place --config ~/.config/modfetch/config.yml --path /path/to/model.safetensors
+
+Use --dry-run to preview without writing.
+
+See docs/PLACEMENT.md and docs/RESOLVERS.md for details and examples.
+
+### TUI dashboard
+
+modfetch tui --config ~/.config/modfetch/config.yml
+
+- Live list of downloads
+- Throughput and ETA per row
+- Keys: q (quit), r (refresh), j/k (select), d (details), / (filter), s (sort by speed), e (sort by ETA)
+
+## Tips
+
+- Increase verbosity for debugging: add --log-level debug
+- Use --json to emit JSON logs
+- Use --summary-json on download to emit a single JSON summary at the end
+- Put ./bin on PATH for convenience:
+
+export PATH="$PWD/bin:$PATH"
+

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -63,12 +63,23 @@ Verify all completed downloads in state:
 
 modfetch verify --config ~/.config/modfetch/config.yml --all
 
+Tips:
+- Add `--only-errors` to show only problematic files
+- Add `--summary` to print total scanned, error count, and a list of error paths
+- Combine with `--safetensors-deep` to include deep validation in state-backed checks
+
 ### Deep-verify safetensors and directory scan/repair
 
 Scan a directory of .safetensors/.sft for structural correctness and exact coverage:
 
 modfetch verify --config ~/.config/modfetch/config.yml \
   --scan-dir /path/to/models --safetensors-deep
+
+Show only errors and a summary:
+
+modfetch verify --config ~/.config/modfetch/config.yml \
+  --scan-dir /path/to/models --safetensors-deep \
+  --only-errors --summary
 
 Repair files with extra trailing bytes (safe, lossless) and quarantine incomplete ones:
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -108,7 +108,15 @@ modfetch tui --config ~/.config/modfetch/config.yml
 
 - Live list of downloads
 - Throughput and ETA per row
-- Keys: q (quit), r (refresh), j/k (select), d (details), / (filter), s (sort by speed), e (sort by ETA)
+- Keys:
+  - Navigation: j/k (select), / (filter), m (menu), h/? (help)
+  - Sorting: s (sort by speed), e (sort by ETA), o (clear sort)
+  - Actions: n (new), r (refresh), d (details), g (group by status), t (toggle columns)
+  - Per-row actions: p (pause/cancel), y (retry), C (copy path), U (copy URL), O (open/reveal), D (delete staged), X (clear row)
+- Behavior:
+  - Resolving spinner row appears immediately after starting, then transitions to planning → running
+  - Live speed and ETA for both chunked and single-stream fallback downloads
+  - Supports pasting CivitAI model page URLs; they’re auto-resolved to the correct direct download
 
 ## Tips
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,12 +25,15 @@ type Config struct {
 }
 
 type General struct {
-	DataRoot     string `yaml:"data_root"`
-	DownloadRoot string `yaml:"download_root"`
-	PlacementMode string `yaml:"placement_mode"` // symlink | hardlink | copy
-	Quarantine    bool   `yaml:"quarantine"`
-	AllowOverwrite bool  `yaml:"allow_overwrite"`
-	DryRun         bool  `yaml:"dry_run"`
+	DataRoot       string `yaml:"data_root"`
+	DownloadRoot   string `yaml:"download_root"`
+	PlacementMode  string `yaml:"placement_mode"` // symlink | hardlink | copy
+	Quarantine     bool   `yaml:"quarantine"`
+	AllowOverwrite bool   `yaml:"allow_overwrite"`
+	DryRun         bool   `yaml:"dry_run"`
+	// Downloads behavior
+	StagePartials  bool   `yaml:"stage_partials"`   // if true (default), write .part files under download_root/.parts
+	AlwaysNoResume bool   `yaml:"always_no_resume"` // if true, do not resume partials unless overridden on CLI
 }
 
 type Network struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,12 +27,13 @@ type Config struct {
 type General struct {
 	DataRoot       string `yaml:"data_root"`
 	DownloadRoot   string `yaml:"download_root"`
+	PartialsRoot   string `yaml:"partials_root"`
 	PlacementMode  string `yaml:"placement_mode"` // symlink | hardlink | copy
 	Quarantine     bool   `yaml:"quarantine"`
 	AllowOverwrite bool   `yaml:"allow_overwrite"`
 	DryRun         bool   `yaml:"dry_run"`
 	// Downloads behavior
-	StagePartials  bool   `yaml:"stage_partials"`   // if true (default), write .part files under download_root/.parts
+	StagePartials  bool   `yaml:"stage_partials"`   // if true (default), write .part files under download_root/.parts or partials_root if set
 	AlwaysNoResume bool   `yaml:"always_no_resume"` // if true, do not resume partials unless overridden on CLI
 }
 
@@ -147,6 +148,7 @@ func (c *Config) expandPaths() error {
 	var err error
 	if c.General.DataRoot, err = expandTilde(c.General.DataRoot); err != nil { return err }
 	if c.General.DownloadRoot, err = expandTilde(c.General.DownloadRoot); err != nil { return err }
+	if c.General.PartialsRoot, err = expandTilde(c.General.PartialsRoot); err != nil { return err }
 	if c.Logging.File.Path, err = expandTilde(c.Logging.File.Path); err != nil { return err }
 	if c.Metrics.PrometheusTextfile.Path, err = expandTilde(c.Metrics.PrometheusTextfile.Path); err != nil { return err }
 	for name, app := range c.Placement.Apps {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,8 +109,9 @@ type PromTextfile struct {
 }
 
 type Validation struct {
-	RequireSHA256          bool `yaml:"require_sha256"`
-	AcceptMD5SHA1IfProvided bool `yaml:"accept_md5_sha1_if_provided"`
+	RequireSHA256                      bool `yaml:"require_sha256"`
+	AcceptMD5SHA1IfProvided            bool `yaml:"accept_md5_sha1_if_provided"`
+	SafetensorsDeepVerifyAfterDownload bool `yaml:"safetensors_deep_verify_after_download"`
 }
 
 // Load reads, parses, expands, and validates a YAML config file.

--- a/internal/downloader/chunked.go
+++ b/internal/downloader/chunked.go
@@ -210,6 +210,9 @@ func (e *Chunked) Download(ctx context.Context, url, destPath, expectedSHA strin
 		chunks, _ = e.st.ListChunks(url, destPath)
 	}
 
+	// Mark download as running now that chunk plan exists
+	_ = e.st.UpsertDownload(state.DownloadRow{URL: url, Dest: destPath, ExpectedSHA256: expectedSHA, ActualSHA256: "", ETag: h.etag, LastModified: h.lastMod, Size: h.size, Status: "running"})
+
 	// Download chunks concurrently
 	perFile := e.cfg.Concurrency.PerFileChunks
 	if perFile <= 0 { perFile = 4 }

--- a/internal/downloader/chunked.go
+++ b/internal/downloader/chunked.go
@@ -272,21 +272,6 @@ req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
-// writeAndSync writes content to path and fsyncs the file.
-func writeAndSync(path string, b []byte) error {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
-	if err != nil { return err }
-	defer f.Close()
-	if _, err := f.Write(b); err != nil { return err }
-	return f.Sync()
-}
-
-func fsyncDir(dir string) error {
-	df, err := os.Open(dir)
-	if err != nil { return err }
-	defer df.Close()
-	return df.Sync()
-}
 
 func hashRange(f *os.File, start, size int64) (string, error) {
 	if _, err := f.Seek(start, io.SeekStart); err != nil { return "", err }

--- a/internal/downloader/chunked_test.go
+++ b/internal/downloader/chunked_test.go
@@ -39,7 +39,7 @@ func TestChunkedDownload1MB(t *testing.T) {
 
 	dl := NewChunked(cfg, log, st, nil)
 	url := "https://proof.ovh.net/files/1Mb.dat"
-	dest, sha, err := dl.Download(context.Background(), url, "", "", nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", "", nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	fi, err := os.Stat(dest)
 	if err != nil { t.Fatalf("stat: %v", err) }
@@ -74,7 +74,7 @@ func TestChunkedCorruptAndRepair(t *testing.T) {
 	dl := NewChunked(cfg, log, st, nil)
 	url := "https://proof.ovh.net/files/1Mb.dat"
 	// First download to get good SHA
-	dest, goodSHA, err := dl.Download(context.Background(), url, "", "", nil)
+	dest, goodSHA, err := dl.Download(context.Background(), url, "", "", nil, false)
 	if err != nil { t.Fatalf("download1: %v", err) }
 	// Corrupt middle 64 bytes
 	f, err := os.OpenFile(dest, os.O_RDWR, 0)
@@ -85,7 +85,7 @@ func TestChunkedCorruptAndRepair(t *testing.T) {
 	for i := range bad { bad[i] = 0xFF }
 	if _, err := f.Write(bad); err != nil { t.Fatalf("write corrupt: %v", err) }
 	// Run downloader again with expected SHA; it should repair the corrupted chunk
-	_, fixedSHA, err := dl.Download(context.Background(), url, dest, goodSHA, nil)
+	_, fixedSHA, err := dl.Download(context.Background(), url, dest, goodSHA, nil, false)
 	if err != nil { t.Fatalf("download2(repair): %v", err) }
 	if fixedSHA != goodSHA {
 		// confirm by local recompute

--- a/internal/downloader/civitai_resolve_download_test.go
+++ b/internal/downloader/civitai_resolve_download_test.go
@@ -97,7 +97,7 @@ func TestCivitAIResolveAndDownload_WithAuthAndChunks(t *testing.T) {
 	res, err := resolver.Resolve(context.Background(), uri, cfg)
 	if err != nil { t.Fatalf("resolve: %v", err) }
 	dl := NewChunked(cfg, log, st, nil)
-	dest, sha, err := dl.Download(context.Background(), res.URL, "", "", res.Headers)
+	dest, sha, err := dl.Download(context.Background(), res.URL, "", "", res.Headers, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	fi, err := os.Stat(dest)
 	if err != nil { t.Fatalf("stat: %v", err) }

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -10,7 +10,7 @@ import (
 
 // Interface is the common downloader interface used across implementations.
 type Interface interface {
-	Download(ctx context.Context, url, destPath, expectedSHA string, headers map[string]string) (finalPath string, sha256 string, err error)
+	Download(ctx context.Context, url, destPath, expectedSHA string, headers map[string]string, noResume bool) (finalPath string, sha256 string, err error)
 }
 
 // Auto implements Interface by delegating to the chunked downloader which
@@ -27,7 +27,7 @@ func NewAuto(c *config.Config, l *logging.Logger, st *state.DB, m interface{ Add
 	return &Auto{c: c, l: l, st: st, m: m}
 }
 
-func (a *Auto) Download(ctx context.Context, url, destPath, expectedSHA string, headers map[string]string) (string, string, error) {
+func (a *Auto) Download(ctx context.Context, url, destPath, expectedSHA string, headers map[string]string, noResume bool) (string, string, error) {
 	// Delegate to chunked downloader which handles head probe and fallback.
-	return NewChunked(a.c, a.l, a.st, a.m).Download(ctx, url, destPath, expectedSHA, headers)
+	return NewChunked(a.c, a.l, a.st, a.m).Download(ctx, url, destPath, expectedSHA, headers, noResume)
 }

--- a/internal/downloader/downloader_http_advanced_test.go
+++ b/internal/downloader/downloader_http_advanced_test.go
@@ -1,0 +1,223 @@
+package downloader
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"modfetch/internal/config"
+	"modfetch/internal/logging"
+	"modfetch/internal/state"
+)
+
+// 5xx backoff: first attempt(s) for each chunk return 503, then success
+func TestChunked_RangeTransient5xxThenSuccess(t *testing.T) {
+	tmp := t.TempDir()
+	// 2 MiB payload to ensure multiple chunks
+	size := 2 << 20
+	payload := make([]byte, size)
+	for i := 0; i < size; i++ { payload[i] = byte((i*13 + 5) % 251) }
+
+	var mu sync.Mutex
+	tries := map[int]int{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fivexx.bin", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Accept-Ranges", "bytes")
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			w.WriteHeader(200); return
+		}
+		if r.Method != http.MethodGet { w.WriteHeader(405); return }
+		rng := r.Header.Get("Range")
+		if rng == "" {
+			w.WriteHeader(200); w.Write(payload); return
+		}
+		var start, end int
+		if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); err != nil { w.WriteHeader(416); return }
+		mu.Lock()
+		tries[start]++
+		count := tries[start]
+		mu.Unlock()
+		// First attempt per start offset returns 503
+		if count == 1 { w.WriteHeader(503); return }
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(payload)))
+		w.WriteHeader(206)
+		w.Write(payload[start : end+1])
+	})
+	ts := httptest.NewServer(mux); defer ts.Close()
+	url := ts.URL + "/fivexx.bin"
+
+	cfgPath := filepath.Join(tmp, "cfg.yml")
+	cfgYaml := []byte(strings.Join([]string{
+		"version: 1",
+		"general:",
+		"  data_root: \""+tmp+"/data\"",
+		"  download_root: \""+tmp+"/dl\"",
+		"network:",
+		"  timeout_seconds: 10",
+		"concurrency:",
+		"  per_file_chunks: 4",
+		"  chunk_size_mb: 1",
+		"  max_retries: 4",
+		"  backoff:",
+		"    min_ms: 1",
+		"    max_ms: 3",
+	}, "\n"))
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	cfg, err := config.Load(cfgPath)
+	if err != nil { t.Fatalf("config: %v", err) }
+	log := logging.New("info", false)
+	st, err := state.Open(cfg)
+	if err != nil { t.Fatalf("state: %v", err) }
+	defer st.SQL.Close()
+
+	dl := NewAuto(cfg, log, st, nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", "", nil)
+	if err != nil { t.Fatalf("download: %v", err) }
+	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest: %v", err) }
+	if len(sha) != 64 { t.Fatalf("sha len: %d", len(sha)) }
+}
+
+// Slow body: server writes slowly but within timeout; download should succeed
+func TestChunked_SlowBodyCompletes(t *testing.T) {
+	tmp := t.TempDir()
+	// 1 MiB payload
+	size := 1 << 20
+	payload := make([]byte, size)
+	for i := 0; i < size; i++ { payload[i] = byte((i*29 + 11) % 251) }
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/slow.bin", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Accept-Ranges", "bytes")
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			w.WriteHeader(200); return
+		}
+		rng := r.Header.Get("Range")
+		var start, end int
+		if rng == "" {
+			start = 0; end = len(payload)-1
+		} else {
+			if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); err != nil { w.WriteHeader(416); return }
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(payload)))
+			w.WriteHeader(206)
+		}
+		if rng == "" { w.WriteHeader(200) }
+		// write in small chunks with small delays; total << client timeout
+		chunk := 64 * 1024
+		for off := start; off <= end; off += chunk {
+			to := off + chunk
+			if to > end+1 { to = end+1 }
+			w.Write(payload[off:to])
+			time.Sleep(5 * time.Millisecond)
+		}
+	})
+	ts := httptest.NewServer(mux); defer ts.Close()
+	url := ts.URL + "/slow.bin"
+
+	cfgPath := filepath.Join(tmp, "cfg.yml")
+	cfgYaml := []byte(strings.Join([]string{
+		"version: 1",
+		"general:",
+		"  data_root: \""+tmp+"/data\"",
+		"  download_root: \""+tmp+"/dl\"",
+		"network:",
+		"  timeout_seconds: 5",
+		"concurrency:",
+		"  per_file_chunks: 2",
+		"  chunk_size_mb: 1",
+	}, "\n"))
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	cfg, err := config.Load(cfgPath)
+	if err != nil { t.Fatalf("config: %v", err) }
+	log := logging.New("info", false)
+	st, err := state.Open(cfg)
+	if err != nil { t.Fatalf("state: %v", err) }
+	defer st.SQL.Close()
+
+	dl := NewAuto(cfg, log, st, nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", "", nil)
+	if err != nil { t.Fatalf("download: %v", err) }
+	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest: %v", err) }
+	if len(sha) != 64 { t.Fatalf("sha len: %d", len(sha)) }
+}
+
+// Truncated body mid-chunk on first attempt; retry then complete
+func TestChunked_TruncatedBodyThenRetrySuccess(t *testing.T) {
+	tmp := t.TempDir()
+	// 1 MiB payload
+	size := 1 << 20
+	payload := make([]byte, size)
+	for i := 0; i < size; i++ { payload[i] = byte((i*7 + 19) % 251) }
+	h := sha256.Sum256(payload)
+	expected := hex.EncodeToString(h[:])
+
+	var once int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/trunc.bin", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Accept-Ranges", "bytes")
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			w.WriteHeader(200); return
+		}
+		rng := r.Header.Get("Range")
+		var start, end int
+		if rng == "" {
+			start = 0; end = len(payload)-1; w.WriteHeader(200)
+		} else {
+			if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); err != nil { w.WriteHeader(416); return }
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(payload)))
+			w.WriteHeader(206)
+		}
+		// First attempt for the first requested range: write only half
+		if atomic.CompareAndSwapInt32(&once, 0, 1) {
+			half := start + (end-start+1)/2
+			w.Write(payload[start:half])
+			return
+		}
+		w.Write(payload[start : end+1])
+	})
+	ts := httptest.NewServer(mux); defer ts.Close()
+	url := ts.URL + "/trunc.bin"
+
+	cfgPath := filepath.Join(tmp, "cfg.yml")
+	cfgYaml := []byte(strings.Join([]string{
+		"version: 1",
+		"general:",
+		"  data_root: \""+tmp+"/data\"",
+		"  download_root: \""+tmp+"/dl\"",
+		"network:",
+		"  timeout_seconds: 10",
+		"concurrency:",
+		"  per_file_chunks: 4",
+		"  chunk_size_mb: 1",
+		"  max_retries: 3",
+		"  backoff:",
+		"    min_ms: 1",
+		"    max_ms: 3",
+	}, "\n"))
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	cfg, err := config.Load(cfgPath)
+	if err != nil { t.Fatalf("config: %v", err) }
+	log := logging.New("info", false)
+	st, err := state.Open(cfg)
+	if err != nil { t.Fatalf("state: %v", err) }
+	defer st.SQL.Close()
+
+	dl := NewAuto(cfg, log, st, nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", expected, nil)
+	if err != nil { t.Fatalf("download: %v", err) }
+	if sha != expected { t.Fatalf("expected sha %s got %s", expected, sha) }
+	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest: %v", err) }
+}

--- a/internal/downloader/downloader_http_advanced_test.go
+++ b/internal/downloader/downloader_http_advanced_test.go
@@ -83,7 +83,7 @@ func TestChunked_RangeTransient5xxThenSuccess(t *testing.T) {
 	defer st.SQL.Close()
 
 	dl := NewAuto(cfg, log, st, nil)
-	dest, sha, err := dl.Download(context.Background(), url, "", "", nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", "", nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest: %v", err) }
 	if len(sha) != 64 { t.Fatalf("sha len: %d", len(sha)) }
@@ -147,7 +147,7 @@ func TestChunked_SlowBodyCompletes(t *testing.T) {
 	defer st.SQL.Close()
 
 	dl := NewAuto(cfg, log, st, nil)
-	dest, sha, err := dl.Download(context.Background(), url, "", "", nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", "", nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest: %v", err) }
 	if len(sha) != 64 { t.Fatalf("sha len: %d", len(sha)) }
@@ -216,7 +216,7 @@ func TestChunked_TruncatedBodyThenRetrySuccess(t *testing.T) {
 	defer st.SQL.Close()
 
 	dl := NewAuto(cfg, log, st, nil)
-	dest, sha, err := dl.Download(context.Background(), url, "", expected, nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", expected, nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	if sha != expected { t.Fatalf("expected sha %s got %s", expected, sha) }
 	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest: %v", err) }

--- a/internal/downloader/downloader_http_test.go
+++ b/internal/downloader/downloader_http_test.go
@@ -1,0 +1,210 @@
+package downloader
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"modfetch/internal/config"
+	"modfetch/internal/logging"
+	"modfetch/internal/state"
+)
+
+// Test a Range-capable server that returns 429 once per chunk then succeeds.
+func TestChunked_RangeWithTransient429(t *testing.T) {
+	tmp := t.TempDir()
+	// Prepare payload 512 KiB
+	size := 512 * 1024
+	payload := make([]byte, size)
+	for i := 0; i < size; i++ { payload[i] = byte((i*31 + 7) % 251) }
+	// Server
+	var tries int64
+	mux := http.NewServeMux()
+	mux.HandleFunc("/file.bin", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Accept-Ranges", "bytes")
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			w.Header().Set("ETag", "\"t\"")
+			w.Header().Set("Last-Modified", r.Header.Get("Date"))
+			w.WriteHeader(200)
+			return
+		}
+		if r.Method != http.MethodGet { w.WriteHeader(405); return }
+		rng := r.Header.Get("Range")
+		if rng == "" {
+			w.WriteHeader(200)
+			w.Write(payload)
+			return
+		}
+		var start, end int
+		if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); err != nil { w.WriteHeader(416); return }
+		if start < 0 || end >= len(payload) || end < start { w.WriteHeader(416); return }
+		// Return 429 on the first attempt overall to exercise retry
+		if atomic.AddInt64(&tries, 1) == 1 {
+			w.WriteHeader(429); return
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(payload)))
+		w.WriteHeader(206)
+		w.Write(payload[start : end+1])
+	})
+	ts := httptest.NewServer(mux); defer ts.Close()
+	url := ts.URL + "/file.bin"
+
+	cfgPath := filepath.Join(tmp, "cfg.yml")
+	cfgYaml := []byte(strings.Join([]string{
+		"version: 1",
+		"general:",
+		"  data_root: \""+tmp+"/data\"",
+		"  download_root: \""+tmp+"/dl\"",
+		"concurrency:",
+		"  per_file_chunks: 4",
+		"  chunk_size_mb: 1",
+		"  max_retries: 3",
+		"  backoff:",
+		"    min_ms: 1",
+		"    max_ms: 2",
+	}, "\n"))
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	cfg, err := config.Load(cfgPath)
+	if err != nil { t.Fatalf("config: %v", err) }
+	log := logging.New("info", false)
+	st, err := state.Open(cfg)
+	if err != nil { t.Fatalf("state: %v", err) }
+	defer st.SQL.Close()
+
+	dl := NewAuto(cfg, log, st, nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", "", nil)
+	if err != nil { t.Fatalf("download: %v", err) }
+	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest: %v", err) }
+	if len(sha) != 64 { t.Fatalf("sha len: %d", len(sha)) }
+}
+
+// Test fallback when HEAD/Range are not supported (no Accept-Ranges)
+func TestFallback_NoRangeSupport(t *testing.T) {
+	tmp := t.TempDir()
+	payload := []byte("hello world")
+	mux := http.NewServeMux()
+	mux.HandleFunc("/norange.bin", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			w.WriteHeader(200); return
+		}
+		if r.Method == http.MethodGet {
+			w.WriteHeader(200); w.Write(payload); return
+		}
+		w.WriteHeader(405)
+	})
+	ts := httptest.NewServer(mux); defer ts.Close()
+	url := ts.URL + "/norange.bin"
+
+	cfgPath := filepath.Join(tmp, "cfg.yml")
+	cfgYaml := []byte(strings.Join([]string{
+		"version: 1",
+		"general:",
+		"  data_root: \""+tmp+"/data\"",
+		"  download_root: \""+tmp+"/dl\"",
+		"concurrency:",
+		"  per_file_chunks: 4",
+		"  chunk_size_mb: 1",
+	}, "\n"))
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	cfg, err := config.Load(cfgPath)
+	if err != nil { t.Fatalf("config: %v", err) }
+	log := logging.New("info", false)
+	st, err := state.Open(cfg)
+	if err != nil { t.Fatalf("state: %v", err) }
+	defer st.SQL.Close()
+
+	dl := NewAuto(cfg, log, st, nil)
+	dest, _, err := dl.Download(context.Background(), url, "", "", nil)
+	if err != nil { t.Fatalf("download: %v", err) }
+	b, err := os.ReadFile(dest)
+	if err != nil { t.Fatalf("read: %v", err) }
+	if string(b) != string(payload) { t.Fatalf("payload mismatch") }
+}
+
+// Test corruption of one chunk on first attempt and repair on retry using expected SHA.
+func TestChunked_CorruptOneChunkThenRepair(t *testing.T) {
+	tmp := t.TempDir()
+	// Build payload 1MiB deterministic
+	size := 1 << 20
+	payload := make([]byte, size)
+	for i := 0; i < size; i++ { payload[i] = byte((i*17 + 3) % 251) }
+	// expected SHA
+	h := sha256.New(); h.Write(payload); expected := hex.EncodeToString(h.Sum(nil))
+	// Corrupt the first GET for the chunk starting at offset 256KiB
+	var corruptOnce int32 = 0
+	chunkStart := 256 * 1024
+	mux := http.NewServeMux()
+	mux.HandleFunc("/c.bin", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Accept-Ranges", "bytes")
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			w.Header().Set("ETag", "\"t\"")
+			w.WriteHeader(200); return
+		}
+		if r.Method != http.MethodGet { w.WriteHeader(405); return }
+		rng := r.Header.Get("Range")
+		if rng == "" {
+			w.WriteHeader(200); w.Write(payload); return
+		}
+		var start, end int
+		if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); err != nil { w.WriteHeader(416); return }
+		if start < 0 || end >= len(payload) || end < start { w.WriteHeader(416); return }
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(payload)))
+		w.WriteHeader(206)
+		chunk := make([]byte, end-start+1)
+		copy(chunk, payload[start:end+1])
+		if start == chunkStart && atomic.CompareAndSwapInt32(&corruptOnce, 0, 1) {
+			// corrupt bytes
+			for i := range chunk { chunk[i] ^= 0xFF }
+		}
+		w.Write(chunk)
+	})
+	ts := httptest.NewServer(mux); defer ts.Close()
+	url := ts.URL + "/c.bin"
+
+	cfgPath := filepath.Join(tmp, "cfg.yml")
+	cfgYaml := []byte(strings.Join([]string{
+		"version: 1",
+		"general:",
+		"  data_root: \""+tmp+"/data\"",
+		"  download_root: \""+tmp+"/dl\"",
+		"concurrency:",
+		"  per_file_chunks: 4",
+		"  chunk_size_mb: 1",
+		"  max_retries: 3",
+		"  backoff:",
+		"    min_ms: 1",
+		"    max_ms: 2",
+	}, "\n"))
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	cfg, err := config.Load(cfgPath)
+	if err != nil { t.Fatalf("config: %v", err) }
+	log := logging.New("info", false)
+	st, err := state.Open(cfg)
+	if err != nil { t.Fatalf("state: %v", err) }
+	defer st.SQL.Close()
+
+	dl := NewAuto(cfg, log, st, nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", expected, nil)
+	if err != nil { t.Fatalf("download: %v", err) }
+	if sha != expected {
+		b, _ := os.ReadFile(dest)
+		h2 := sha256.Sum256(b)
+		if hex.EncodeToString(h2[:]) != expected {
+			t.Fatalf("sha not repaired: got=%s expected=%s", sha, expected)
+		}
+	}
+}
+

--- a/internal/downloader/downloader_http_test.go
+++ b/internal/downloader/downloader_http_test.go
@@ -82,7 +82,7 @@ func TestChunked_RangeWithTransient429(t *testing.T) {
 	defer st.SQL.Close()
 
 	dl := NewAuto(cfg, log, st, nil)
-	dest, sha, err := dl.Download(context.Background(), url, "", "", nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", "", nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest: %v", err) }
 	if len(sha) != 64 { t.Fatalf("sha len: %d", len(sha)) }
@@ -125,7 +125,7 @@ func TestFallback_NoRangeSupport(t *testing.T) {
 	defer st.SQL.Close()
 
 	dl := NewAuto(cfg, log, st, nil)
-	dest, _, err := dl.Download(context.Background(), url, "", "", nil)
+	dest, _, err := dl.Download(context.Background(), url, "", "", nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	b, err := os.ReadFile(dest)
 	if err != nil { t.Fatalf("read: %v", err) }
@@ -196,7 +196,7 @@ func TestChunked_CorruptOneChunkThenRepair(t *testing.T) {
 	defer st.SQL.Close()
 
 	dl := NewAuto(cfg, log, st, nil)
-	dest, sha, err := dl.Download(context.Background(), url, "", expected, nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", expected, nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	if sha != expected {
 		b, _ := os.ReadFile(dest)

--- a/internal/downloader/downloader_http_test.go
+++ b/internal/downloader/downloader_http_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"

--- a/internal/downloader/fsutil.go
+++ b/internal/downloader/fsutil.go
@@ -1,0 +1,22 @@
+package downloader
+
+import (
+	"os"
+)
+
+// writeAndSync writes content to path and fsyncs the file.
+func writeAndSync(path string, b []byte) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil { return err }
+	defer f.Close()
+	if _, err := f.Write(b); err != nil { return err }
+	return f.Sync()
+}
+
+func fsyncDir(dir string) error {
+	df, err := os.Open(dir)
+	if err != nil { return err }
+	defer df.Close()
+	return df.Sync()
+}
+

--- a/internal/downloader/hf_resolve_download_test.go
+++ b/internal/downloader/hf_resolve_download_test.go
@@ -36,7 +36,7 @@ func TestHFResolveAndDownload(t *testing.T) {
 	res, err := resolver.Resolve(context.Background(), uri, cfg)
 	if err != nil { t.Fatalf("resolve: %v", err) }
 	dl := NewChunked(cfg, log, st, nil)
-	dest, sha, err := dl.Download(context.Background(), res.URL, "", "", res.Headers)
+	dest, sha, err := dl.Download(context.Background(), res.URL, "", "", res.Headers, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest stat: %v", err) }
 	if len(sha) != 64 { t.Fatalf("sha length: %d", len(sha)) }

--- a/internal/downloader/httpclient.go
+++ b/internal/downloader/httpclient.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"runtime"
+	"strings"
 	"time"
 
 	"modfetch/internal/config"
@@ -29,7 +30,21 @@ func newHTTPClient(cfg *config.Config) *http.Client {
 			MinVersion: tls.VersionTLS12,
 		},
 	}
-	return &http.Client{Transport: tr, Timeout: timeout}
+	client := &http.Client{Transport: tr, Timeout: timeout}
+	// Preserve important headers across redirects (Range, If-Range, UA). Avoid leaking Authorization across hosts.
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) == 0 { return nil }
+		prev := via[len(via)-1]
+		if ua := prev.Header.Get("User-Agent"); ua != "" { req.Header.Set("User-Agent", ua) }
+		if rng := prev.Header.Get("Range"); rng != "" { req.Header.Set("Range", rng) }
+		if ir := prev.Header.Get("If-Range"); ir != "" { req.Header.Set("If-Range", ir) }
+		// Only forward Authorization when host is the same
+		if prev.URL != nil && req.URL != nil && strings.EqualFold(prev.URL.Host, req.URL.Host) {
+			if auth := prev.Header.Get("Authorization"); auth != "" { req.Header.Set("Authorization", auth) }
+		}
+		return nil
+	}
+	return client
 }
 
 // userAgent returns the configured User-Agent, or a sensible default

--- a/internal/downloader/paths.go
+++ b/internal/downloader/paths.go
@@ -12,9 +12,16 @@ import (
 	"modfetch/internal/config"
 )
 
-// stagePartPath returns a staging .part path under download_root/.parts, unique to (url,dest).
+// stagePartPath returns a staging .part path under download_root/.parts or partials_root if set, unique to (url,dest).
 func stagePartPath(cfg *config.Config, url, dest string) string {
-	partsDir := filepath.Join(cfg.General.DownloadRoot, ".parts")
+	if cfg != nil && !cfg.General.StagePartials {
+		return dest + ".part"
+	}
+	// Prefer explicit partials_root if configured; otherwise fallback to download_root/.parts
+	partsDir := cfg.General.PartialsRoot
+	if partsDir == "" {
+		partsDir = filepath.Join(cfg.General.DownloadRoot, ".parts")
+	}
 	_ = os.MkdirAll(partsDir, 0o755)
 	keySrc := url + "|" + dest
 	h := sha1.Sum([]byte(keySrc))

--- a/internal/downloader/paths.go
+++ b/internal/downloader/paths.go
@@ -31,6 +31,12 @@ func stagePartPath(cfg *config.Config, url, dest string) string {
 	return filepath.Join(partsDir, file)
 }
 
+// StagePartPath is an exported helper for UI components to locate the .part file
+// for an in-progress download, consistent with downloader behavior.
+func StagePartPath(cfg *config.Config, url, dest string) string {
+	return stagePartPath(cfg, url, dest)
+}
+
 // renameOrCopy attempts to rename, falling back to copy when cross-device.
 func renameOrCopy(src, dst string) error {
 	if err := os.Rename(src, dst); err != nil {

--- a/internal/downloader/safetensors_fix.go
+++ b/internal/downloader/safetensors_fix.go
@@ -1,0 +1,142 @@
+package downloader
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"modfetch/internal/logging"
+)
+
+// adjustSafetensors trims any trailing bytes beyond what the safetensors header declares.
+// If the file is shorter than required, returns an error.
+// Returns true when the file was modified (truncated).
+func adjustSafetensors(path string, log *logging.Logger) (bool, error) {
+	if !(strings.HasSuffix(strings.ToLower(path), ".safetensors") || strings.HasSuffix(strings.ToLower(path), ".sft")) {
+		return false, nil
+	}
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil { return false, err }
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil { return false, err }
+	if fi.Size() < 8 { return false, fmt.Errorf("safetensors: file too small: %d", fi.Size()) }
+	// Read header length
+	var hdrLen uint64
+	if _, err := f.Seek(0, 0); err != nil { return false, err }
+	if err := binary.Read(f, binary.LittleEndian, &hdrLen); err != nil { return false, err }
+	if hdrLen == 0 || hdrLen > uint64(fi.Size()) { return false, fmt.Errorf("safetensors: invalid header len %d", hdrLen) }
+	hdr := make([]byte, hdrLen)
+	if _, err := f.Read(hdr); err != nil { return false, err }
+	var meta map[string]any
+	if err := json.Unmarshal(hdr, &meta); err != nil { return false, fmt.Errorf("safetensors: header json: %w", err) }
+	// Compute max data end from top-level tensor entries
+	var maxEnd int64 = 0
+	for k, v := range meta {
+		lk := strings.ToLower(k)
+		if lk == "metadata" || lk == "__metadata__" { continue }
+		m, ok := v.(map[string]any)
+		if !ok { continue }
+		off, ok := m["data_offsets"].([]any)
+		if !ok || len(off) != 2 { continue }
+		_, ok1 := toInt64(off[0])
+		end, ok2 := toInt64(off[1])
+		if !ok1 || !ok2 { continue }
+		if end > maxEnd { maxEnd = end }
+	}
+	req := int64(8) + int64(hdrLen) + maxEnd
+	if req < 0 { return false, fmt.Errorf("safetensors: computed size invalid") }
+	if fi.Size() < req {
+		return false, fmt.Errorf("safetensors: file incomplete: have=%d need=%d", fi.Size(), req)
+	}
+	if fi.Size() > req {
+		if err := f.Truncate(req); err != nil { return false, err }
+		if log != nil { log.Warnf("safetensors: truncated trailing %d bytes", fi.Size()-req) }
+		return true, nil
+	}
+	return false, nil
+}
+
+// deepVerifySafetensors validates header coverage, data offsets and exact file length match.
+// Returns ok, declared_total_size, error.
+func deepVerifySafetensors(path string) (bool, int64, error) {
+	if !(strings.HasSuffix(strings.ToLower(path), ".safetensors") || strings.HasSuffix(strings.ToLower(path), ".sft")) {
+		return true, 0, nil
+	}
+	f, err := os.Open(path)
+	if err != nil { return false, 0, err }
+	defer f.Close()
+	fi, err := f.Stat(); if err != nil { return false, 0, err }
+	if fi.Size() < 8 { return false, 0, fmt.Errorf("file too small: %d", fi.Size()) }
+	var hdrLen uint64
+	if err := binary.Read(f, binary.LittleEndian, &hdrLen); err != nil { return false, 0, err }
+	if hdrLen == 0 || hdrLen > uint64(fi.Size()-8) || hdrLen > 64*1024*1024 { return false, 0, fmt.Errorf("invalid safetensors header length: %d", hdrLen) }
+	hdr := make([]byte, hdrLen)
+	if _, err := io.ReadFull(f, hdr); err != nil { return false, 0, err }
+	var meta map[string]any
+	if err := json.Unmarshal(hdr, &meta); err != nil { return false, 0, fmt.Errorf("header json: %w", err) }
+	dataLen := fi.Size() - 8 - int64(hdrLen)
+	if dataLen < 0 { return false, 0, fmt.Errorf("negative data length") }
+	var maxEnd int64
+	for k, v := range meta {
+		lk := strings.ToLower(k)
+		if lk == "metadata" || lk == "__metadata__" { continue }
+		m, ok := v.(map[string]any)
+		if !ok { continue }
+		off, ok := m["data_offsets"].([]any)
+		if !ok || len(off) != 2 { continue }
+		start, ok1 := toInt64(off[0])
+		end, ok2 := toInt64(off[1])
+		if !ok1 || !ok2 { return false, 0, fmt.Errorf("tensor %q: invalid data_offsets", k) }
+		if start < 0 || end < 0 || end < start { return false, 0, fmt.Errorf("tensor %q: invalid range %d-%d", k, start, end) }
+		if end > dataLen { return false, 0, fmt.Errorf("tensor %q: data end %d beyond data length %d", k, end, dataLen) }
+		if dtRaw, ok := m["dtype"].(string); ok {
+			if shp, ok := m["shape"].([]any); ok {
+				exp := dtypeBytes(dtRaw)
+				if exp > 0 {
+					var cnt int64 = 1
+					for _, dim := range shp { d, ok := toInt64(dim); if !ok || d <= 0 { cnt = 0; break }; cnt *= d }
+					if cnt > 0 {
+						sz := end - start
+						if sz != cnt*exp { return false, 0, fmt.Errorf("tensor %q: size %d != %d*%d", k, sz, cnt, exp) }
+					}
+				}
+			}
+		}
+		if end > maxEnd { maxEnd = end }
+	}
+	declared := int64(8) + int64(hdrLen) + maxEnd
+	if fi.Size() < declared { return false, declared, fmt.Errorf("incomplete: have=%d need=%d", fi.Size(), declared) }
+	if fi.Size() > declared { return false, declared, fmt.Errorf("extra bytes: have=%d need=%d", fi.Size(), declared) }
+	return true, declared, nil
+}
+
+func dtypeBytes(dt string) int64 {
+	switch strings.ToUpper(strings.TrimSpace(dt)) {
+	case "F64": return 8
+	case "F32": return 4
+	case "F16", "BF16": return 2
+	case "F8", "F8_E4M3FN", "F8_E5M2": return 1
+	case "I64": return 8
+	case "I32": return 4
+	case "I16": return 2
+	case "I8", "U8", "BOOL": return 1
+	default: return 0
+	}
+}
+
+func toInt64(v any) (int64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return int64(x), true
+	case int64:
+		return x, true
+	case int:
+		return int64(x), true
+	default:
+		return 0, false
+	}
+}

--- a/internal/downloader/single.go
+++ b/internal/downloader/single.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -163,9 +165,12 @@ func (s *Single) head(ctx context.Context, url string, headers map[string]string
 	return
 }
 
-func lastURLSegment(u string) string {
-	if i := strings.LastIndex(u, "/"); i >= 0 && i < len(u)-1 {
-		return u[i+1:]
+func lastURLSegment(uStr string) string {
+	if u, err := neturl.Parse(uStr); err == nil {
+		b := path.Base(u.Path)
+		if b != "/" && b != "." && b != "" {
+			return b
+		}
 	}
 	return ""
 }

--- a/internal/downloader/single.go
+++ b/internal/downloader/single.go
@@ -174,21 +174,6 @@ func equalSHA(exp, got string) bool {
 	return strings.EqualFold(strings.TrimSpace(exp), strings.TrimSpace(got))
 }
 
-// writeAndSync writes content to path and fsyncs the file.
-func writeAndSync(path string, b []byte) error {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
-	if err != nil { return err }
-	defer f.Close()
-	if _, err := f.Write(b); err != nil { return err }
-	return f.Sync()
-}
-
-func fsyncDir(dir string) error {
-	df, err := os.Open(dir)
-	if err != nil { return err }
-	defer df.Close()
-	return df.Sync()
-}
 
 func friendlyIOError(err error) error {
 	// Map ENOSPC to a friendlier message

--- a/internal/downloader/single.go
+++ b/internal/downloader/single.go
@@ -87,6 +87,8 @@ func (s *Single) Download(ctx context.Context, url, destPath, expectedSHA string
 	// Prepare hasher and file
 	var hasher = sha256.New()
 	var start int64 = 0
+	// Clear any stale chunk state since we're using single-stream
+	_ = s.st.DeleteChunks(url, destPath)
 	if fi, err := os.Stat(part); err == nil {
 		start = fi.Size()
 		s.log.Infof("resuming: %s (have %d bytes)", part, start)

--- a/internal/downloader/single_test.go
+++ b/internal/downloader/single_test.go
@@ -33,7 +33,7 @@ func TestSingleDownloadHF(t *testing.T) {
 	defer st.SQL.Close()
 
 	dl := NewSingle(cfg, log, st, nil)
-	final, sum, err := dl.Download(context.Background(), "https://raw.githubusercontent.com/github/gitignore/main/Go.gitignore", "", "", nil)
+	final, sum, err := dl.Download(context.Background(), "https://raw.githubusercontent.com/github/gitignore/main/Go.gitignore", "", "", nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	if _, err := os.Stat(final); err != nil { t.Fatalf("final file missing: %v", err) }
 	if len(sum) != 64 { t.Fatalf("unexpected sha256 length: %d", len(sum)) }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -40,7 +40,9 @@ type Logger struct {
 }
 
 func New(level string, jsonOut bool) *Logger {
-	return &Logger{min: ParseLevel(level), json: jsonOut, out: os.Stdout}
+	out := io.Writer(os.Stderr)
+	if jsonOut { out = os.Stdout }
+	return &Logger{min: ParseLevel(level), json: jsonOut, out: out}
 }
 
 func (l *Logger) Enabled(v Level) bool { return v >= l.min }

--- a/internal/logging/sanitize.go
+++ b/internal/logging/sanitize.go
@@ -12,6 +12,10 @@ func SanitizeURL(raw string) string {
 	if s == "" { return s }
 	u, err := url.Parse(s)
 	if err != nil { return s }
+	// If no scheme and no authority, keep as-is to avoid percent-encoding spaces
+	if u.Scheme == "" && !strings.Contains(s, "://") {
+		return s
+	}
 	u.User = nil
 	u.RawQuery = ""
 	u.Fragment = ""

--- a/internal/resolver/civitai_test.go
+++ b/internal/resolver/civitai_test.go
@@ -67,6 +67,10 @@ func TestCivitAIResolve_ModelLatestAndHeaders(t *testing.T) {
 	if got := res.Headers["Authorization"]; got != "Bearer XYZ" {
 		t.Fatalf("auth header not set: %q", got)
 	}
+	// Suggested filename falls back to original file name when model name is absent in API
+	if res.SuggestedFilename == "" || !strings.HasSuffix(res.SuggestedFilename, ".safetensors") {
+		t.Fatalf("expected suggested filename safetensors, got %q", res.SuggestedFilename)
+	}
 
 	// Filter by file name substring
 	res2, err := (&CivitAI{}).Resolve(context.Background(), "civitai://model/123?file=vae", cfg)
@@ -74,12 +78,18 @@ func TestCivitAIResolve_ModelLatestAndHeaders(t *testing.T) {
 	if !strings.HasSuffix(res2.URL, "/dl/vae.bin") {
 		t.Fatalf("unexpected url2: %s", res2.URL)
 	}
+	if res2.SuggestedFilename == "" || !strings.Contains(res2.SuggestedFilename, "vae") {
+		t.Fatalf("expected suggested filename containing 'vae', got %q", res2.SuggestedFilename)
+	}
 
 	// Specific version
 	res3, err := (&CivitAI{}).Resolve(context.Background(), "civitai://model/123?version=12", cfg)
 	if err != nil { t.Fatalf("resolve3: %v", err) }
 	if !strings.HasSuffix(res3.URL, "/dl/mv.bin") {
 		t.Fatalf("unexpected url3: %s", res3.URL)
+	}
+	if res3.SuggestedFilename == "" || !strings.Contains(res3.SuggestedFilename, ".safetensors") {
+		t.Fatalf("expected suggested safetensors filename, got %q", res3.SuggestedFilename)
 	}
 }
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -9,8 +9,14 @@ import (
 )
 
 type Resolved struct {
-	URL     string
-	Headers map[string]string
+	URL               string
+	Headers           map[string]string
+	// Optional metadata (primarily for CivitAI) — may be empty for other resolvers
+	ModelName         string
+	VersionName       string
+	VersionID         string
+	FileName          string
+	SuggestedFilename string
 }
 
 type Resolver interface {

--- a/internal/state/chunks.go
+++ b/internal/state/chunks.go
@@ -65,3 +65,9 @@ func (db *DB) UpdateChunkSHA(url, dest string, idx int, sha string) error {
 	return err
 }
 
+// DeleteChunks removes all chunk rows for a given url+dest pair.
+func (db *DB) DeleteChunks(url, dest string) error {
+	_, err := db.SQL.Exec(`DELETE FROM chunks WHERE url=? AND dest=?`, url, dest)
+	return err
+}
+

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -88,6 +88,12 @@ func (db *DB) IncDownloadRetries(url, dest string, delta int64) error {
 	return err
 }
 
+// DeleteDownload removes a download row for the given url+dest.
+func (db *DB) DeleteDownload(url, dest string) error {
+	_, err := db.SQL.Exec(`DELETE FROM downloads WHERE url=? AND dest=?`, url, dest)
+	return err
+}
+
 // ListDownloads returns a snapshot of the downloads table
 func (db *DB) ListDownloads() ([]DownloadRow, error) {
 	rows, err := db.SQL.Query(`SELECT url,dest,expected_sha256,actual_sha256,etag,last_modified,size,status,retries,updated_at FROM downloads ORDER BY updated_at DESC`)

--- a/internal/util/paths.go
+++ b/internal/util/paths.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SafeFileName strips directory components and disallowed characters.
+// Keep it conservative: replace '/' and '\\' with '_', trim spaces, and ensure non-empty.
+func SafeFileName(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.ReplaceAll(name, "\\", "_")
+	name = strings.ReplaceAll(name, "/", "_")
+	if name == "" { return "download" }
+	return name
+}
+
+// UniquePath returns a unique path inside dir for the given base filename.
+// If a file already exists, it first tries adding a version hint " (v<versionHint>)"
+// before the extension (when versionHint != ""). Then it tries numeric suffixes
+// " (2)", " (3)", etc., before the extension.
+func UniquePath(dir, base, versionHint string) (string, error) {
+	base = SafeFileName(base)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+	path := filepath.Join(dir, base)
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) { return path, nil }
+		return "", err
+	}
+	if strings.TrimSpace(versionHint) != "" {
+		cand := filepath.Join(dir, fmt.Sprintf("%s (v%s)%s", name, versionHint, ext))
+		if _, err := os.Stat(cand); os.IsNotExist(err) { return cand, nil }
+	}
+	for i := 2; ; i++ {
+		cand := filepath.Join(dir, fmt.Sprintf("%s (%d)%s", name, i, ext))
+		if _, err := os.Stat(cand); os.IsNotExist(err) { return cand, nil }
+	}
+}

--- a/internal/util/paths_test.go
+++ b/internal/util/paths_test.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSafeFileName(t *testing.T) {
+	cases := map[string]string{
+		"foo/bar":            "foo_bar",
+		"foo\\bar":           "foo_bar",
+		"  spaced name  ":   "spaced name",
+		"":                   "download",
+	}
+	for in, want := range cases {
+		got := SafeFileName(in)
+		if got != want {
+			t.Fatalf("SafeFileName(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestUniquePath(t *testing.T) {
+	d := t.TempDir()
+	base := "ModelX - file.bin"
+	p1, err := UniquePath(d, base, "")
+	if err != nil { t.Fatal(err) }
+	if filepath.Base(p1) != base { t.Fatalf("got %s want %s", filepath.Base(p1), base) }
+	// create p1
+	if err := os.WriteFile(p1, []byte("x"), 0o644); err != nil { t.Fatal(err) }
+	// Next should try version hint
+	p2, err := UniquePath(d, base, "12")
+	if err != nil { t.Fatal(err) }
+	if filepath.Base(p2) != "ModelX - file (v12).bin" {
+		t.Fatalf("unexpected p2: %s", filepath.Base(p2))
+	}
+	// create p2
+	if err := os.WriteFile(p2, []byte("x"), 0o644); err != nil { t.Fatal(err) }
+	// Next should try numeric suffix
+	p3, err := UniquePath(d, base, "12")
+	if err != nil { t.Fatal(err) }
+	if filepath.Base(p3) != "ModelX - file (2).bin" {
+		t.Fatalf("unexpected p3: %s", filepath.Base(p3))
+	}
+}
+


### PR DESCRIPTION
This PR is intended for CodeRabbit review only; please DO NOT merge.

Highlights:
- downloader(chunked): enable Range GET probe when HEAD is blocked (e.g., 403/EOF), inferring total size from Content-Range
- relax host capability gating to prefer chunked when Accept-Ranges is available even if HEAD is blocked
- wrap single-stream fallback with retry/backoff to improve reliability on services that ignore Range or drop connections mid-body
- advanced httptest coverage: transient 5xx per-chunk, slow body streaming, truncated body mid-chunk then retry success
- earlier change: de-duplicate writeAndSync/fsyncDir helpers and centralize in fsutil.go; logging SanitizeURL preserves raw strings without scheme

All packages build and tests pass: go test ./...