### PR TITLE
refactor tui Update into helpers

### DIFF
--- a/internal/tui/v2/model.go
+++ b/internal/tui/v2/model.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,7 +14,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-	neturl "net/url"
 
 	"github.com/charmbracelet/bubbles/progress"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -61,56 +61,79 @@ func defaultTheme() Theme {
 
 type tickMsg time.Time
 
-type dlDoneMsg struct{ url, dest, path string; err error }
+type dlDoneMsg struct {
+	url, dest, path string
+	err             error
+}
 
-type destSuggestMsg struct{ url string; dest string }
+type destSuggestMsg struct {
+	url  string
+	dest string
+}
 
-type metaMsg struct{ url string; fileName string; suggested string; civType string }
+type metaMsg struct {
+	url       string
+	fileName  string
+	suggested string
+	civType   string
+}
 
-type probeMsg struct{ url string; dest string; reachable bool; info string }
+type probeMsg struct {
+	url       string
+	dest      string
+	reachable bool
+	info      string
+}
 
-type obs struct{ bytes int64; t time.Time }
+type obs struct {
+	bytes int64
+	t     time.Time
+}
 
-type toast struct{ msg string; when time.Time; ttl time.Duration }
+type toast struct {
+	msg  string
+	when time.Time
+	ttl  time.Duration
+}
 
 type Model struct {
-	cfg   *config.Config
-	st    *state.DB
-	th    Theme
-	w,h   int
-	build string
-	activeTab int // 0: Pending, 1: Active, 2: Completed, 3: Failed
-	rows  []state.DownloadRow
-	selected int
-	filterOn bool
-	filterInput textinput.Model
-	sortMode string // ""|"speed"|"eta"
-	groupBy string  // ""|"host"
-	lastRefresh time.Time
-	prog  progress.Model
-	prev  map[string]obs
-	running map[string]context.CancelFunc
-	selectedKeys map[string]bool
-	toasts []toast
+	cfg             *config.Config
+	st              *state.DB
+	th              Theme
+	w, h            int
+	build           string
+	activeTab       int // 0: Pending, 1: Active, 2: Completed, 3: Failed
+	rows            []state.DownloadRow
+	selected        int
+	filterOn        bool
+	filterInput     textinput.Model
+	sortMode        string // ""|"speed"|"eta"
+	groupBy         string // ""|"host"
+	lastRefresh     time.Time
+	prog            progress.Model
+	prev            map[string]obs
+	running         map[string]context.CancelFunc
+	selectedKeys    map[string]bool
+	toasts          []toast
 	showToastDrawer bool
-	showHelp bool
-	showInspector bool
+	showHelp        bool
+	showInspector   bool
 	// New download modal state
-	newJob bool
-	newStep int
-	newInput textinput.Model
-	newURL string
-	newDest string
-	newType string
-	newAutoPlace bool
+	newJob           bool
+	newStep          int
+	newInput         textinput.Model
+	newURL           string
+	newDest          string
+	newType          string
+	newAutoPlace     bool
 	newAutoSuggested string // latest auto-suggested dest (to avoid overriding manual edits)
-	newTypeDetected string  // detected artifact type (from civitai or heuristics)
-	newTypeSource   string  // e.g., "civitai", "heuristic"
-	newDetectedName string  // suggested filename/name from resolver (for display)
+	newTypeDetected  string // detected artifact type (from civitai or heuristics)
+	newTypeSource    string // e.g., "civitai", "heuristic"
+	newDetectedName  string // suggested filename/name from resolver (for display)
 	// Extension suggestion when filename lacks suffix (e.g., .safetensors, .gguf)
 	newSuggestExt string
 	// Batch import modal state
-	batchMode bool
+	batchMode  bool
 	batchInput textinput.Model
 	// Overrides for auto-place by key url|dest
 	placeType map[string]string
@@ -122,11 +145,11 @@ type Model struct {
 
 	themeIndex int
 	columnMode string // dest|url|host
-	tickEvery time.Duration
+	tickEvery  time.Duration
 	// caches for performance
-	rateCache map[string]float64
-	etaCache  map[string]string
-	totalCache map[string]int64
+	rateCache     map[string]float64
+	etaCache      map[string]string
+	totalCache    map[string]int64
 	curBytesCache map[string]int64
 	// rate history for sparkline
 	rateHist map[string][]float64
@@ -134,11 +157,11 @@ type Model struct {
 	hostCache map[string]string
 	// transient retrying indicator per key
 	retrying map[string]time.Time
-	err   error
+	err      error
 	// token/env status
-	hfTokenSet bool
+	hfTokenSet  bool
 	civTokenSet bool
-	hfRejected bool
+	hfRejected  bool
 	civRejected bool
 }
 
@@ -152,28 +175,36 @@ type uiState struct {
 }
 
 func New(cfg *config.Config, st *state.DB, version string) tea.Model {
-p := progress.New(progress.WithDefaultGradient(), progress.WithWidth(16))
-	fi := textinput.New(); fi.Placeholder = "filter (url or dest contains)"; fi.CharLimit = 4096
+	p := progress.New(progress.WithDefaultGradient(), progress.WithWidth(16))
+	fi := textinput.New()
+	fi.Placeholder = "filter (url or dest contains)"
+	fi.CharLimit = 4096
 	// compute refresh
 	refresh := time.Second
 	if hz := cfg.UI.RefreshHz; hz > 0 {
-		if hz > 10 { hz = 10 }
+		if hz > 10 {
+			hz = 10
+		}
 		refresh = time.Second / time.Duration(hz)
 	}
-// decide initial column mode
+	// decide initial column mode
 	mode := strings.ToLower(strings.TrimSpace(cfg.UI.ColumnMode))
 	if mode != "dest" && mode != "url" && mode != "host" {
-		if cfg.UI.ShowURL { mode = "url" } else { mode = "dest" }
+		if cfg.UI.ShowURL {
+			mode = "url"
+		} else {
+			mode = "dest"
+		}
 	}
-m := &Model{
+	m := &Model{
 		cfg: cfg, st: st, th: defaultTheme(), activeTab: -1, prog: p, prev: map[string]obs{},
-		build: strings.TrimSpace(version),
+		build:   strings.TrimSpace(version),
 		running: map[string]context.CancelFunc{}, selectedKeys: map[string]bool{}, filterInput: fi,
 		rateCache: map[string]float64{}, etaCache: map[string]string{}, totalCache: map[string]int64{}, curBytesCache: map[string]int64{}, rateHist: map[string][]float64{}, hostCache: map[string]string{},
-		retrying: map[string]time.Time{},
-		tickEvery: refresh,
+		retrying:   map[string]time.Time{},
+		tickEvery:  refresh,
 		columnMode: mode,
-		placeType: map[string]string{}, autoPlace: map[string]bool{},
+		placeType:  map[string]string{}, autoPlace: map[string]bool{},
 	}
 	m.configTypes = computeTypesFromConfig(cfg)
 	// Load UI state overrides if present
@@ -182,7 +213,7 @@ m := &Model{
 }
 
 func (m *Model) Init() tea.Cmd {
-return tea.Tick(m.tickEvery, func(t time.Time) tea.Msg { return tickMsg(t) })
+	return tea.Tick(m.tickEvery, func(t time.Time) tea.Msg { return tickMsg(t) })
 }
 
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -190,256 +221,35 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.w, m.h = msg.Width, msg.Height
 		return m, nil
-case tea.KeyMsg:
-		s := msg.String()
-		// New job modal handling
+	case tea.KeyMsg:
 		if m.newJob {
-			switch s {
-			case "esc": m.newJob = false; return m, nil
-			case "tab":
-				// Path completion on Destination step
-				if m.newStep == 4 {
-					cur := strings.TrimSpace(m.newInput.Value())
-					comp := m.completePath(cur)
-					if strings.TrimSpace(comp) != "" { m.newInput.SetValue(comp); m.newAutoSuggested = comp }
-					return m, nil
-				}
-				return m, nil
-			case "x", "X":
-				// Accept suggested extension if available on Step 4
-				if m.newStep == 4 && strings.TrimSpace(m.newSuggestExt) != "" {
-					cur := strings.TrimSpace(m.newInput.Value())
-					if filepath.Ext(cur) == "" {
-						m.newInput.SetValue(cur + m.newSuggestExt)
-						m.newSuggestExt = ""
-					}
-				}
-				return m, nil
-			case "enter":
-				val := strings.TrimSpace(m.newInput.Value())
-				if m.newStep == 1 {
-					if val == "" { return m, nil }
-					m.newURL = val
-					// Show normalization note if applicable
-					if norm, ok := m.normalizeURLForNote(val); ok { m.newNormNote = norm } else { m.newNormNote = "" }
-					// Next: ask for artifact type
-					m.newInput.SetValue("")
-					m.newInput.Placeholder = "Artifact type (optional, e.g. sd.checkpoint)"
-					m.newStep = 2
-					// Resolve metadata in background (detect type, name)
-					return m, m.resolveMetaCmd(m.newURL)
-				} else if m.newStep == 2 {
-					// Got type; ask for autoplace
-					m.newType = val
-					m.newInput.SetValue("")
-					m.newInput.Placeholder = "Auto place after download? y/n (default n)"
-					m.newStep = 3
-					return m, nil
-				} else if m.newStep == 3 {
-					// Decide on destination suggestion based on autoplace choice
-					v := strings.ToLower(strings.TrimSpace(val))
-					m.newAutoPlace = v == "y" || v == "yes" || v == "true" || v == "1"
-					var cand string
-					if m.newAutoPlace {
-						cand = m.computePlacementSuggestionImmediate(m.newURL, m.newType)
-						// Background refine using resolver and placer targets
-						m.newAutoSuggested = cand
-						m.newInput.SetValue(cand)
-						m.newInput.Placeholder = "Destination path (Enter to accept)"
-						m.newStep = 4
-						// Suggest extension if missing
-						if filepath.Ext(cand) == "" { m.newSuggestExt = m.inferExt() } else { m.newSuggestExt = "" }
-						return m, m.suggestPlacementCmd(m.newURL, m.newType)
-					}
-					// No autoplace: suggest download_root path
-					cand = m.immediateDestCandidate(m.newURL)
-					m.newAutoSuggested = cand
-					m.newInput.SetValue(cand)
-					m.newInput.Placeholder = "Destination path (Enter to accept)"
-					m.newStep = 4
-					// Suggest extension if missing
-					if filepath.Ext(cand) == "" { m.newSuggestExt = m.inferExt() } else { m.newSuggestExt = "" }
-					return m, m.suggestDestCmd(m.newURL)
-				} else if m.newStep == 4 {
-					// Finalize destination and start download
-					urlStr := m.newURL
-					dest := strings.TrimSpace(val)
-					if dest == "" {
-						if m.newAutoPlace { dest = m.computePlacementSuggestionImmediate(urlStr, m.newType) } else { dest = m.computeDefaultDest(urlStr) }
-					}
-					// Preflight: ensure destination directory is writable
-					if err := m.preflightDest(dest); err != nil {
-						m.addToast("dest not writable: "+err.Error())
-						return m, nil
-					}
-					// Make the job visible immediately as pending before background download begins
-					_ = m.st.UpsertDownload(state.DownloadRow{URL: urlStr, Dest: dest, Status: "pending"})
-					cmd := m.startDownloadCmd(urlStr, dest)
-					key := urlStr+"|"+dest
-					if strings.TrimSpace(m.newType) != "" { m.placeType[key] = m.newType }
-					if m.newAutoPlace { m.autoPlace[key] = true }
-					m.addToast("started: "+truncateMiddle(dest, 40))
-					m.newJob = false
-					return m, cmd
-				}
-			}
-			var cmd tea.Cmd
-			m.newInput, cmd = m.newInput.Update(msg)
-			return m, cmd
+			return m.updateNewJob(msg)
 		}
-		// Batch modal handling
 		if m.batchMode {
-			switch s { case "esc": m.batchMode = false; return m, nil }
-			if s == "enter" {
-				path := strings.TrimSpace(m.batchInput.Value())
-				var cmd tea.Cmd
-				if path != "" { cmd = m.importBatchFile(path) }
-				m.batchMode = false
-				return m, cmd
-			}
-			var cmd tea.Cmd
-			m.batchInput, cmd = m.batchInput.Update(msg)
-			return m, cmd
+			return m.updateBatchMode(msg)
 		}
-		// If filter mode is on, handle input first (swallow other keys into the input)
 		if m.filterOn {
-			switch s {
-			case "enter": m.filterOn = false; m.filterInput.Blur(); return m, nil
-			case "esc": m.filterOn = false; m.filterInput.SetValue(""); m.filterInput.Blur(); return m, nil
-			}
-			var cmd tea.Cmd
-			m.filterInput, cmd = m.filterInput.Update(msg)
-			return m, cmd
+			return m.updateFilter(msg)
 		}
-		// Normal key handling
-		switch s {
-	case "q", "ctrl+c":
-			m.saveUIState()
-			return m, tea.Quit
-		case "/":
-			m.filterOn = true; m.filterInput.Focus(); return m, nil
-		case "n": // new download wizard
-			m.newJob = true; m.newStep = 1; m.newInput = textinput.New(); m.newInput.Placeholder = "Enter URL or resolver URI"; m.newInput.Focus(); return m, nil
-		case "b": // batch import from text file
-			m.batchMode = true; m.batchInput = textinput.New(); m.batchInput.Placeholder = "Path to text file with URLs"; m.batchInput.Focus(); return m, nil
-		case "s": m.sortMode = "speed"; return m, nil
-		case "e": m.sortMode = "eta"; return m, nil
-		case "o": m.sortMode = ""; return m, nil
-		case "g": if m.groupBy=="host" { m.groupBy = "" } else { m.groupBy = "host" }; return m, nil
-case "t": // cycle last column DEST->URL->HOST
-			switch m.columnMode {
-			case "dest": m.columnMode = "url"
-			case "url": m.columnMode = "host"
-			default: m.columnMode = "dest"
-			}
-			m.saveUIState(); return m, nil
-case "v": // compact view toggle
-			m.compactToggle(); m.saveUIState()
-			return m, nil
-case "T": // theme cycle presets
-			presets := themePresets()
-			m.themeIndex = (m.themeIndex + 1) % len(presets)
-			m.th = presets[m.themeIndex]
-			m.saveUIState()
-			return m, nil
-		case "H": // toggle toast drawer
-			m.showToastDrawer = !m.showToastDrawer
-			return m, nil
-		case "P": // re-probe reachability for selected/current without starting
-			rows := m.selectionOrCurrent()
-			if len(rows) == 0 { return m, nil }
-			return m, m.probeSelectedCmd(rows)
-		case "?":
-			m.showHelp = !m.showHelp
-			return m, nil
-		case "i": // toggle inspector panel
-			m.showInspector = !m.showInspector
-			return m, nil
-		case "0": m.activeTab = -1; m.selected = 0; return m, nil
-		case "1": m.activeTab = 0; m.selected = 0; return m, nil
-		case "2": m.activeTab = 1; m.selected = 0; return m, nil
-		case "3": m.activeTab = 2; m.selected = 0; return m, nil
-		case "4": m.activeTab = 3; m.selected = 0; return m, nil
-		case "j", "down": if m.selected < len(m.visibleRows())-1 { m.selected++ }; return m, nil
-		case "k", "up": if m.selected > 0 { m.selected-- }; return m, nil
-		case " ": // toggle selection
-			rows := m.visibleRows()
-			if m.selected >=0 && m.selected < len(rows) {
-				key := keyFor(rows[m.selected])
-				if m.selectedKeys[key] { delete(m.selectedKeys, key) } else { m.selectedKeys[key] = true }
-			}
-			return m, nil
-		case "A": // select all visible
-			for _, r := range m.visibleRows() { m.selectedKeys[keyFor(r)] = true }
-			return m, nil
-		case "X": // clear selection
-			m.selectedKeys = map[string]bool{}
-			return m, nil
-		case "r": // start selected (alias of retry)
-			fallthrough
-case "y": // retry (batch-aware)
-			targets := m.selectionOrCurrent()
-			if len(targets) == 0 { return m, nil }
-			cmds := make([]tea.Cmd, 0, len(targets))
-			now := time.Now()
-			for _, r := range targets {
-				ctx, cancel := context.WithCancel(context.Background())
-				m.running[keyFor(r)] = cancel
-				m.retrying[keyFor(r)] = now
-				cmds = append(cmds, m.startDownloadCmdCtx(ctx, r.URL, r.Dest))
-			}
-			m.addToast(fmt.Sprintf("retrying %d item(s)…", len(targets)))
-			return m, tea.Batch(cmds...)
-		case "p": // cancel (batch-aware)
-			cnt := 0
-			for _, r := range m.selectionOrCurrent() {
-				key := keyFor(r)
-				if cancel, ok := m.running[key]; ok { cancel(); delete(m.running, key); cnt++ }
-			}
-			if cnt > 0 { m.addToast(fmt.Sprintf("cancelled %d", cnt)) }
-			return m, nil
-		case "O": // open/reveal in file manager
-			rows := m.selectionOrCurrent()
-			if len(rows) > 0 {
-				_ = openInFileManager(rows[0].Dest, true)
-			}
-			return m, nil
-		case "C": // copy dest of current
-			rows := m.selectionOrCurrent()
-			if len(rows) > 0 { _ = copyToClipboard(rows[0].Dest) }
-			return m, nil
-		case "U": // copy URL of current
-			rows := m.selectionOrCurrent()
-			if len(rows) > 0 { _ = copyToClipboard(rows[0].URL) }
-			return m, nil
-		case "D": // delete selected rows from DB (even if planning)
-			rows := m.selectionOrCurrent()
-			if len(rows) == 0 { return m, nil }
-			deleted := 0
-			for _, r := range rows {
-				key := keyFor(r)
-				if cancel, ok := m.running[key]; ok { cancel(); delete(m.running, key) }
-				_ = m.st.DeleteChunks(r.URL, r.Dest)
-				if err := m.st.DeleteDownload(r.URL, r.Dest); err == nil { deleted++ }
-				delete(m.selectedKeys, key)
-			}
-			if deleted > 0 { m.addToast(fmt.Sprintf("deleted %d", deleted)) }
-			return m, m.refresh()
-		}
+		return m.updateNormal(msg)
 	case tickMsg:
 		return m, m.refresh()
-case destSuggestMsg:
+	case destSuggestMsg:
 		// Update the suggested dest only if the user hasn't edited it since our last suggestion
 		if m.newJob && m.newStep == 4 && strings.TrimSpace(m.newURL) == strings.TrimSpace(msg.url) {
 			if strings.TrimSpace(m.newInput.Value()) == strings.TrimSpace(m.newAutoSuggested) || strings.TrimSpace(m.newInput.Value()) == "" {
 				m.newInput.SetValue(msg.dest)
 				m.newAutoSuggested = msg.dest
 				// Recompute extension suggestion if missing extension
-				if filepath.Ext(msg.dest) == "" { m.newSuggestExt = m.inferExt() } else { m.newSuggestExt = "" }
+				if filepath.Ext(msg.dest) == "" {
+					m.newSuggestExt = m.inferExt()
+				} else {
+					m.newSuggestExt = ""
+				}
 			}
 		}
 		return m, nil
-case metaMsg:
+	case metaMsg:
 		if m.newJob && strings.TrimSpace(m.newURL) == strings.TrimSpace(msg.url) {
 			m.newDetectedName = msg.suggested
 			// Map civitai type to artifact type; fallback to heuristic from filename
@@ -448,20 +258,22 @@ case metaMsg:
 			m.newTypeSource = "civitai"
 			if m.newStep == 2 {
 				cur := strings.TrimSpace(m.newInput.Value())
-				if cur == "" { m.newInput.SetValue(t) }
+				if cur == "" {
+					m.newInput.SetValue(t)
+				}
 			}
 		}
 		return m, nil
-case probeMsg:
+	case probeMsg:
 		// Show toast for probe result; refresh table to reflect any hold updates
 		host := hostOf(msg.url)
 		if msg.reachable {
-			m.addToast("probe ok: "+host+" ("+msg.info+")")
+			m.addToast("probe ok: " + host + " (" + msg.info + ")")
 		} else {
-			m.addToast("probe failed: unreachable; on hold ("+msg.info+")")
+			m.addToast("probe failed: unreachable; on hold (" + msg.info + ")")
 		}
 		return m, m.refresh()
-case dlDoneMsg:
+	case dlDoneMsg:
 		if msg.err != nil {
 			m.err = msg.err
 			// Mark token rejection hints on known hosts based on error text
@@ -478,16 +290,373 @@ case dlDoneMsg:
 		}
 		// On success, clear any prior rejection for the host
 		u := strings.ToLower(msg.url)
-		if strings.HasPrefix(u, "hf://") || strings.Contains(u, "huggingface") { m.hfRejected = false }
-		if strings.HasPrefix(u, "civitai://") || strings.Contains(u, "civitai") { m.civRejected = false }
+		if strings.HasPrefix(u, "hf://") || strings.Contains(u, "huggingface") {
+			m.hfRejected = false
+		}
+		if strings.HasPrefix(u, "civitai://") || strings.Contains(u, "civitai") {
+			m.civRejected = false
+		}
 		// Auto place if configured
-		key := msg.url+"|"+msg.dest
+		key := msg.url + "|" + msg.dest
 		if m.autoPlace[key] {
 			atype := m.placeType[key]
-			if atype == "" { atype = "" }
+			if atype == "" {
+				atype = ""
+			}
 			placed, err := placer.Place(m.cfg, msg.path, atype, "")
-			if err != nil { m.addToast("place failed: "+err.Error()) } else if len(placed) > 0 { m.addToast("placed: "+truncateMiddle(placed[0], 40)) }
-			delete(m.autoPlace, key); delete(m.placeType, key)
+			if err != nil {
+				m.addToast("place failed: " + err.Error())
+			} else if len(placed) > 0 {
+				m.addToast("placed: " + truncateMiddle(placed[0], 40))
+			}
+			delete(m.autoPlace, key)
+			delete(m.placeType, key)
+		}
+		return m, m.refresh()
+	}
+	return m, nil
+}
+
+func (m *Model) updateNewJob(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	s := msg.String()
+	switch s {
+	case "esc":
+		m.newJob = false
+		return m, nil
+	case "tab":
+		if m.newStep == 4 {
+			cur := strings.TrimSpace(m.newInput.Value())
+			comp := m.completePath(cur)
+			if strings.TrimSpace(comp) != "" {
+				m.newInput.SetValue(comp)
+				m.newAutoSuggested = comp
+			}
+			return m, nil
+		}
+		return m, nil
+	case "x", "X":
+		if m.newStep == 4 && strings.TrimSpace(m.newSuggestExt) != "" {
+			cur := strings.TrimSpace(m.newInput.Value())
+			if filepath.Ext(cur) == "" {
+				m.newInput.SetValue(cur + m.newSuggestExt)
+				m.newSuggestExt = ""
+			}
+		}
+		return m, nil
+	case "enter":
+		val := strings.TrimSpace(m.newInput.Value())
+		if m.newStep == 1 {
+			if val == "" {
+				return m, nil
+			}
+			m.newURL = val
+			if norm, ok := m.normalizeURLForNote(val); ok {
+				m.newNormNote = norm
+			} else {
+				m.newNormNote = ""
+			}
+			m.newInput.SetValue("")
+			m.newInput.Placeholder = "Artifact type (optional, e.g. sd.checkpoint)"
+			m.newStep = 2
+			return m, m.resolveMetaCmd(m.newURL)
+		} else if m.newStep == 2 {
+			m.newType = val
+			m.newInput.SetValue("")
+			m.newInput.Placeholder = "Auto place after download? y/n (default n)"
+			m.newStep = 3
+			return m, nil
+		} else if m.newStep == 3 {
+			v := strings.ToLower(strings.TrimSpace(val))
+			m.newAutoPlace = v == "y" || v == "yes" || v == "true" || v == "1"
+			var cand string
+			if m.newAutoPlace {
+				cand = m.computePlacementSuggestionImmediate(m.newURL, m.newType)
+				m.newAutoSuggested = cand
+				m.newInput.SetValue(cand)
+				m.newInput.Placeholder = "Destination path (Enter to accept)"
+				m.newStep = 4
+				if filepath.Ext(cand) == "" {
+					m.newSuggestExt = m.inferExt()
+				} else {
+					m.newSuggestExt = ""
+				}
+				return m, m.suggestPlacementCmd(m.newURL, m.newType)
+			}
+			cand = m.immediateDestCandidate(m.newURL)
+			m.newAutoSuggested = cand
+			m.newInput.SetValue(cand)
+			m.newInput.Placeholder = "Destination path (Enter to accept)"
+			m.newStep = 4
+			if filepath.Ext(cand) == "" {
+				m.newSuggestExt = m.inferExt()
+			} else {
+				m.newSuggestExt = ""
+			}
+			return m, m.suggestDestCmd(m.newURL)
+		} else if m.newStep == 4 {
+			urlStr := m.newURL
+			dest := strings.TrimSpace(val)
+			if dest == "" {
+				if m.newAutoPlace {
+					dest = m.computePlacementSuggestionImmediate(urlStr, m.newType)
+				} else {
+					dest = m.computeDefaultDest(urlStr)
+				}
+			}
+			if err := m.preflightDest(dest); err != nil {
+				m.addToast("dest not writable: " + err.Error())
+				return m, nil
+			}
+			_ = m.st.UpsertDownload(state.DownloadRow{URL: urlStr, Dest: dest, Status: "pending"})
+			cmd := m.startDownloadCmd(urlStr, dest)
+			key := urlStr + "|" + dest
+			if strings.TrimSpace(m.newType) != "" {
+				m.placeType[key] = m.newType
+			}
+			if m.newAutoPlace {
+				m.autoPlace[key] = true
+			}
+			m.addToast("started: " + truncateMiddle(dest, 40))
+			m.newJob = false
+			return m, cmd
+		}
+	}
+	var cmd tea.Cmd
+	m.newInput, cmd = m.newInput.Update(msg)
+	return m, cmd
+}
+
+func (m *Model) updateBatchMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	s := msg.String()
+	switch s {
+	case "esc":
+		m.batchMode = false
+		return m, nil
+	case "enter":
+		path := strings.TrimSpace(m.batchInput.Value())
+		var cmd tea.Cmd
+		if path != "" {
+			cmd = m.importBatchFile(path)
+		}
+		m.batchMode = false
+		return m, cmd
+	}
+	var cmd tea.Cmd
+	m.batchInput, cmd = m.batchInput.Update(msg)
+	return m, cmd
+}
+
+func (m *Model) updateFilter(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	s := msg.String()
+	switch s {
+	case "enter":
+		m.filterOn = false
+		m.filterInput.Blur()
+		return m, nil
+	case "esc":
+		m.filterOn = false
+		m.filterInput.SetValue("")
+		m.filterInput.Blur()
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.filterInput, cmd = m.filterInput.Update(msg)
+	return m, cmd
+}
+
+func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	s := msg.String()
+	switch s {
+	case "q", "ctrl+c":
+		m.saveUIState()
+		return m, tea.Quit
+	case "/":
+		m.filterOn = true
+		m.filterInput.Focus()
+		return m, nil
+	case "n":
+		m.newJob = true
+		m.newStep = 1
+		m.newInput = textinput.New()
+		m.newInput.Placeholder = "Enter URL or resolver URI"
+		m.newInput.Focus()
+		return m, nil
+	case "b":
+		m.batchMode = true
+		m.batchInput = textinput.New()
+		m.batchInput.Placeholder = "Path to text file with URLs"
+		m.batchInput.Focus()
+		return m, nil
+	case "s":
+		m.sortMode = "speed"
+		return m, nil
+	case "e":
+		m.sortMode = "eta"
+		return m, nil
+	case "o":
+		m.sortMode = ""
+		return m, nil
+	case "g":
+		if m.groupBy == "host" {
+			m.groupBy = ""
+		} else {
+			m.groupBy = "host"
+		}
+		return m, nil
+	case "t":
+		switch m.columnMode {
+		case "dest":
+			m.columnMode = "url"
+		case "url":
+			m.columnMode = "host"
+		default:
+			m.columnMode = "dest"
+		}
+		m.saveUIState()
+		return m, nil
+	case "v":
+		m.compactToggle()
+		m.saveUIState()
+		return m, nil
+	case "T":
+		presets := themePresets()
+		m.themeIndex = (m.themeIndex + 1) % len(presets)
+		m.th = presets[m.themeIndex]
+		m.saveUIState()
+		return m, nil
+	case "H":
+		m.showToastDrawer = !m.showToastDrawer
+		return m, nil
+	case "P":
+		rows := m.selectionOrCurrent()
+		if len(rows) == 0 {
+			return m, nil
+		}
+		return m, m.probeSelectedCmd(rows)
+	case "?":
+		m.showHelp = !m.showHelp
+		return m, nil
+	case "i":
+		m.showInspector = !m.showInspector
+		return m, nil
+	case "0":
+		m.activeTab = -1
+		m.selected = 0
+		return m, nil
+	case "1":
+		m.activeTab = 0
+		m.selected = 0
+		return m, nil
+	case "2":
+		m.activeTab = 1
+		m.selected = 0
+		return m, nil
+	case "3":
+		m.activeTab = 2
+		m.selected = 0
+		return m, nil
+	case "4":
+		m.activeTab = 3
+		m.selected = 0
+		return m, nil
+	case "j", "down":
+		if m.selected < len(m.visibleRows())-1 {
+			m.selected++
+		}
+		return m, nil
+	case "k", "up":
+		if m.selected > 0 {
+			m.selected--
+		}
+		return m, nil
+	case " ":
+		rows := m.visibleRows()
+		if m.selected >= 0 && m.selected < len(rows) {
+			key := keyFor(rows[m.selected])
+			if m.selectedKeys[key] {
+				delete(m.selectedKeys, key)
+			} else {
+				m.selectedKeys[key] = true
+			}
+		}
+		return m, nil
+	case "A":
+		for _, r := range m.visibleRows() {
+			m.selectedKeys[keyFor(r)] = true
+		}
+		return m, nil
+	case "X":
+		m.selectedKeys = map[string]bool{}
+		return m, nil
+	case "r":
+		fallthrough
+	case "y":
+		targets := m.selectionOrCurrent()
+		if len(targets) == 0 {
+			return m, nil
+		}
+		cmds := make([]tea.Cmd, 0, len(targets))
+		now := time.Now()
+		for _, r := range targets {
+			ctx, cancel := context.WithCancel(context.Background())
+			m.running[keyFor(r)] = cancel
+			m.retrying[keyFor(r)] = now
+			cmds = append(cmds, m.startDownloadCmdCtx(ctx, r.URL, r.Dest))
+		}
+		m.addToast(fmt.Sprintf("retrying %d item(s)…", len(targets)))
+		return m, tea.Batch(cmds...)
+	case "p":
+		cnt := 0
+		for _, r := range m.selectionOrCurrent() {
+			key := keyFor(r)
+			if cancel, ok := m.running[key]; ok {
+				cancel()
+				delete(m.running, key)
+				cnt++
+			}
+		}
+		if cnt > 0 {
+			m.addToast(fmt.Sprintf("cancelled %d", cnt))
+		}
+		return m, nil
+	case "O":
+		rows := m.selectionOrCurrent()
+		if len(rows) > 0 {
+			_ = openInFileManager(rows[0].Dest, true)
+		}
+		return m, nil
+	case "C":
+		rows := m.selectionOrCurrent()
+		if len(rows) > 0 {
+			_ = copyToClipboard(rows[0].Dest)
+		}
+		return m, nil
+	case "U":
+		rows := m.selectionOrCurrent()
+		if len(rows) > 0 {
+			_ = copyToClipboard(rows[0].URL)
+		}
+		return m, nil
+	case "D":
+		rows := m.selectionOrCurrent()
+		if len(rows) == 0 {
+			return m, nil
+		}
+		deleted := 0
+		for _, r := range rows {
+			key := keyFor(r)
+			if cancel, ok := m.running[key]; ok {
+				cancel()
+				delete(m.running, key)
+			}
+			_ = m.st.DeleteChunks(r.URL, r.Dest)
+			if err := m.st.DeleteDownload(r.URL, r.Dest); err == nil {
+				deleted++
+			}
+			delete(m.selectedKeys, key)
+		}
+		if deleted > 0 {
+			m.addToast(fmt.Sprintf("deleted %d", deleted))
 		}
 		return m, m.refresh()
 	}
@@ -495,47 +664,73 @@ case dlDoneMsg:
 }
 
 func (m *Model) View() string {
-	if m.w == 0 { m.w = 120 }
-	if m.h == 0 { m.h = 30 }
+	if m.w == 0 {
+		m.w = 120
+	}
+	if m.h == 0 {
+		m.h = 30
+	}
 	// Title bar + inline toasts
 	ver := m.build
-	if ver == "" { ver = "dev" }
+	if ver == "" {
+		ver = "dev"
+	}
 	title := m.th.title.Render(fmt.Sprintf("modfetch • TUI v2 (build %s)", ver))
 	toastStr := m.renderToasts()
-	titleBar := m.th.border.Width(m.w-2).Render(lipgloss.JoinHorizontal(lipgloss.Top, title, "  ", toastStr))
+	titleBar := m.th.border.Width(m.w - 2).Render(lipgloss.JoinHorizontal(lipgloss.Top, title, "  ", toastStr))
 
 	// Horizontal tabs across full width
-	tabs := m.th.border.Width(m.w-2).Render(m.renderTabs())
+	tabs := m.th.border.Width(m.w - 2).Render(m.renderTabs())
 
 	// Commands bar for quick reference
-	commands := m.th.border.Width(m.w-2).Render(m.renderCommandsBar())
+	commands := m.th.border.Width(m.w - 2).Render(m.renderCommandsBar())
 
 	// Full-width table
-	table := m.th.border.Width(m.w-2).Render(m.renderTable())
+	table := m.th.border.Width(m.w - 2).Render(m.renderTable())
 
 	// Always-on inspector below the table showing highlighted job details
-	inspector := m.th.border.Width(m.w-2).Render(m.renderInspector())
+	inspector := m.th.border.Width(m.w - 2).Render(m.renderInspector())
 
 	// Optional overlays
 	drawer := ""
-	if m.showToastDrawer { drawer = m.th.border.Width(m.w-2).Render(m.renderToastDrawer()) }
+	if m.showToastDrawer {
+		drawer = m.th.border.Width(m.w - 2).Render(m.renderToastDrawer())
+	}
 	help := ""
-	if m.showHelp { help = m.th.border.Width(m.w-2).Render(m.renderHelp()) }
+	if m.showHelp {
+		help = m.th.border.Width(m.w - 2).Render(m.renderHelp())
+	}
 	modal := ""
-	if m.newJob { modal = m.th.border.Width(m.w-4).Render(m.renderNewJobModal()) }
-	if m.batchMode { modal = m.th.border.Width(m.w-4).Render(m.renderBatchModal()) }
+	if m.newJob {
+		modal = m.th.border.Width(m.w - 4).Render(m.renderNewJobModal())
+	}
+	if m.batchMode {
+		modal = m.th.border.Width(m.w - 4).Render(m.renderBatchModal())
+	}
 
 	// Minimal footer: show filter input only when active
 	filterBar := ""
-	if m.filterOn { filterBar = "Filter: "+ m.filterInput.View() }
+	if m.filterOn {
+		filterBar = "Filter: " + m.filterInput.View()
+	}
 	footer := ""
-	if strings.TrimSpace(filterBar) != "" { footer = m.th.border.Width(m.w-2).Render(m.th.footer.Render(filterBar)) }
+	if strings.TrimSpace(filterBar) != "" {
+		footer = m.th.border.Width(m.w - 2).Render(m.th.footer.Render(filterBar))
+	}
 
 	parts := []string{titleBar, tabs, commands, table, inspector}
-	if help != "" { parts = append(parts, help) }
-	if drawer != "" { parts = append(parts, drawer) }
-	if modal != "" { parts = append(parts, modal) }
-	if footer != "" { parts = append(parts, footer) }
+	if help != "" {
+		parts = append(parts, help)
+	}
+	if drawer != "" {
+		parts = append(parts, drawer)
+	}
+	if modal != "" {
+		parts = append(parts, modal)
+	}
+	if footer != "" {
+		parts = append(parts, footer)
+	}
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }
 
@@ -543,7 +738,9 @@ func (m *Model) refresh() tea.Cmd {
 	// Update token env presence status on each refresh tick
 	m.updateTokenEnvStatus()
 	rows, err := m.st.ListDownloads()
-	if err != nil { _ = logging.New("error", false) }
+	if err != nil {
+		_ = logging.New("error", false)
+	}
 	m.rows = rows
 	m.lastRefresh = time.Now()
 	m.gcToasts()
@@ -552,7 +749,9 @@ func (m *Model) refresh() tea.Cmd {
 	vr := m.visibleRows()
 	maxRows := m.maxRowsOnScreen()
 	for i, r := range vr {
-		if i >= maxRows { break }
+		if i >= maxRows {
+			break
+		}
 		vis[keyFor(r)] = struct{}{}
 	}
 	// recompute caches, prioritizing visible, running rows
@@ -577,7 +776,9 @@ func (m *Model) refresh() tea.Cmd {
 			prev := m.prev[key]
 			dt := time.Since(prev.t).Seconds()
 			var rate float64
-			if dt > 0 { rate = float64(cur - prev.bytes) / dt }
+			if dt > 0 {
+				rate = float64(cur-prev.bytes) / dt
+			}
 			m.prev[key] = obs{bytes: cur, t: time.Now()}
 			m.rateCache[key] = rate
 			if rate > 0 && total > 0 && cur < total {
@@ -585,7 +786,9 @@ func (m *Model) refresh() tea.Cmd {
 				m.etaCache[key] = fmt.Sprintf("%ds", int(rem+0.5))
 			} else {
 				// Keep last ETA instead of blanking; initialize to '-' if missing
-				if strings.TrimSpace(m.etaCache[key]) == "" { m.etaCache[key] = "-" }
+				if strings.TrimSpace(m.etaCache[key]) == "" {
+					m.etaCache[key] = "-"
+				}
 			}
 			m.addRateSample(key, rate)
 		}
@@ -599,10 +802,14 @@ func (m *Model) renderStats() string {
 	for _, r := range m.rows {
 		ls := strings.ToLower(r.Status)
 		switch ls {
-		case "pending","planning": pending++
-		case "running": active++
-		case "complete": done++
-		case "error","checksum_mismatch","verify_failed": failed++
+		case "pending", "planning":
+			pending++
+		case "running":
+			active++
+		case "complete":
+			done++
+		case "error", "checksum_mismatch", "verify_failed":
+			failed++
 		}
 		rate := m.rateCache[keyFor(r)]
 		gRate += rate
@@ -628,57 +835,69 @@ func (m *Model) renderTopLeftHints() string {
 
 func (m *Model) renderNewJobModal() string {
 	var sb strings.Builder
-	sb.WriteString(m.th.head.Render("New Download")+"\n")
+	sb.WriteString(m.th.head.Render("New Download") + "\n")
 	// Token status inline
-	sb.WriteString(m.th.label.Render(m.renderAuthStatus())+"\n\n")
+	sb.WriteString(m.th.label.Render(m.renderAuthStatus()) + "\n\n")
 	steps := []string{
 		"1) URL/URI",
 		"2) Artifact type (optional)",
 		"3) Auto place after download (y/n)",
 		"4) Destination path",
 	}
-	sb.WriteString(m.th.label.Render(strings.Join(steps, " • "))+"\n\n")
+	sb.WriteString(m.th.label.Render(strings.Join(steps, " • ")) + "\n\n")
 	// Step-specific helper text
 	switch m.newStep {
 	case 1:
-sb.WriteString(m.th.label.Render("Enter an HTTP URL or a resolver URI (hf://owner/repo/path?rev=..., civitai://model/ID?version=...).")+"\n")
+		sb.WriteString(m.th.label.Render("Enter an HTTP URL or a resolver URI (hf://owner/repo/path?rev=..., civitai://model/ID?version=...).") + "\n")
 	case 2:
 		// Show available types from config mapping
 		if len(m.configTypes) > 0 {
-sb.WriteString(m.th.label.Render("Types from your config: "+strings.Join(m.configTypes, ", "))+"\n")
+			sb.WriteString(m.th.label.Render("Types from your config: "+strings.Join(m.configTypes, ", ")) + "\n")
 		}
-sb.WriteString(m.th.label.Render("Type helps choose placement directories. Leave blank to skip placement or if unsure.")+"\n")
+		sb.WriteString(m.th.label.Render("Type helps choose placement directories. Leave blank to skip placement or if unsure.") + "\n")
 	case 3:
-sb.WriteString(m.th.label.Render("y: Place into mapped app directories after download • n: Save only to download_root.")+"\n")
+		sb.WriteString(m.th.label.Render("y: Place into mapped app directories after download • n: Save only to download_root.") + "\n")
 	case 4:
 		if m.newAutoPlace {
 			cand := strings.TrimSpace(m.newAutoSuggested)
-if cand != "" { sb.WriteString(m.th.label.Render("Will place into: "+cand)+"\n") }
-sb.WriteString(m.th.label.Render("Edit the destination to override.")+"\n")
+			if cand != "" {
+				sb.WriteString(m.th.label.Render("Will place into: "+cand) + "\n")
+			}
+			sb.WriteString(m.th.label.Render("Edit the destination to override.") + "\n")
 		} else {
-sb.WriteString(m.th.label.Render("Choose where to save the file. You can place later via 'place'.")+"\n")
+			sb.WriteString(m.th.label.Render("Choose where to save the file. You can place later via 'place'.") + "\n")
 		}
 		// If we can infer an extension and current input lacks one, suggest adding via X
 		curVal := strings.TrimSpace(m.newInput.Value())
 		if strings.TrimSpace(m.newSuggestExt) != "" && filepath.Ext(curVal) == "" {
-			sb.WriteString(m.th.label.Render("Suggestion: append "+m.newSuggestExt+" (press X)\n"))
+			sb.WriteString(m.th.label.Render("Suggestion: append " + m.newSuggestExt + " (press X)\n"))
 		}
 	}
 	cur := ""
-	if m.newStep == 1 { cur = "Enter URL or resolver URI" }
-	if m.newStep == 2 { cur = "Artifact type (optional)" }
-	if m.newStep == 3 { cur = "Auto place? y/n" }
-	if m.newStep == 4 { cur = "Destination path (Tab to complete)" }
-	sb.WriteString(m.th.label.Render(cur)+"\n")
+	if m.newStep == 1 {
+		cur = "Enter URL or resolver URI"
+	}
+	if m.newStep == 2 {
+		cur = "Artifact type (optional)"
+	}
+	if m.newStep == 3 {
+		cur = "Auto place? y/n"
+	}
+	if m.newStep == 4 {
+		cur = "Destination path (Tab to complete)"
+	}
+	sb.WriteString(m.th.label.Render(cur) + "\n")
 	// Show normalization note once URL entered
 	if m.newStep >= 2 && strings.TrimSpace(m.newNormNote) != "" {
-		sb.WriteString(m.th.label.Render(m.newNormNote)+"\n")
+		sb.WriteString(m.th.label.Render(m.newNormNote) + "\n")
 	}
 	// Show detected type/name if available when choosing type
 	if m.newStep == 2 && strings.TrimSpace(m.newTypeDetected) != "" {
 		from := m.newTypeSource
-		if from == "" { from = "heuristic" }
-		sb.WriteString(m.th.label.Render(fmt.Sprintf("Detected: %s (%s)", m.newTypeDetected, from))+"\n")
+		if from == "" {
+			from = "heuristic"
+		}
+		sb.WriteString(m.th.label.Render(fmt.Sprintf("Detected: %s (%s)", m.newTypeDetected, from)) + "\n")
 	}
 	sb.WriteString(m.newInput.View())
 	return sb.String()
@@ -686,8 +905,8 @@ sb.WriteString(m.th.label.Render("Choose where to save the file. You can place l
 
 func (m *Model) renderBatchModal() string {
 	var sb strings.Builder
-	sb.WriteString(m.th.head.Render("Batch Import")+"\n")
-	sb.WriteString(m.th.label.Render("Enter path to text file with one URL per line (tokens: dest=..., type=..., place=true, mode=copy|symlink|hardlink)" )+"\n\n")
+	sb.WriteString(m.th.head.Render("Batch Import") + "\n")
+	sb.WriteString(m.th.label.Render("Enter path to text file with one URL per line (tokens: dest=..., type=..., place=true, mode=copy|symlink|hardlink)") + "\n\n")
 	sb.WriteString(m.batchInput.View())
 	return sb.String()
 }
@@ -699,10 +918,14 @@ func (m *Model) renderTopRightStats() string {
 	for _, r := range m.rows {
 		ls := strings.ToLower(r.Status)
 		switch ls {
-		case "pending","planning": pending++
-		case "running": active++
-		case "complete": done++
-		case "error","checksum_mismatch","verify_failed": failed++
+		case "pending", "planning":
+			pending++
+		case "running":
+			active++
+		case "complete":
+			done++
+		case "error", "checksum_mismatch", "verify_failed":
+			failed++
 		}
 		gRate += m.rateCache[keyFor(r)]
 	}
@@ -719,7 +942,10 @@ func (m *Model) renderTopRightStats() string {
 }
 
 func (m *Model) renderTabs() string {
-	labels := []struct{ name string; tab int }{
+	labels := []struct {
+		name string
+		tab  int
+	}{
 		{"All", -1},
 		{"Pending", 0},
 		{"Active", 1},
@@ -729,11 +955,19 @@ func (m *Model) renderTabs() string {
 	var sb strings.Builder
 	for i, it := range labels {
 		style := m.th.tabInactive
-		if it.tab == m.activeTab { style = m.th.tabActive }
+		if it.tab == m.activeTab {
+			style = m.th.tabActive
+		}
 		count := 0
-		if it.tab == -1 { count = len(m.rows) } else { count = len(m.filterRows(it.tab)) }
+		if it.tab == -1 {
+			count = len(m.rows)
+		} else {
+			count = len(m.filterRows(it.tab))
+		}
 		sb.WriteString(style.Render(fmt.Sprintf("%s (%d)", it.name, count)))
-		if i < len(labels)-1 { sb.WriteString("  •  ") }
+		if i < len(labels)-1 {
+			sb.WriteString("  •  ")
+		}
 	}
 	return sb.String()
 }
@@ -748,13 +982,28 @@ func (m *Model) visibleRows() []state.DownloadRow {
 func (m *Model) filterRows(tab int) []state.DownloadRow {
 	var out []state.DownloadRow
 	for _, r := range m.rows {
-		if tab == -1 { out = append(out, r); continue }
+		if tab == -1 {
+			out = append(out, r)
+			continue
+		}
 		ls := strings.ToLower(r.Status)
 		switch tab {
-		case 0: if ls=="pending" || ls=="planning" || ls=="hold" { out = append(out, r) }
-		case 1: if ls=="running" { out = append(out, r) }
-		case 2: if ls=="complete" { out = append(out, r) }
-		case 3: if ls=="error" || ls=="checksum_mismatch" || ls=="verify_failed" { out = append(out, r) }
+		case 0:
+			if ls == "pending" || ls == "planning" || ls == "hold" {
+				out = append(out, r)
+			}
+		case 1:
+			if ls == "running" {
+				out = append(out, r)
+			}
+		case 2:
+			if ls == "complete" {
+				out = append(out, r)
+			}
+		case 3:
+			if ls == "error" || ls == "checksum_mismatch" || ls == "verify_failed" {
+				out = append(out, r)
+			}
 		}
 	}
 	return out
@@ -762,28 +1011,42 @@ func (m *Model) filterRows(tab int) []state.DownloadRow {
 
 func (m *Model) applySearch(in []state.DownloadRow) []state.DownloadRow {
 	q := strings.ToLower(strings.TrimSpace(m.filterInput.Value()))
-	if q == "" { return in }
+	if q == "" {
+		return in
+	}
 	var out []state.DownloadRow
 	for _, r := range in {
-		if strings.Contains(strings.ToLower(r.URL), q) || strings.Contains(strings.ToLower(r.Dest), q) { out = append(out, r) }
+		if strings.Contains(strings.ToLower(r.URL), q) || strings.Contains(strings.ToLower(r.Dest), q) {
+			out = append(out, r)
+		}
 	}
 	return out
 }
 
 func (m *Model) applySort(in []state.DownloadRow) []state.DownloadRow {
-	if m.sortMode == "" { return in }
-	out := make([]state.DownloadRow, len(in)); copy(out, in)
+	if m.sortMode == "" {
+		return in
+	}
+	out := make([]state.DownloadRow, len(in))
+	copy(out, in)
 	sort.SliceStable(out, func(i, j int) bool {
 		ci, ti, ri, _ := m.progressFor(out[i])
 		cj, tj, rj, _ := m.progressFor(out[j])
 		etaI := etaSeconds(ci, ti, ri)
 		etaJ := etaSeconds(cj, tj, rj)
 		switch m.sortMode {
-		case "speed": return ri > rj
+		case "speed":
+			return ri > rj
 		case "eta":
-			if etaI == 0 && etaJ == 0 { return ri > rj }
-			if etaI == 0 { return false }
-			if etaJ == 0 { return true }
+			if etaI == 0 && etaJ == 0 {
+				return ri > rj
+			}
+			if etaI == 0 {
+				return false
+			}
+			if etaJ == 0 {
+				return true
+			}
 			return etaI < etaJ
 		}
 		return false
@@ -792,7 +1055,9 @@ func (m *Model) applySort(in []state.DownloadRow) []state.DownloadRow {
 }
 
 func etaSeconds(cur, total int64, rate float64) float64 {
-	if rate <= 0 || total <= 0 || cur >= total { return 0 }
+	if rate <= 0 || total <= 0 || cur >= total {
+		return 0
+	}
 	return float64(total-cur) / rate
 }
 
@@ -800,21 +1065,27 @@ func (m *Model) renderTable() string {
 	rows := m.visibleRows()
 	var sb strings.Builder
 	lastLabel := "DEST"
-	if m.columnMode == "url" { lastLabel = "URL" } else if m.columnMode == "host" { lastLabel = "HOST" }
-if m.isCompact() {
+	if m.columnMode == "url" {
+		lastLabel = "URL"
+	} else if m.columnMode == "host" {
+		lastLabel = "HOST"
+	}
+	if m.isCompact() {
 		sb.WriteString(m.th.head.Render(fmt.Sprintf("%-1s %-8s %-3s  %-16s  %-4s  %-12s  %-8s  %-s", "S", "STATUS", "RT", "PROG", "PCT", "SRC", "ETA", lastLabel)))
 	} else {
 		sb.WriteString(m.th.head.Render(fmt.Sprintf("%-1s %-8s %-3s  %-16s  %-4s  %-10s  %-10s  %-12s  %-8s  %-s", "S", "STATUS", "RT", "PROG", "PCT", "SPEED", "THR", "SRC", "ETA", lastLabel)))
 	}
 	sb.WriteString("\n")
 	maxRows := m.h - 10
-	if maxRows < 3 { maxRows = len(rows) }
+	if maxRows < 3 {
+		maxRows = len(rows)
+	}
 	var prevGroup string
 	for i, r := range rows {
 		if m.groupBy == "host" {
 			host := hostOf(r.URL)
 			if i == 0 || host != prevGroup {
-				sb.WriteString(m.th.label.Render("// "+host)+"\n")
+				sb.WriteString(m.th.label.Render("// "+host) + "\n")
 				prevGroup = host
 			}
 		}
@@ -824,8 +1095,12 @@ if m.isCompact() {
 		pct := "--%"
 		if total > 0 {
 			ratio := float64(cur) / float64(total)
-			if ratio < 0 { ratio = 0 }
-			if ratio > 1 { ratio = 1 }
+			if ratio < 0 {
+				ratio = 0
+			}
+			if ratio > 1 {
+				ratio = 1
+			}
 			pct = fmt.Sprintf("%3.0f%%", ratio*100)
 		}
 		// For completed jobs, force 100%
@@ -834,7 +1109,10 @@ if m.isCompact() {
 		}
 		eta := m.etaCache[keyFor(r)]
 		thr := m.renderSparkline(keyFor(r))
-		sel := " "; if m.selectedKeys[keyFor(r)] { sel = "*" }
+		sel := " "
+		if m.selectedKeys[keyFor(r)] {
+			sel = "*"
+		}
 		// status label with transient retrying overlay
 		statusLabel := r.Status
 		if ts, ok := m.retrying[keyFor(r)]; ok {
@@ -845,7 +1123,11 @@ if m.isCompact() {
 			}
 		}
 		last := r.Dest
-		if m.columnMode == "url" { last = logging.SanitizeURL(r.URL) } else if m.columnMode == "host" { last = hostOf(r.URL) }
+		if m.columnMode == "url" {
+			last = logging.SanitizeURL(r.URL)
+		} else if m.columnMode == "host" {
+			last = hostOf(r.URL)
+		}
 		src := hostOf(r.URL)
 		src = truncateMiddle(src, 12)
 		lw := m.lastColumnWidth(m.isCompact())
@@ -865,22 +1147,30 @@ if m.isCompact() {
 			}
 		}
 		var line string
-if m.isCompact() {
+		if m.isCompact() {
 			line = fmt.Sprintf("%-1s %-8s %-3d  %-16s  %-4s  %-12s  %-8s  %s", sel, statusLabel, r.Retries, prog, pct, src, eta, last)
 		} else {
 			line = fmt.Sprintf("%-1s %-8s %-3d  %-16s  %-4s  %-10s  %-10s  %-12s  %-8s  %s", sel, statusLabel, r.Retries, prog, pct, speedStr, thr, src, eta, last)
 		}
-		if i == m.selected { line = m.th.rowSelected.Render(line) }
-		sb.WriteString(line+"\n")
-		if i+1 >= maxRows { break }
+		if i == m.selected {
+			line = m.th.rowSelected.Render(line)
+		}
+		sb.WriteString(line + "\n")
+		if i+1 >= maxRows {
+			break
+		}
 	}
-	if len(rows) == 0 { sb.WriteString(m.th.label.Render("(no items)")) }
+	if len(rows) == 0 {
+		sb.WriteString(m.th.label.Render("(no items)"))
+	}
 	return sb.String()
 }
 
 func (m *Model) renderInspector() string {
 	rows := m.visibleRows()
-	if m.selected < 0 || m.selected >= len(rows) { return m.th.label.Render("No selection") }
+	if m.selected < 0 || m.selected >= len(rows) {
+		return m.th.label.Render("No selection")
+	}
 	r := rows[m.selected]
 	var sb strings.Builder
 	sb.WriteString(m.th.head.Render("Details"))
@@ -905,7 +1195,11 @@ func (m *Model) renderInspector() string {
 	// Retries and status (with transient retrying overlay)
 	statusLabel := r.Status
 	if ts, ok := m.retrying[keyFor(r)]; ok {
-		if time.Since(ts) < 4*time.Second { statusLabel = "retrying" } else { delete(m.retrying, keyFor(r)) }
+		if time.Since(ts) < 4*time.Second {
+			statusLabel = "retrying"
+		} else {
+			delete(m.retrying, keyFor(r))
+		}
 	}
 	sb.WriteString(fmt.Sprintf("%s %d\n", m.th.label.Render("Retries:"), r.Retries))
 	sb.WriteString(fmt.Sprintf("%s %s\n", m.th.label.Render("Status:"), statusLabel))
@@ -931,13 +1225,17 @@ func (m *Model) renderInspector() string {
 	if strings.TrimSpace(r.ExpectedSHA256) != "" || strings.TrimSpace(r.ActualSHA256) != "" {
 		sb.WriteString(m.th.label.Render("SHA256:"))
 		sb.WriteString("\n")
-		if strings.TrimSpace(r.ExpectedSHA256) != "" { sb.WriteString(fmt.Sprintf("expected: %s\n", r.ExpectedSHA256)) }
-		if strings.TrimSpace(r.ActualSHA256) != "" { sb.WriteString(fmt.Sprintf("actual:   %s\n", r.ActualSHA256)) }
+		if strings.TrimSpace(r.ExpectedSHA256) != "" {
+			sb.WriteString(fmt.Sprintf("expected: %s\n", r.ExpectedSHA256))
+		}
+		if strings.TrimSpace(r.ActualSHA256) != "" {
+			sb.WriteString(fmt.Sprintf("actual:   %s\n", r.ActualSHA256))
+		}
 		if r.ExpectedSHA256 != "" && r.ActualSHA256 != "" {
 			if strings.EqualFold(strings.TrimSpace(r.ExpectedSHA256), strings.TrimSpace(r.ActualSHA256)) {
-				sb.WriteString(m.th.ok.Render("verified: OK")+"\n")
+				sb.WriteString(m.th.ok.Render("verified: OK") + "\n")
 			} else {
-				sb.WriteString(m.th.bad.Render("verified: MISMATCH")+"\n")
+				sb.WriteString(m.th.bad.Render("verified: MISMATCH") + "\n")
 			}
 		}
 	}
@@ -956,7 +1254,9 @@ func (m *Model) progressFor(r state.DownloadRow) (cur int64, total int64, rate f
 	rate = m.smoothedRate(key)
 	eta = m.etaCache[key]
 	// Fallback if cache not populated yet
-	if total == 0 && r.Size > 0 { total = r.Size }
+	if total == 0 && r.Size > 0 {
+		total = r.Size
+	}
 	return
 }
 
@@ -964,17 +1264,21 @@ func (m *Model) progressFor(r state.DownloadRow) (cur int64, total int64, rate f
 // falling back to the last instantaneous rate if no positive samples exist.
 func (m *Model) smoothedRate(key string) float64 {
 	h := m.rateHist[key]
-	if len(h) == 0 { return m.rateCache[key] }
+	if len(h) == 0 {
+		return m.rateCache[key]
+	}
 	sum := 0.0
 	count := 0
-	for i := len(h)-1; i >= 0 && count < 5; i-- {
+	for i := len(h) - 1; i >= 0 && count < 5; i-- {
 		v := h[i]
 		if v > 0 {
 			sum += v
 			count++
 		}
 	}
-	if count > 0 { return sum / float64(count) }
+	if count > 0 {
+		return sum / float64(count)
+	}
 	return m.rateCache[key]
 }
 
@@ -983,13 +1287,19 @@ func (m *Model) computeCurAndTotal(r state.DownloadRow) (cur int64, total int64)
 	chunks, _ := m.st.ListChunks(r.URL, r.Dest)
 	if len(chunks) > 0 {
 		for _, c := range chunks {
-			if strings.EqualFold(c.Status, "complete") { cur += c.Size }
+			if strings.EqualFold(c.Status, "complete") {
+				cur += c.Size
+			}
 		}
 		return cur, total
 	}
 	if r.Dest != "" {
 		p := downloader.StagePartPath(m.cfg, r.URL, r.Dest)
-		if st, err := os.Stat(p); err == nil { cur = st.Size() } else if st, err := os.Stat(r.Dest); err == nil { cur = st.Size() }
+		if st, err := os.Stat(p); err == nil {
+			cur = st.Size()
+		} else if st, err := os.Stat(r.Dest); err == nil {
+			cur = st.Size()
+		}
 	}
 	return cur, total
 }
@@ -1000,37 +1310,60 @@ func (m *Model) renderProgress(r state.DownloadRow) string {
 		return m.prog.ViewAs(1)
 	}
 	cur, total, _, _ := m.progressFor(r)
-	if total <= 0 { return "--" }
+	if total <= 0 {
+		return "--"
+	}
 	ratio := float64(cur) / float64(total)
-	if ratio < 0 { ratio = 0 }
-	if ratio > 1 { ratio = 1 }
+	if ratio < 0 {
+		ratio = 0
+	}
+	if ratio > 1 {
+		ratio = 1
+	}
 	return m.prog.ViewAs(ratio)
 }
 
 func (m *Model) addRateSample(key string, rate float64) {
 	h := m.rateHist[key]
 	h = append(h, rate)
-	if len(h) > 10 { h = h[len(h)-10:] }
+	if len(h) > 10 {
+		h = h[len(h)-10:]
+	}
 	m.rateHist[key] = h
 }
 
 func (m *Model) renderSparklineKey(key string) string {
 	h := m.rateHist[key]
-	if len(h) == 0 { return "" }
+	if len(h) == 0 {
+		return ""
+	}
 	// map rates to 8 levels; normalize by max
 	max := 0.0
-	for _, v := range h { if v > max { max = v } }
-	if max <= 0 { return "──────────" }
-	levels := []rune{'▁','▂','▃','▄','▅','▆','▇','█'}
+	for _, v := range h {
+		if v > max {
+			max = v
+		}
+	}
+	if max <= 0 {
+		return "──────────"
+	}
+	levels := []rune{'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}
 	var sb strings.Builder
 	// Oldest on the left, newest on the right (rightward growth)
 	for _, v := range h {
 		r := int((v/max)*float64(len(levels)-1) + 0.5)
-		if r < 0 { r = 0 }; if r >= len(levels) { r = len(levels)-1 }
+		if r < 0 {
+			r = 0
+		}
+		if r >= len(levels) {
+			r = len(levels) - 1
+		}
 		sb.WriteRune(levels[r])
 	}
 	// pad to 10
-	for sb.Len() < 10 { sb.WriteRune(' ') }
+	for sb.Len() < 10 {
+		sb.WriteRune(' ')
+	}
 	return sb.String()
 }
 
@@ -1039,16 +1372,22 @@ func (m *Model) renderSparkline(key string) string { return m.renderSparklineKey
 // Preflight: ensure destination's parent is writable
 func (m *Model) preflightDest(dest string) error {
 	d := strings.TrimSpace(dest)
-	if d == "" { return fmt.Errorf("empty dest") }
+	if d == "" {
+		return fmt.Errorf("empty dest")
+	}
 	dir := filepath.Dir(d)
-	if err := os.MkdirAll(dir, 0o755); err != nil { return err }
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
 	return tryWrite(dir)
 }
 
 // Path completion for destination
 func (m *Model) completePath(input string) string {
 	s := strings.TrimSpace(input)
-	if s == "" { return s }
+	if s == "" {
+		return s
+	}
 	// Expand ~ and env for lookup
 	h, _ := os.UserHomeDir()
 	exp := os.ExpandEnv(s)
@@ -1064,16 +1403,22 @@ func (m *Model) completePath(input string) string {
 		prefix = filepath.Base(exp)
 	}
 	ents, err := os.ReadDir(dir)
-	if err != nil { return s }
+	if err != nil {
+		return s
+	}
 	matches := make([]string, 0, len(ents))
 	for _, e := range ents {
 		name := e.Name()
 		if strings.HasPrefix(strings.ToLower(name), strings.ToLower(prefix)) {
-			if e.IsDir() { name += "/" }
+			if e.IsDir() {
+				name += "/"
+			}
 			matches = append(matches, name)
 		}
 	}
-	if len(matches) == 0 { return s }
+	if len(matches) == 0 {
+		return s
+	}
 	// If single match, replace basename
 	base := prefix
 	if len(matches) == 1 {
@@ -1091,11 +1436,15 @@ func (m *Model) completePath(input string) string {
 }
 
 func longestCommonPrefix(ss []string) string {
-	if len(ss) == 0 { return "" }
+	if len(ss) == 0 {
+		return ""
+	}
 	p := ss[0]
 	for _, s := range ss[1:] {
 		for !strings.HasPrefix(strings.ToLower(s), strings.ToLower(p)) {
-			if len(p) == 0 { return "" }
+			if len(p) == 0 {
+				return ""
+			}
 			p = p[:len(p)-1]
 		}
 	}
@@ -1104,20 +1453,28 @@ func longestCommonPrefix(ss []string) string {
 
 func tryWrite(dir string) error {
 	f, err := os.CreateTemp(dir, ".mf-wr-*")
-	if err != nil { return err }
-	name := f.Name(); _ = f.Close(); _ = os.Remove(name)
+	if err != nil {
+		return err
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
 	return nil
 }
 
 // Immediate (non-blocking) dest candidate based on URL only
 func (m *Model) immediateDestCandidate(urlStr string) string {
 	s := strings.TrimSpace(urlStr)
-	if s == "" { return filepath.Join(m.cfg.General.DownloadRoot, "download") }
+	if s == "" {
+		return filepath.Join(m.cfg.General.DownloadRoot, "download")
+	}
 	// If it's a resolver URI, guess based on path base
 	if strings.HasPrefix(s, "hf://") || strings.HasPrefix(s, "civitai://") {
 		if u, err := neturl.Parse(s); err == nil {
 			base := filepath.Base(strings.Trim(u.Path, "/"))
-			if base == "" { base = "download" }
+			if base == "" {
+				base = "download"
+			}
 			return filepath.Join(m.cfg.General.DownloadRoot, utilSafe(base))
 		}
 	}
@@ -1129,7 +1486,9 @@ func (m *Model) immediateDestCandidate(urlStr string) string {
 			if len(parts) >= 1 {
 				if len(parts) >= 5 && parts[2] == "blob" {
 					base := filepath.Base(strings.Join(parts[4:], "/"))
-					if base != "" { return filepath.Join(m.cfg.General.DownloadRoot, utilSafe(base)) }
+					if base != "" {
+						return filepath.Join(m.cfg.General.DownloadRoot, utilSafe(base))
+					}
 				}
 				return filepath.Join(m.cfg.General.DownloadRoot, utilSafe(filepath.Base(u.Path)))
 			}
@@ -1139,17 +1498,23 @@ func (m *Model) immediateDestCandidate(urlStr string) string {
 			parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 			if len(parts) >= 2 {
 				id := parts[1]
-				if id != "" { return filepath.Join(m.cfg.General.DownloadRoot, utilSafe(id)) }
+				if id != "" {
+					return filepath.Join(m.cfg.General.DownloadRoot, utilSafe(id))
+				}
 			}
 		}
 		// Fallback to path base
 		base := filepath.Base(s)
-		if base == "" || base == "/" || base == "." { base = "download" }
+		if base == "" || base == "/" || base == "." {
+			base = "download"
+		}
 		return filepath.Join(m.cfg.General.DownloadRoot, utilSafe(base))
 	}
 	// raw fallback
 	base := filepath.Base(s)
-	if base == "" || base == "/" || base == "." { base = "download" }
+	if base == "" || base == "/" || base == "." {
+		base = "download"
+	}
 	return filepath.Join(m.cfg.General.DownloadRoot, utilSafe(base))
 }
 
@@ -1177,35 +1542,49 @@ func (m *Model) suggestDestCmd(urlStr string) tea.Cmd {
 func (m *Model) headFilename(u string) string {
 	ctx := context.Background()
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, u, nil)
-	if err != nil { return "" }
+	if err != nil {
+		return ""
+	}
 	// Add CivitAI token if configured
 	if m.cfg != nil && m.cfg.Sources.CivitAI.Enabled {
 		env := strings.TrimSpace(m.cfg.Sources.CivitAI.TokenEnv)
-		if env == "" { env = "CIVITAI_TOKEN" }
+		if env == "" {
+			env = "CIVITAI_TOKEN"
+		}
 		if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
 			req.Header.Set("Authorization", "Bearer "+tok)
 		}
 	}
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
-	if err != nil { return "" }
+	if err != nil {
+		return ""
+	}
 	defer resp.Body.Close()
 	cd := resp.Header.Get("Content-Disposition")
-	if cd == "" { return "" }
+	if cd == "" {
+		return ""
+	}
 	lcd := strings.ToLower(cd)
 	// RFC 5987 filename*
 	if idx := strings.Index(lcd, "filename*="); idx >= 0 {
 		v := cd[idx+len("filename*="):]
 		// expect UTF-8''... optionally
-		if strings.HasPrefix(strings.ToLower(v), "utf-8''") { v = v[len("utf-8''"):] }
-		if semi := strings.IndexByte(v, ';'); semi >= 0 { v = v[:semi] }
+		if strings.HasPrefix(strings.ToLower(v), "utf-8''") {
+			v = v[len("utf-8''"):]
+		}
+		if semi := strings.IndexByte(v, ';'); semi >= 0 {
+			v = v[:semi]
+		}
 		name, _ := neturl.QueryUnescape(strings.Trim(v, "\"' "))
 		return name
 	}
 	// Simple filename=
 	if idx := strings.Index(lcd, "filename="); idx >= 0 {
 		v := cd[idx+len("filename="):]
-		if semi := strings.IndexByte(v, ';'); semi >= 0 { v = v[:semi] }
+		if semi := strings.IndexByte(v, ';'); semi >= 0 {
+			v = v[:semi]
+		}
 		name := strings.Trim(v, "\"' ")
 		return name
 	}
@@ -1215,18 +1594,26 @@ func (m *Model) headFilename(u string) string {
 // Immediate placement suggestion using artifact type and quick filename
 func (m *Model) computePlacementSuggestionImmediate(urlStr, atype string) string {
 	atype = strings.TrimSpace(atype)
-	if atype == "" { return m.immediateDestCandidate(urlStr) }
+	if atype == "" {
+		return m.immediateDestCandidate(urlStr)
+	}
 	dirs, err := placer.ComputeTargets(m.cfg, atype)
-	if err != nil || len(dirs) == 0 { return m.immediateDestCandidate(urlStr) }
+	if err != nil || len(dirs) == 0 {
+		return m.immediateDestCandidate(urlStr)
+	}
 	base := filepath.Base(m.immediateDestCandidate(urlStr))
-	if strings.TrimSpace(base) == "" { base = "download" }
-return filepath.Join(dirs[0], utilSafe(base))
+	if strings.TrimSpace(base) == "" {
+		base = "download"
+	}
+	return filepath.Join(dirs[0], utilSafe(base))
 }
 
 func (m *Model) inferExt() string {
 	// Prefer explicit user-provided type
 	t := strings.TrimSpace(m.newType)
-	if t == "" { t = strings.TrimSpace(m.newTypeDetected) }
+	if t == "" {
+		t = strings.TrimSpace(m.newTypeDetected)
+	}
 	switch strings.ToLower(t) {
 	case "sd.checkpoint", "sd.lora", "sd.vae", "sd.controlnet":
 		return ".safetensors"
@@ -1255,8 +1642,12 @@ func mapCivitFileType(civType, fileName string) string {
 	if strings.Contains(name, "control") || strings.Contains(name, "controlnet") {
 		return "sd.controlnet"
 	}
-	if strings.HasSuffix(name, ".gguf") { return "llm.gguf" }
-	if strings.HasSuffix(name, ".safetensors") { return "sd.checkpoint" }
+	if strings.HasSuffix(name, ".gguf") {
+		return "llm.gguf"
+	}
+	if strings.HasSuffix(name, ".safetensors") {
+		return "sd.checkpoint"
+	}
 	return "generic"
 }
 
@@ -1264,13 +1655,19 @@ func mapCivitFileType(civType, fileName string) string {
 func (m *Model) suggestPlacementCmd(urlStr, atype string) tea.Cmd {
 	return func() tea.Msg {
 		atype = strings.TrimSpace(atype)
-		if atype == "" { return destSuggestMsg{url: urlStr, dest: m.computeDefaultDest(urlStr)} }
+		if atype == "" {
+			return destSuggestMsg{url: urlStr, dest: m.computeDefaultDest(urlStr)}
+		}
 		dirs, err := placer.ComputeTargets(m.cfg, atype)
-		if err != nil || len(dirs) == 0 { return destSuggestMsg{url: urlStr, dest: m.computeDefaultDest(urlStr)} }
+		if err != nil || len(dirs) == 0 {
+			return destSuggestMsg{url: urlStr, dest: m.computeDefaultDest(urlStr)}
+		}
 		// Derive a good filename via resolver-backed default dest
 		cand := m.computeDefaultDest(urlStr)
 		base := filepath.Base(cand)
-		if strings.TrimSpace(base) == "" { base = "download" }
+		if strings.TrimSpace(base) == "" {
+			base = "download"
+		}
 		d := filepath.Join(dirs[0], utilSafe(base))
 		return destSuggestMsg{url: urlStr, dest: d}
 	}
@@ -1280,7 +1677,9 @@ func (m *Model) suggestPlacementCmd(urlStr, atype string) tea.Cmd {
 func (m *Model) resolveMetaCmd(raw string) tea.Cmd {
 	return func() tea.Msg {
 		s := strings.TrimSpace(raw)
-		if s == "" { return metaMsg{url: raw} }
+		if s == "" {
+			return metaMsg{url: raw}
+		}
 		// Normalize civitai page URLs to civitai://
 		if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
 			if u, err := neturl.Parse(s); err == nil {
@@ -1289,9 +1688,15 @@ func (m *Model) resolveMetaCmd(raw string) tea.Cmd {
 					parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 					if len(parts) >= 2 {
 						modelID := parts[1]
-						q := u.Query(); ver := q.Get("modelVersionId"); if ver == "" { ver = q.Get("version") }
+						q := u.Query()
+						ver := q.Get("modelVersionId")
+						if ver == "" {
+							ver = q.Get("version")
+						}
 						civ := "civitai://model/" + modelID
-						if strings.TrimSpace(ver) != "" { civ += "?version=" + neturl.QueryEscape(ver) }
+						if strings.TrimSpace(ver) != "" {
+							civ += "?version=" + neturl.QueryEscape(ver)
+						}
 						s = civ
 					}
 				}
@@ -1311,7 +1716,9 @@ func computeTypesFromConfig(cfg *config.Config) []string {
 	var out []string
 	for _, r := range cfg.Placement.Mapping {
 		t := strings.TrimSpace(r.Match)
-		if t == "" { continue }
+		if t == "" {
+			continue
+		}
 		if !seen[t] {
 			seen[t] = true
 			out = append(out, t)
@@ -1322,10 +1729,16 @@ func computeTypesFromConfig(cfg *config.Config) []string {
 }
 
 func truncateMiddle(s string, max int) string {
-	if max <= 0 { return "" }
+	if max <= 0 {
+		return ""
+	}
 	runes := []rune(s)
-	if len(runes) <= max { return s }
-	if max <= 1 { return string(runes[:max]) }
+	if len(runes) <= max {
+		return s
+	}
+	if max <= 1 {
+		return string(runes[:max])
+	}
 	left := max / 2
 	right := max - left - 1
 	return string(runes[:left]) + "…" + string(runes[len(runes)-right:])
@@ -1334,28 +1747,36 @@ func truncateMiddle(s string, max int) string {
 func (m *Model) lastColumnWidth(compact bool) int {
 	// Without side panels, use nearly full width minus borders
 	usable := m.w - 2*2 // borders on left/right wrappers
-	if usable < 40 { usable = 40 }
+	if usable < 40 {
+		usable = 40
+	}
 	if compact {
 		// S(1), space(1), STATUS(8), space(1), RT(3), 2sp, PROG(16), 2sp, PCT(4), 2sp, SRC(12), 2sp, ETA(8), 2sp
 		consumed := 1 + 1 + 8 + 1 + 3 + 2 + 16 + 2 + 4 + 2 + 12 + 2 + 8 + 2
 		lw := usable - consumed
-		if lw < 10 { lw = 10 }
+		if lw < 10 {
+			lw = 10
+		}
 		return lw
 	}
 	// non-compact consumed widths: + SPEED(10) + THR(10) before SRC
 	consumed := 1 + 1 + 8 + 1 + 3 + 2 + 16 + 2 + 4 + 2 + 10 + 2 + 10 + 2 + 12 + 2 + 8 + 2
 	lw := usable - consumed
-	if lw < 10 { lw = 10 }
+	if lw < 10 {
+		lw = 10
+	}
 	return lw
 }
 
 func (m *Model) maxRowsOnScreen() int {
 	max := m.h - 10
-	if max < 3 { return 3 }
+	if max < 3 {
+		return 3
+	}
 	return max
 }
 
-func keyFor(r state.DownloadRow) string { return r.URL+"|"+r.Dest }
+func keyFor(r state.DownloadRow) string { return r.URL + "|" + r.Dest }
 
 func hostOf(urlStr string) string {
 	if u, err := neturl.Parse(urlStr); err == nil {
@@ -1367,16 +1788,22 @@ func hostOf(urlStr string) string {
 func (m *Model) selectionOrCurrent() []state.DownloadRow {
 	rows := m.visibleRows()
 	if len(m.selectedKeys) == 0 {
-		if m.selected >= 0 && m.selected < len(rows) { return []state.DownloadRow{ rows[m.selected] } }
+		if m.selected >= 0 && m.selected < len(rows) {
+			return []state.DownloadRow{rows[m.selected]}
+		}
 		return nil
 	}
 	var out []state.DownloadRow
-	for _, r := range rows { if m.selectedKeys[keyFor(r)] { out = append(out, r) } }
+	for _, r := range rows {
+		if m.selectedKeys[keyFor(r)] {
+			out = append(out, r)
+		}
+	}
 	return out
 }
 
 func (m *Model) addToast(s string) {
-	m.toasts = append(m.toasts, toast{msg: s, when: time.Now(), ttl: 3*time.Second})
+	m.toasts = append(m.toasts, toast{msg: s, when: time.Now(), ttl: 3 * time.Second})
 	if len(m.toasts) > 50 {
 		// keep last 50
 		m.toasts = m.toasts[len(m.toasts)-50:]
@@ -1386,18 +1813,26 @@ func (m *Model) addToast(s string) {
 func (m *Model) gcToasts() {
 	now := time.Now()
 	var keep []toast
-	for _, t := range m.toasts { if now.Sub(t.when) < t.ttl { keep = append(keep, t) } }
+	for _, t := range m.toasts {
+		if now.Sub(t.when) < t.ttl {
+			keep = append(keep, t)
+		}
+	}
 	m.toasts = keep
 }
 
 func (m *Model) renderToasts() string {
-	if len(m.toasts) == 0 { return "" }
+	if len(m.toasts) == 0 {
+		return ""
+	}
 	parts := make([]string, 0, len(m.toasts))
-	for _, t := range m.toasts { parts = append(parts, t.msg) }
+	for _, t := range m.toasts {
+		parts = append(parts, t.msg)
+	}
 	return m.th.label.Render(strings.Join(parts, " • "))
 }
 
-func (m *Model) compactToggle() { m.cfg.UI.Compact = !m.cfg.UI.Compact }
+func (m *Model) compactToggle()  { m.cfg.UI.Compact = !m.cfg.UI.Compact }
 func (m *Model) isCompact() bool { return m.cfg.UI.Compact }
 
 func (m *Model) uiStatePath() string {
@@ -1413,23 +1848,39 @@ func (m *Model) uiStatePath() string {
 func (m *Model) loadUIState() {
 	p := m.uiStatePath()
 	b, err := os.ReadFile(p)
-	if err != nil { return }
+	if err != nil {
+		return
+	}
 	var st uiState
-	if err := json.Unmarshal(b, &st); err != nil { return }
+	if err := json.Unmarshal(b, &st); err != nil {
+		return
+	}
 	// Apply
 	m.themeIndex = st.ThemeIndex
 	presets := themePresets()
-	if m.themeIndex >= 0 && m.themeIndex < len(presets) { m.th = presets[m.themeIndex] }
-if st.ColumnMode != "" { m.columnMode = st.ColumnMode } else if st.ShowURL { m.columnMode = "url" }
-	if st.Compact { m.cfg.UI.Compact = true }
-	if st.GroupBy != "" { m.groupBy = st.GroupBy }
-	if st.SortMode != "" { m.sortMode = st.SortMode }
+	if m.themeIndex >= 0 && m.themeIndex < len(presets) {
+		m.th = presets[m.themeIndex]
+	}
+	if st.ColumnMode != "" {
+		m.columnMode = st.ColumnMode
+	} else if st.ShowURL {
+		m.columnMode = "url"
+	}
+	if st.Compact {
+		m.cfg.UI.Compact = true
+	}
+	if st.GroupBy != "" {
+		m.groupBy = st.GroupBy
+	}
+	if st.SortMode != "" {
+		m.sortMode = st.SortMode
+	}
 }
 
 func (m *Model) saveUIState() {
 	p := m.uiStatePath()
 	_ = os.MkdirAll(filepath.Dir(p), 0o755)
-st := uiState{ThemeIndex: m.themeIndex, ShowURL: m.columnMode == "url", ColumnMode: m.columnMode, Compact: m.cfg.UI.Compact, GroupBy: m.groupBy, SortMode: m.sortMode}
+	st := uiState{ThemeIndex: m.themeIndex, ShowURL: m.columnMode == "url", ColumnMode: m.columnMode, Compact: m.cfg.UI.Compact, GroupBy: m.groupBy, SortMode: m.sortMode}
 	b, _ := json.MarshalIndent(st, "", "  ")
 	_ = os.WriteFile(p, b, 0o644)
 }
@@ -1441,7 +1892,7 @@ func (m *Model) renderCommandsBar() string {
 
 func (m *Model) renderHelp() string {
 	var sb strings.Builder
-	sb.WriteString(m.th.head.Render("Help (TUI v2)")+"\n")
+	sb.WriteString(m.th.head.Render("Help (TUI v2)") + "\n")
 	sb.WriteString("Tabs: 1 Pending • 2 Active • 3 Completed • 4 Failed\n")
 	sb.WriteString("Nav: j/k up/down\n")
 	sb.WriteString("Filter: / to enter; Enter to apply; Esc to clear\n")
@@ -1451,17 +1902,19 @@ func (m *Model) renderHelp() string {
 	sb.WriteString("Toasts: H toggle drawer\n")
 	sb.WriteString("Select: Space toggle • A select all • X clear selection\n")
 	sb.WriteString("Probe: P re-probe reachability of selected/current (does not start download)\n")
-sb.WriteString("Columns: t cycle URL/DEST/HOST • v compact view\n")
+	sb.WriteString("Columns: t cycle URL/DEST/HOST • v compact view\n")
 	sb.WriteString("Actions: y/r start • p cancel • D delete • O open • C copy path • U copy URL\n")
 	sb.WriteString("Quit: q\n")
 	return sb.String()
 }
 
 func (m *Model) renderToastDrawer() string {
-	if len(m.toasts) == 0 { return m.th.label.Render("(no recent notifications)") }
+	if len(m.toasts) == 0 {
+		return m.th.label.Render("(no recent notifications)")
+	}
 	now := time.Now()
 	var sb strings.Builder
-	for i := len(m.toasts)-1; i >= 0; i-- { // newest first
+	for i := len(m.toasts) - 1; i >= 0; i-- { // newest first
 		t := m.toasts[i]
 		dur := now.Sub(t.when).Round(time.Second)
 		sb.WriteString(fmt.Sprintf("%s  %s\n", t.msg, m.th.label.Render(dur.String()+" ago")))
@@ -1472,24 +1925,37 @@ func (m *Model) renderToastDrawer() string {
 // URL normalization helper (for modal note only)
 func (m *Model) normalizeURLForNote(raw string) (string, bool) {
 	s := strings.TrimSpace(raw)
-	if !(strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")) { return "", false }
+	if !(strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")) {
+		return "", false
+	}
 	u, err := neturl.Parse(s)
-	if err != nil { return "", false }
+	if err != nil {
+		return "", false
+	}
 	h := strings.ToLower(u.Hostname())
 	if hostIs(h, "civitai.com") && strings.HasPrefix(u.Path, "/models/") {
 		parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 		if len(parts) >= 2 {
 			modelID := parts[1]
-			q := u.Query(); ver := q.Get("modelVersionId"); if ver == "" { ver = q.Get("version") }
+			q := u.Query()
+			ver := q.Get("modelVersionId")
+			if ver == "" {
+				ver = q.Get("version")
+			}
 			civ := "civitai://model/" + modelID
-			if strings.TrimSpace(ver) != "" { civ += "?version=" + ver }
+			if strings.TrimSpace(ver) != "" {
+				civ += "?version=" + ver
+			}
 			return "Normalized to " + civ, true
 		}
 	}
 	if hostIs(h, "huggingface.co") {
 		parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 		if len(parts) >= 5 && parts[2] == "blob" {
-			owner := parts[0]; repo := parts[1]; rev := parts[3]; filePath := strings.Join(parts[4:], "/")
+			owner := parts[0]
+			repo := parts[1]
+			rev := parts[3]
+			filePath := strings.Join(parts[4:], "/")
 			hf := "hf://" + owner + "/" + repo + "/" + filePath + "?rev=" + rev
 			return "Normalized to " + hf, true
 		}
@@ -1502,14 +1968,18 @@ func (m *Model) updateTokenEnvStatus() {
 	// Presence only (set/unset); rejection is updated upon errors in dlDoneMsg
 	if m.cfg.Sources.HuggingFace.Enabled {
 		env := strings.TrimSpace(m.cfg.Sources.HuggingFace.TokenEnv)
-		if env == "" { env = "HF_TOKEN" }
+		if env == "" {
+			env = "HF_TOKEN"
+		}
 		m.hfTokenSet = strings.TrimSpace(os.Getenv(env)) != ""
 	} else {
 		m.hfTokenSet = false
 	}
 	if m.cfg.Sources.CivitAI.Enabled {
 		env := strings.TrimSpace(m.cfg.Sources.CivitAI.TokenEnv)
-		if env == "" { env = "CIVITAI_TOKEN" }
+		if env == "" {
+			env = "CIVITAI_TOKEN"
+		}
 		m.civTokenSet = strings.TrimSpace(os.Getenv(env)) != ""
 	} else {
 		m.civTokenSet = false
@@ -1526,9 +1996,13 @@ func hostIs(h, root string) bool {
 func (m *Model) renderAuthStatus() string {
 	// derive statuses with precedence: disabled > rejected > set > unset
 	envHF := strings.TrimSpace(m.cfg.Sources.HuggingFace.TokenEnv)
-	if envHF == "" { envHF = "HF_TOKEN" }
+	if envHF == "" {
+		envHF = "HF_TOKEN"
+	}
 	envCIV := strings.TrimSpace(m.cfg.Sources.CivitAI.TokenEnv)
-	if envCIV == "" { envCIV = "CIVITAI_TOKEN" }
+	if envCIV == "" {
+		envCIV = "CIVITAI_TOKEN"
+	}
 	hfEnabled := m.cfg.Sources.HuggingFace.Enabled
 	civEnabled := m.cfg.Sources.CivitAI.Enabled
 	var hf string
@@ -1577,12 +2051,19 @@ func (m *Model) computeDefaultDest(urlStr string) string {
 				if len(parts) >= 2 {
 					modelID := parts[1]
 					q := pu.Query()
-					ver := q.Get("modelVersionId"); if ver == "" { ver = q.Get("version") }
+					ver := q.Get("modelVersionId")
+					if ver == "" {
+						ver = q.Get("version")
+					}
 					civ := "civitai://model/" + modelID
-					if strings.TrimSpace(ver) != "" { civ += "?version=" + neturl.QueryEscape(ver) }
+					if strings.TrimSpace(ver) != "" {
+						civ += "?version=" + neturl.QueryEscape(ver)
+					}
 					if res, err := resolver.Resolve(ctx, civ, m.cfg); err == nil {
 						name := res.SuggestedFilename
-						if strings.TrimSpace(name) == "" { name = filepath.Base(res.URL) }
+						if strings.TrimSpace(name) == "" {
+							name = filepath.Base(res.URL)
+						}
 						name = utilSafe(name)
 						return filepath.Join(m.cfg.General.DownloadRoot, name)
 					}
@@ -1606,20 +2087,27 @@ func (m *Model) computeDefaultDest(urlStr string) string {
 		}
 	}
 	base := filepath.Base(u)
-	if base == "" || base == "/" || base == "." { base = "download" }
+	if base == "" || base == "/" || base == "." {
+		base = "download"
+	}
 	return filepath.Join(m.cfg.General.DownloadRoot, utilSafe(base))
 }
 
 func (m *Model) importBatchFile(path string) tea.Cmd {
 	f, err := os.Open(path)
-	if err != nil { m.addToast("batch open failed: "+err.Error()); return nil }
+	if err != nil {
+		m.addToast("batch open failed: " + err.Error())
+		return nil
+	}
 	defer f.Close()
 	sc := bufio.NewScanner(f)
 	count := 0
 	cmds := make([]tea.Cmd, 0, 64)
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())
-		if line == "" || strings.HasPrefix(line, "#") { continue }
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
 		parts := strings.Fields(line)
 		u := parts[0]
 		dest := ""
@@ -1630,20 +2118,32 @@ func (m *Model) importBatchFile(path string) tea.Cmd {
 				k := strings.ToLower(strings.TrimSpace(tok[:i]))
 				v := strings.TrimSpace(tok[i+1:])
 				switch k {
-				case "dest": dest = v
-				case "type": typeOv = v
-				case "place": v2 := strings.ToLower(v); place = v2=="y"||v2=="yes"||v2=="true"||v2=="1"
+				case "dest":
+					dest = v
+				case "type":
+					typeOv = v
+				case "place":
+					v2 := strings.ToLower(v)
+					place = v2 == "y" || v2 == "yes" || v2 == "true" || v2 == "1"
 				}
 			}
 		}
-		if dest == "" { dest = m.computeDefaultDest(u) }
+		if dest == "" {
+			dest = m.computeDefaultDest(u)
+		}
 		cmds = append(cmds, m.startDownloadCmd(u, dest))
-		key := u+"|"+dest
-		if strings.TrimSpace(typeOv) != "" { m.placeType[key] = typeOv }
-		if place { m.autoPlace[key] = true }
+		key := u + "|" + dest
+		if strings.TrimSpace(typeOv) != "" {
+			m.placeType[key] = typeOv
+		}
+		if place {
+			m.autoPlace[key] = true
+		}
 		count++
 	}
-	if err := sc.Err(); err != nil { m.addToast("batch read error: "+err.Error()) }
+	if err := sc.Err(); err != nil {
+		m.addToast("batch read error: " + err.Error())
+	}
 	m.addToast(fmt.Sprintf("batch: started %d", count))
 	return tea.Batch(cmds...)
 }
@@ -1653,7 +2153,9 @@ func utilSafe(name string) string {
 	name = strings.TrimSpace(name)
 	name = strings.ReplaceAll(name, "\\", "_")
 	name = strings.ReplaceAll(name, "/", "_")
-	if name == "" { return "download" }
+	if name == "" {
+		return "download"
+	}
 	return name
 }
 
@@ -1674,16 +2176,28 @@ func (m *Model) probeSelectedCmd(rows []state.DownloadRow) tea.Cmd {
 			if u, err := neturl.Parse(row.URL); err == nil {
 				h := strings.ToLower(u.Hostname())
 				if hostIs(h, "huggingface.co") && m.cfg.Sources.HuggingFace.Enabled {
-					env := strings.TrimSpace(m.cfg.Sources.HuggingFace.TokenEnv); if env == "" { env = "HF_TOKEN" }
-					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" { headers["Authorization"] = "Bearer "+tok }
+					env := strings.TrimSpace(m.cfg.Sources.HuggingFace.TokenEnv)
+					if env == "" {
+						env = "HF_TOKEN"
+					}
+					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
+						headers["Authorization"] = "Bearer " + tok
+					}
 				}
 				if hostIs(h, "civitai.com") && m.cfg.Sources.CivitAI.Enabled {
-					env := strings.TrimSpace(m.cfg.Sources.CivitAI.TokenEnv); if env == "" { env = "CIVITAI_TOKEN" }
-					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" { headers["Authorization"] = "Bearer "+tok }
+					env := strings.TrimSpace(m.cfg.Sources.CivitAI.TokenEnv)
+					if env == "" {
+						env = "CIVITAI_TOKEN"
+					}
+					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
+						headers["Authorization"] = "Bearer " + tok
+					}
 				}
 			}
 			reach, info := downloader.CheckReachable(ctx, m.cfg, row.URL, headers)
-if !reach { _ = m.st.UpsertDownload(state.DownloadRow{URL: row.URL, Dest: row.Dest, Status: "hold", LastError: info}) }
+			if !reach {
+				_ = m.st.UpsertDownload(state.DownloadRow{URL: row.URL, Dest: row.Dest, Status: "hold", LastError: info})
+			}
 			return probeMsg{url: row.URL, dest: row.Dest, reachable: reach, info: info}
 		})
 	}
@@ -1710,10 +2224,20 @@ func (m *Model) downloadOrHoldCmd(ctx context.Context, urlStr, dest string, star
 					if len(parts) >= 2 {
 						modelID := parts[1]
 						q := u.Query()
-						ver := q.Get("modelVersionId"); if ver == "" { ver = q.Get("version") }
-						civ := "civitai://model/" + modelID; if strings.TrimSpace(ver) != "" { civ += "?version=" + neturl.QueryEscape(ver) }
+						ver := q.Get("modelVersionId")
+						if ver == "" {
+							ver = q.Get("version")
+						}
+						civ := "civitai://model/" + modelID
+						if strings.TrimSpace(ver) != "" {
+							civ += "?version=" + neturl.QueryEscape(ver)
+						}
 						normToast = "normalized CivitAI page → " + civ
-						if res, err := resolver.Resolve(ctx, civ, m.cfg); err == nil { resolved = res.URL; headers = res.Headers; m.addToast(normToast) }
+						if res, err := resolver.Resolve(ctx, civ, m.cfg); err == nil {
+							resolved = res.URL
+							headers = res.Headers
+							m.addToast(normToast)
+						}
 					}
 				}
 				// Hugging Face blob page -> hf://owner/repo/path?rev=...
@@ -1726,36 +2250,58 @@ func (m *Model) downloadOrHoldCmd(ctx context.Context, urlStr, dest string, star
 						filePath := strings.Join(parts[4:], "/")
 						hf := "hf://" + owner + "/" + repo + "/" + filePath + "?rev=" + rev
 						normToast = "normalized HF blob → " + hf
-						if res, err := resolver.Resolve(ctx, hf, m.cfg); err == nil { resolved = res.URL; headers = res.Headers; m.addToast(normToast) }
+						if res, err := resolver.Resolve(ctx, hf, m.cfg); err == nil {
+							resolved = res.URL
+							headers = res.Headers
+							m.addToast(normToast)
+						}
 					}
 				}
 			}
 		}
 		if strings.HasPrefix(resolved, "hf://") || strings.HasPrefix(resolved, "civitai://") {
 			res, err := resolver.Resolve(ctx, resolved, m.cfg)
-			if err != nil { return dlDoneMsg{url: urlStr, dest: dest, path: "", err: err} }
+			if err != nil {
+				return dlDoneMsg{url: urlStr, dest: dest, path: "", err: err}
+			}
 			resolved = res.URL
 			headers = res.Headers
 		} else {
 			if u, err := neturl.Parse(resolved); err == nil {
 				h := strings.ToLower(u.Hostname())
 				if hostIs(h, "huggingface.co") && m.cfg.Sources.HuggingFace.Enabled {
-					env := strings.TrimSpace(m.cfg.Sources.HuggingFace.TokenEnv); if env == "" { env = "HF_TOKEN" }
-					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" { headers["Authorization"] = "Bearer "+tok }
+					env := strings.TrimSpace(m.cfg.Sources.HuggingFace.TokenEnv)
+					if env == "" {
+						env = "HF_TOKEN"
+					}
+					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
+						headers["Authorization"] = "Bearer " + tok
+					}
 				}
 				if hostIs(h, "civitai.com") && m.cfg.Sources.CivitAI.Enabled {
-					env := strings.TrimSpace(m.cfg.Sources.CivitAI.TokenEnv); if env == "" { env = "CIVITAI_TOKEN" }
-					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" { headers["Authorization"] = "Bearer "+tok }
+					env := strings.TrimSpace(m.cfg.Sources.CivitAI.TokenEnv)
+					if env == "" {
+						env = "CIVITAI_TOKEN"
+					}
+					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
+						headers["Authorization"] = "Bearer " + tok
+					}
 				}
 			}
 		}
 		// Merge any pre-inserted row under the original URL into the resolved URL key to avoid duplicates
-		origKey := urlStr+"|"+dest
-		resKey := resolved+"|"+dest
+		origKey := urlStr + "|" + dest
+		resKey := resolved + "|" + dest
 		if origKey != resKey {
 			// Mirror placement overrides
-			if m.autoPlace[origKey] { m.autoPlace[resKey] = true; delete(m.autoPlace, origKey) }
-			if t := m.placeType[origKey]; strings.TrimSpace(t) != "" { m.placeType[resKey] = t; delete(m.placeType, origKey) }
+			if m.autoPlace[origKey] {
+				m.autoPlace[resKey] = true
+				delete(m.autoPlace, origKey)
+			}
+			if t := m.placeType[origKey]; strings.TrimSpace(t) != "" {
+				m.placeType[resKey] = t
+				delete(m.placeType, origKey)
+			}
 			// Remove the old pending row and create/refresh the resolved one as pending
 			_ = m.st.DeleteDownload(urlStr, dest)
 			_ = m.st.UpsertDownload(state.DownloadRow{URL: resolved, Dest: dest, Status: "pending"})
@@ -1763,14 +2309,18 @@ func (m *Model) downloadOrHoldCmd(ctx context.Context, urlStr, dest string, star
 		if start {
 			// Quick reachability probe; if network-unreachable, put job on hold and do not start download
 			reach, info := downloader.CheckReachable(ctx, m.cfg, resolved, headers)
-if !reach {
+			if !reach {
 				_ = m.st.UpsertDownload(state.DownloadRow{URL: resolved, Dest: dest, Status: "hold", LastError: info})
 				// mirror autoplace/type mappings to resolved key so future retries work
-				origKey := urlStr+"|"+dest
-				resKey := resolved+"|"+dest
-				if m.autoPlace[origKey] { m.autoPlace[resKey] = true }
-				if t := m.placeType[origKey]; t != "" { m.placeType[resKey] = t }
-				m.addToast("probe failed: unreachable; job on hold ("+info+")")
+				origKey := urlStr + "|" + dest
+				resKey := resolved + "|" + dest
+				if m.autoPlace[origKey] {
+					m.autoPlace[resKey] = true
+				}
+				if t := m.placeType[origKey]; t != "" {
+					m.placeType[resKey] = t
+				}
+				m.addToast("probe failed: unreachable; job on hold (" + info + ")")
 				return dlDoneMsg{url: resolved, dest: dest, path: "", err: fmt.Errorf("hold: unreachable")}
 			}
 			log := logging.New("error", false)
@@ -1780,18 +2330,26 @@ if !reach {
 		}
 		// Probe-only path
 		reach, info := downloader.CheckReachable(ctx, m.cfg, resolved, headers)
-if !reach { _ = m.st.UpsertDownload(state.DownloadRow{URL: resolved, Dest: dest, Status: "hold", LastError: info}) }
+		if !reach {
+			_ = m.st.UpsertDownload(state.DownloadRow{URL: resolved, Dest: dest, Status: "hold", LastError: info})
+		}
 		return probeMsg{url: resolved, dest: dest, reachable: reach, info: info}
 	}
 }
 
 func openInFileManager(p string, reveal bool) error {
 	p = strings.TrimSpace(p)
-	if p == "" { return fmt.Errorf("empty path") }
+	if p == "" {
+		return fmt.Errorf("empty path")
+	}
 	// Determine directory to open even if file doesn't exist yet
 	dir := p
 	if fi, err := os.Stat(p); err == nil {
-		if fi.IsDir() { dir = p } else { dir = filepath.Dir(p) }
+		if fi.IsDir() {
+			dir = p
+		} else {
+			dir = filepath.Dir(p)
+		}
 	} else {
 		dir = filepath.Dir(p)
 	}
@@ -1799,7 +2357,9 @@ func openInFileManager(p string, reveal bool) error {
 	case "darwin":
 		if reveal {
 			// Reveal if possible; if that fails, fallback to opening dir
-			if err := exec.Command("open", "-R", p).Run(); err == nil { return nil }
+			if err := exec.Command("open", "-R", p).Run(); err == nil {
+				return nil
+			}
 		}
 		return exec.Command("open", dir).Run()
 	case "linux":
@@ -1830,33 +2390,53 @@ func themePresets() []Theme {
 	solar.head = solar.head.Foreground(lipgloss.Color("178"))
 	solar.border = solar.border.BorderForeground(lipgloss.Color("136"))
 	solar.tabActive = solar.tabActive.Foreground(lipgloss.Color("166"))
-	return []Theme{ base, neon, drac, solar }
+	return []Theme{base, neon, drac, solar}
 }
 
 func copyToClipboard(s string) error {
 	s = strings.TrimSpace(s)
-	if s == "" { return fmt.Errorf("empty") }
+	if s == "" {
+		return fmt.Errorf("empty")
+	}
 	switch runtime.GOOS {
 	case "darwin":
 		cmd := exec.Command("pbcopy")
-		in, err := cmd.StdinPipe(); if err != nil { return err }
-		if err := cmd.Start(); err != nil { return err }
-		_, _ = in.Write([]byte(s)); _ = in.Close()
+		in, err := cmd.StdinPipe()
+		if err != nil {
+			return err
+		}
+		if err := cmd.Start(); err != nil {
+			return err
+		}
+		_, _ = in.Write([]byte(s))
+		_ = in.Close()
 		return cmd.Wait()
 	case "linux":
 		// try wl-copy then xclip
 		if _, err := exec.LookPath("wl-copy"); err == nil {
 			cmd := exec.Command("wl-copy")
-			in, err := cmd.StdinPipe(); if err != nil { return err }
-			if err := cmd.Start(); err != nil { return err }
-			_, _ = in.Write([]byte(s)); _ = in.Close()
+			in, err := cmd.StdinPipe()
+			if err != nil {
+				return err
+			}
+			if err := cmd.Start(); err != nil {
+				return err
+			}
+			_, _ = in.Write([]byte(s))
+			_ = in.Close()
 			return cmd.Wait()
 		}
 		if _, err := exec.LookPath("xclip"); err == nil {
 			cmd := exec.Command("xclip", "-selection", "clipboard")
-			in, err := cmd.StdinPipe(); if err != nil { return err }
-			if err := cmd.Start(); err != nil { return err }
-			_, _ = in.Write([]byte(s)); _ = in.Close()
+			in, err := cmd.StdinPipe()
+			if err != nil {
+				return err
+			}
+			if err := cmd.Start(); err != nil {
+				return err
+			}
+			_, _ = in.Write([]byte(s))
+			_ = in.Close()
 			return cmd.Wait()
 		}
 	}

--- a/internal/tui/v2/model_test.go
+++ b/internal/tui/v2/model_test.go
@@ -1,0 +1,40 @@
+package tui2
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestUpdateNewJobEsc(t *testing.T) {
+	m := &Model{newJob: true, newStep: 1, newInput: textinput.New()}
+	m.updateNewJob(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.newJob {
+		t.Fatalf("newJob should be false after esc")
+	}
+}
+
+func TestUpdateBatchModeEsc(t *testing.T) {
+	m := &Model{batchMode: true, batchInput: textinput.New()}
+	m.updateBatchMode(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.batchMode {
+		t.Fatalf("batchMode should be false after esc")
+	}
+}
+
+func TestUpdateFilterEsc(t *testing.T) {
+	m := &Model{filterOn: true, filterInput: textinput.New()}
+	m.updateFilter(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.filterOn {
+		t.Fatalf("filterOn should be false after esc")
+	}
+}
+
+func TestUpdateNormalQuestion(t *testing.T) {
+	m := &Model{}
+	m.updateNormal(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}, Alt: false})
+	if !m.showHelp {
+		t.Fatalf("showHelp should be true after '?' key")
+	}
+}


### PR DESCRIPTION
## Summary
- split massive Update into small helpers for job modal, batch import, filter input, and normal key handling
- add unit tests covering the new helper paths

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b46be94dc0832c9ed3d730d6f14eaa