### PR TITLE
CivitAI: model-aware default filenames; CLI wiring; util helpers; docs; tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ User guide (see docs/USER_GUIDE.md for full guide)
   modfetch download --config /path/to/config.yml --url 'hf://gpt2/README.md?rev=main'
   modfetch download --config /path/to/config.yml --url 'civitai://model/123456?file=vae'
   
+  - Default filename:
+    - civitai:// uses `<ModelName> - <OriginalFileName>` if `--dest` is omitted (with collision-safe suffixes)
+    - others use the basename of the resolved URL
   - Quiet mode (suppress progress/info logs): add `--quiet`
   - On completion, a summary is printed (dest, size, SHA256, duration, average speed)
 - Place artifacts into apps:

--- a/docs/BATCH.md
+++ b/docs/BATCH.md
@@ -17,7 +17,9 @@ BatchJob fields:
   - Direct HTTP(S) or resolver URI
   - Examples: `https://...`, `hf://owner/repo/path?rev=main`, `civitai://model/123456?version=42&file=vae`
 - dest: string (optional)
-  - Destination file path; if omitted, modfetch saves to `<general.download_root>/<basename-of-resolved-URL>`
+  - Destination file path. If omitted:
+    - For civitai:// URIs: modfetch saves to `<general.download_root>/<ModelName> - <OriginalFileName>` (sanitized), with collision-safe suffixes.
+    - For other URIs: modfetch saves to `<general.download_root>/<basename-of-resolved-URL>`.
 - sha256: string (optional)
   - Expected final SHA256 (hex). On mismatch, modfetch will re-hash chunks to identify and re-fetch the corrupted ones. If still mismatched, the job fails.
   - A `.sha256` sidecar file is always written on success.

--- a/docs/RESOLVERS.md
+++ b/docs/RESOLVERS.md
@@ -34,7 +34,9 @@ CivitAI (civitai://)
   - The resolver queries the CivitAI API:
     - GET /api/v1/models/{modelId} to enumerate versions and files
     - or GET /api/v1/model-versions/{versionId}
-  - Returns the file.downloadUrl from the selected file.
+  - Returns the file.downloadUrl from the selected file and also provides metadata: model name, version name/id, original file name.
+- Default filename when --dest is omitted:
+  - For civitai:// URIs, modfetch will save to `<general.download_root>/<ModelName> - <OriginalFileName>` (sanitized). If a file with that name already exists, it tries appending `(v<versionId>)` before the extension, then numeric suffixes `(2)`, `(3)`, etc.
 - Authentication:
   - If sources.civitai.enabled is true and sources.civitai.token_env points to an environment variable (e.g., CIVITAI_TOKEN), an Authorization: Bearer <token> header is attached and used for both HEAD and GET requests.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,57 @@
+# TODO / Plan: CivitAI model-aware default filenames
+
+Goal
+- When downloading via civitai:// and no --dest is provided, default the destination filename to include the CivitAI model name so files are easy to recognize and organize.
+
+Default behavior
+- Pattern: "<ModelName> - <OriginalFileName>"
+  - Keep the original extension (it comes from CivitAI’s file name).
+  - Sanitize the final filename (replace path separators and disallowed chars with underscores).
+- Scope: Only applies when the user provides civitai:// URIs and omits --dest (and dest is empty in batch jobs). Direct https://civitai.com URLs retain the current behavior.
+- Collision policy: If the computed filename already exists under download_root, try adding version ID hint " (v<versionId>)"; if still collides, add numeric suffixes before the extension: " (2)", "(3)", etc.
+
+Implementation tasks
+1) Extend Resolved metadata
+   - internal/resolver/resolver.go: add optional fields to Resolved: ModelName, VersionName, VersionID, FileName, SuggestedFilename.
+   - HuggingFace resolver leaves these empty; CivitAI resolver populates them.
+
+2) Populate CivitAI metadata and suggested filename
+   - internal/resolver/civitai.go:
+     - Extend API structs to capture model/version names (e.g., civitModel.Name, civitVersion.Name, civitVersion.ModelID).
+     - If ?version is present, fetch version and (if needed) fetch model to obtain model name; else fetch model (contains versions) and pick latest version as today.
+     - Preserve existing file selection logic (file substring, primary, Model type, fallback first).
+     - After selecting a file, set: ModelName, VersionName, VersionID, FileName (file.Name).
+     - Compute SuggestedFilename = SafeFileName(ModelName + " - " + FileName).
+
+3) Shared helpers
+   - internal/util/paths.go (new):
+     - SafeFileName(name string) string — centralize filename sanitization.
+     - UniquePath(dir, base, versionHint string) (string, error) — returns a unique filename in dir, applying version hint and numeric suffixes.
+   - internal/downloader/chunked.go: switch to util.SafeFileName and remove duplicated local helper.
+
+4) Wire CLI to use SuggestedFilename
+   - cmd/modfetch/main.go:
+     - After resolver.Resolve for civitai://, when dest is empty and res.SuggestedFilename is set, compute dest = UniquePath(download_root, res.SuggestedFilename, res.VersionID).
+     - Use this dest for the progress display (so the .part path matches) and for the downloader.
+   - Batch mode: same behavior for jobs with empty dest.
+
+5) Tests
+   - internal/resolver/civitai_test.go: assert that resolver populates ModelName, VersionName, SuggestedFilename and still chooses the correct file.
+   - internal/util/paths_test.go: SafeFileName and UniquePath edge cases (illegal chars, collisions, suffix placement before extension).
+   - Update any outdated tests (e.g., downloader resolve tests) to reflect signatures and new behavior.
+
+6) Docs
+   - docs/RESOLVERS.md, docs/BATCH.md, README.md: document civitai default naming when dest is omitted, scope/limits, and collision policy.
+
+Acceptance criteria
+- Given civitai://model/{id} (with or without ?version) and no --dest, the final saved filename contains the model name following the pattern above and retains the correct extension.
+- When the computed name collides in download_root, a unique name is chosen via version hint or numeric suffix.
+- Progress bar reflects the chosen destination path from start to finish.
+- Behavior for hf:// and direct HTTP(S) downloads remains unchanged.
+- Unit tests for resolver metadata and helpers pass; existing tests remain green.
+- Docs updated to reflect the new behavior.
+
+Out of scope (for now)
+- Config/CLI knobs for naming patterns; can be added later if needed (proposal: sources.civitai.naming.pattern, include_version: bool).
+- Deriving model names for direct https://civitai.com links (non-civitai:// URIs).
+

--- a/internal/downloader/chunked_test.go
+++ b/internal/downloader/chunked_test.go
@@ -39,7 +39,7 @@ func TestChunkedDownload1MB(t *testing.T) {
 
 	dl := NewChunked(cfg, log, st, nil)
 	url := "https://proof.ovh.net/files/1Mb.dat"
-	dest, sha, err := dl.Download(context.Background(), url, "", "", nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", "", nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	fi, err := os.Stat(dest)
 	if err != nil { t.Fatalf("stat: %v", err) }
@@ -74,7 +74,7 @@ func TestChunkedCorruptAndRepair(t *testing.T) {
 	dl := NewChunked(cfg, log, st, nil)
 	url := "https://proof.ovh.net/files/1Mb.dat"
 	// First download to get good SHA
-	dest, goodSHA, err := dl.Download(context.Background(), url, "", "", nil)
+	dest, goodSHA, err := dl.Download(context.Background(), url, "", "", nil, false)
 	if err != nil { t.Fatalf("download1: %v", err) }
 	// Corrupt middle 64 bytes
 	f, err := os.OpenFile(dest, os.O_RDWR, 0)
@@ -85,7 +85,7 @@ func TestChunkedCorruptAndRepair(t *testing.T) {
 	for i := range bad { bad[i] = 0xFF }
 	if _, err := f.Write(bad); err != nil { t.Fatalf("write corrupt: %v", err) }
 	// Run downloader again with expected SHA; it should repair the corrupted chunk
-	_, fixedSHA, err := dl.Download(context.Background(), url, dest, goodSHA, nil)
+	_, fixedSHA, err := dl.Download(context.Background(), url, dest, goodSHA, nil, false)
 	if err != nil { t.Fatalf("download2(repair): %v", err) }
 	if fixedSHA != goodSHA {
 		// confirm by local recompute

--- a/internal/downloader/civitai_resolve_download_test.go
+++ b/internal/downloader/civitai_resolve_download_test.go
@@ -97,7 +97,7 @@ func TestCivitAIResolveAndDownload_WithAuthAndChunks(t *testing.T) {
 	res, err := resolver.Resolve(context.Background(), uri, cfg)
 	if err != nil { t.Fatalf("resolve: %v", err) }
 	dl := NewChunked(cfg, log, st, nil)
-	dest, sha, err := dl.Download(context.Background(), res.URL, "", "", res.Headers)
+	dest, sha, err := dl.Download(context.Background(), res.URL, "", "", res.Headers, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	fi, err := os.Stat(dest)
 	if err != nil { t.Fatalf("stat: %v", err) }

--- a/internal/downloader/downloader_http_advanced_test.go
+++ b/internal/downloader/downloader_http_advanced_test.go
@@ -83,7 +83,7 @@ func TestChunked_RangeTransient5xxThenSuccess(t *testing.T) {
 	defer st.SQL.Close()
 
 	dl := NewAuto(cfg, log, st, nil)
-	dest, sha, err := dl.Download(context.Background(), url, "", "", nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", "", nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest: %v", err) }
 	if len(sha) != 64 { t.Fatalf("sha len: %d", len(sha)) }
@@ -147,7 +147,7 @@ func TestChunked_SlowBodyCompletes(t *testing.T) {
 	defer st.SQL.Close()
 
 	dl := NewAuto(cfg, log, st, nil)
-	dest, sha, err := dl.Download(context.Background(), url, "", "", nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", "", nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest: %v", err) }
 	if len(sha) != 64 { t.Fatalf("sha len: %d", len(sha)) }
@@ -216,7 +216,7 @@ func TestChunked_TruncatedBodyThenRetrySuccess(t *testing.T) {
 	defer st.SQL.Close()
 
 	dl := NewAuto(cfg, log, st, nil)
-	dest, sha, err := dl.Download(context.Background(), url, "", expected, nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", expected, nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	if sha != expected { t.Fatalf("expected sha %s got %s", expected, sha) }
 	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest: %v", err) }

--- a/internal/downloader/downloader_http_test.go
+++ b/internal/downloader/downloader_http_test.go
@@ -82,7 +82,7 @@ func TestChunked_RangeWithTransient429(t *testing.T) {
 	defer st.SQL.Close()
 
 	dl := NewAuto(cfg, log, st, nil)
-	dest, sha, err := dl.Download(context.Background(), url, "", "", nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", "", nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest: %v", err) }
 	if len(sha) != 64 { t.Fatalf("sha len: %d", len(sha)) }
@@ -125,7 +125,7 @@ func TestFallback_NoRangeSupport(t *testing.T) {
 	defer st.SQL.Close()
 
 	dl := NewAuto(cfg, log, st, nil)
-	dest, _, err := dl.Download(context.Background(), url, "", "", nil)
+	dest, _, err := dl.Download(context.Background(), url, "", "", nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	b, err := os.ReadFile(dest)
 	if err != nil { t.Fatalf("read: %v", err) }
@@ -196,7 +196,7 @@ func TestChunked_CorruptOneChunkThenRepair(t *testing.T) {
 	defer st.SQL.Close()
 
 	dl := NewAuto(cfg, log, st, nil)
-	dest, sha, err := dl.Download(context.Background(), url, "", expected, nil)
+	dest, sha, err := dl.Download(context.Background(), url, "", expected, nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	if sha != expected {
 		b, _ := os.ReadFile(dest)

--- a/internal/downloader/hf_resolve_download_test.go
+++ b/internal/downloader/hf_resolve_download_test.go
@@ -36,7 +36,7 @@ func TestHFResolveAndDownload(t *testing.T) {
 	res, err := resolver.Resolve(context.Background(), uri, cfg)
 	if err != nil { t.Fatalf("resolve: %v", err) }
 	dl := NewChunked(cfg, log, st, nil)
-	dest, sha, err := dl.Download(context.Background(), res.URL, "", "", res.Headers)
+	dest, sha, err := dl.Download(context.Background(), res.URL, "", "", res.Headers, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest stat: %v", err) }
 	if len(sha) != 64 { t.Fatalf("sha length: %d", len(sha)) }

--- a/internal/downloader/paths.go
+++ b/internal/downloader/paths.go
@@ -12,9 +12,16 @@ import (
 	"modfetch/internal/config"
 )
 
-// stagePartPath returns a staging .part path under download_root/.parts, unique to (url,dest).
+// stagePartPath returns a staging .part path under download_root/.parts or partials_root if set, unique to (url,dest).
 func stagePartPath(cfg *config.Config, url, dest string) string {
-	partsDir := filepath.Join(cfg.General.DownloadRoot, ".parts")
+	if cfg != nil && !cfg.General.StagePartials {
+		return dest + ".part"
+	}
+	// Prefer explicit partials_root if configured; otherwise fallback to download_root/.parts
+	partsDir := cfg.General.PartialsRoot
+	if partsDir == "" {
+		partsDir = filepath.Join(cfg.General.DownloadRoot, ".parts")
+	}
 	_ = os.MkdirAll(partsDir, 0o755)
 	keySrc := url + "|" + dest
 	h := sha1.Sum([]byte(keySrc))

--- a/internal/downloader/single_test.go
+++ b/internal/downloader/single_test.go
@@ -33,7 +33,7 @@ func TestSingleDownloadHF(t *testing.T) {
 	defer st.SQL.Close()
 
 	dl := NewSingle(cfg, log, st, nil)
-	final, sum, err := dl.Download(context.Background(), "https://raw.githubusercontent.com/github/gitignore/main/Go.gitignore", "", "", nil)
+	final, sum, err := dl.Download(context.Background(), "https://raw.githubusercontent.com/github/gitignore/main/Go.gitignore", "", "", nil, false)
 	if err != nil { t.Fatalf("download: %v", err) }
 	if _, err := os.Stat(final); err != nil { t.Fatalf("final file missing: %v", err) }
 	if len(sum) != 64 { t.Fatalf("unexpected sha256 length: %d", len(sum)) }

--- a/internal/resolver/civitai_test.go
+++ b/internal/resolver/civitai_test.go
@@ -67,6 +67,10 @@ func TestCivitAIResolve_ModelLatestAndHeaders(t *testing.T) {
 	if got := res.Headers["Authorization"]; got != "Bearer XYZ" {
 		t.Fatalf("auth header not set: %q", got)
 	}
+	// Suggested filename falls back to original file name when model name is absent in API
+	if res.SuggestedFilename == "" || !strings.HasSuffix(res.SuggestedFilename, ".safetensors") {
+		t.Fatalf("expected suggested filename safetensors, got %q", res.SuggestedFilename)
+	}
 
 	// Filter by file name substring
 	res2, err := (&CivitAI{}).Resolve(context.Background(), "civitai://model/123?file=vae", cfg)
@@ -74,12 +78,18 @@ func TestCivitAIResolve_ModelLatestAndHeaders(t *testing.T) {
 	if !strings.HasSuffix(res2.URL, "/dl/vae.bin") {
 		t.Fatalf("unexpected url2: %s", res2.URL)
 	}
+	if res2.SuggestedFilename == "" || !strings.Contains(res2.SuggestedFilename, "vae") {
+		t.Fatalf("expected suggested filename containing 'vae', got %q", res2.SuggestedFilename)
+	}
 
 	// Specific version
 	res3, err := (&CivitAI{}).Resolve(context.Background(), "civitai://model/123?version=12", cfg)
 	if err != nil { t.Fatalf("resolve3: %v", err) }
 	if !strings.HasSuffix(res3.URL, "/dl/mv.bin") {
 		t.Fatalf("unexpected url3: %s", res3.URL)
+	}
+	if res3.SuggestedFilename == "" || !strings.Contains(res3.SuggestedFilename, ".safetensors") {
+		t.Fatalf("expected suggested safetensors filename, got %q", res3.SuggestedFilename)
 	}
 }
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -9,8 +9,14 @@ import (
 )
 
 type Resolved struct {
-	URL     string
-	Headers map[string]string
+	URL               string
+	Headers           map[string]string
+	// Optional metadata (primarily for CivitAI) — may be empty for other resolvers
+	ModelName         string
+	VersionName       string
+	VersionID         string
+	FileName          string
+	SuggestedFilename string
 }
 
 type Resolver interface {

--- a/internal/util/paths.go
+++ b/internal/util/paths.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SafeFileName strips directory components and disallowed characters.
+// Keep it conservative: replace '/' and '\\' with '_', trim spaces, and ensure non-empty.
+func SafeFileName(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.ReplaceAll(name, "\\", "_")
+	name = strings.ReplaceAll(name, "/", "_")
+	if name == "" { return "download" }
+	return name
+}
+
+// UniquePath returns a unique path inside dir for the given base filename.
+// If a file already exists, it first tries adding a version hint " (v<versionHint>)"
+// before the extension (when versionHint != ""). Then it tries numeric suffixes
+// " (2)", " (3)", etc., before the extension.
+func UniquePath(dir, base, versionHint string) (string, error) {
+	base = SafeFileName(base)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+	path := filepath.Join(dir, base)
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) { return path, nil }
+		return "", err
+	}
+	if strings.TrimSpace(versionHint) != "" {
+		cand := filepath.Join(dir, fmt.Sprintf("%s (v%s)%s", name, versionHint, ext))
+		if _, err := os.Stat(cand); os.IsNotExist(err) { return cand, nil }
+	}
+	for i := 2; ; i++ {
+		cand := filepath.Join(dir, fmt.Sprintf("%s (%d)%s", name, i, ext))
+		if _, err := os.Stat(cand); os.IsNotExist(err) { return cand, nil }
+	}
+}

--- a/internal/util/paths_test.go
+++ b/internal/util/paths_test.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSafeFileName(t *testing.T) {
+	cases := map[string]string{
+		"foo/bar":            "foo_bar",
+		"foo\\bar":           "foo_bar",
+		"  spaced name  ":   "spaced name",
+		"":                   "download",
+	}
+	for in, want := range cases {
+		got := SafeFileName(in)
+		if got != want {
+			t.Fatalf("SafeFileName(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestUniquePath(t *testing.T) {
+	d := t.TempDir()
+	base := "ModelX - file.bin"
+	p1, err := UniquePath(d, base, "")
+	if err != nil { t.Fatal(err) }
+	if filepath.Base(p1) != base { t.Fatalf("got %s want %s", filepath.Base(p1), base) }
+	// create p1
+	if err := os.WriteFile(p1, []byte("x"), 0o644); err != nil { t.Fatal(err) }
+	// Next should try version hint
+	p2, err := UniquePath(d, base, "12")
+	if err != nil { t.Fatal(err) }
+	if filepath.Base(p2) != "ModelX - file (v12).bin" {
+		t.Fatalf("unexpected p2: %s", filepath.Base(p2))
+	}
+	// create p2
+	if err := os.WriteFile(p2, []byte("x"), 0o644); err != nil { t.Fatal(err) }
+	// Next should try numeric suffix
+	p3, err := UniquePath(d, base, "12")
+	if err != nil { t.Fatal(err) }
+	if filepath.Base(p3) != "ModelX - file (2).bin" {
+		t.Fatalf("unexpected p3: %s", filepath.Base(p3))
+	}
+}
+


### PR DESCRIPTION
- Resolver now returns model/version metadata and SuggestedFilename
- CivitAI resolver populates SuggestedFilename = <ModelName> - <OriginalFileName>
- CLI uses SuggestedFilename when --dest is omitted for civitai://
- Added util.SafeFileName and util.UniquePath (collision-safe)
- Updated docs and added unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - civitai:// downloads now auto-name files as "<ModelName> - <OriginalFileName>" when --dest is omitted, with collision-safe suffixes (v<versionId>, then (2), (3), …).
  - Applies to single and batch downloads; progress displays the computed destination.
  - Enhanced partial download handling: optionally store .part files alongside the final file or in a central partials directory, honoring configuration.
- Documentation
  - Updated README, BATCH.md, and RESOLVERS.md to describe default naming rules, collision policy, and batch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->