### PR TITLE
state: add downloads indices and prepared stmts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Highlights
   - Sample config includes sane defaults; CivitAI model page URLs auto-resolve
 - Misc
   - Metrics writes guarded when disabled
+- State
+  - downloads table indexed on status and dest columns
 
 Assets
 - Linux: modfetch_linux_amd64, modfetch_linux_arm64

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -13,52 +13,105 @@ import (
 )
 
 type DB struct {
-	SQL *sql.DB
+	SQL  *sql.DB
 	Path string
+
+	stmtUpsertDownload     *sql.Stmt
+	stmtIncDownloadRetries *sql.Stmt
+	stmtListDownloads      *sql.Stmt
 }
 
 func Open(cfg *config.Config) (*DB, error) {
-	if cfg == nil { return nil, errors.New("nil config") }
-	if cfg.General.DataRoot == "" { return nil, errors.New("general.data_root required") }
-	if err := os.MkdirAll(cfg.General.DataRoot, 0o755); err != nil { return nil, err }
-path := filepath.Join(cfg.General.DataRoot, "state.db")
+	if cfg == nil {
+		return nil, errors.New("nil config")
+	}
+	if cfg.General.DataRoot == "" {
+		return nil, errors.New("general.data_root required")
+	}
+	if err := os.MkdirAll(cfg.General.DataRoot, 0o755); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(cfg.General.DataRoot, "state.db")
 	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout=5000&_pragma=journal_mode(WAL)&_fk=1", path)
 	sqldb, err := sql.Open("sqlite", dsn)
-	if err != nil { return nil, err }
-	if err := initSchema(sqldb); err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
+	if err := initSchema(sqldb); err != nil {
+		return nil, err
+	}
 	db := &DB{SQL: sqldb, Path: path}
-	if err := db.InitChunksTable(); err != nil { return nil, err }
-	if err := db.InitHostCapsTable(); err != nil { return nil, err }
+	if err := db.prepareStatements(); err != nil {
+		return nil, err
+	}
+	if err := db.InitChunksTable(); err != nil {
+		return nil, err
+	}
+	if err := db.InitHostCapsTable(); err != nil {
+		return nil, err
+	}
 	return db, nil
 }
 
 func initSchema(db *sql.DB) error {
 	stmts := []string{
 		`CREATE TABLE IF NOT EXISTS downloads (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			url TEXT NOT NULL,
-			dest TEXT NOT NULL,
-			expected_sha256 TEXT,
-			actual_sha256 TEXT,
-			etag TEXT,
-			last_modified TEXT,
-			size INTEGER,
-			status TEXT,
-			retries INTEGER DEFAULT 0,
-			created_at INTEGER NOT NULL,
-			updated_at INTEGER NOT NULL,
-			last_error TEXT,
-			UNIQUE(url, dest)
-		);`,
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        url TEXT NOT NULL,
+                        dest TEXT NOT NULL,
+                        expected_sha256 TEXT,
+                        actual_sha256 TEXT,
+                        etag TEXT,
+                        last_modified TEXT,
+                        size INTEGER,
+                        status TEXT,
+                        retries INTEGER DEFAULT 0,
+                        created_at INTEGER NOT NULL,
+                        updated_at INTEGER NOT NULL,
+                        last_error TEXT,
+                        UNIQUE(url, dest)
+                );`,
+		`CREATE INDEX IF NOT EXISTS idx_downloads_status ON downloads(status);`,
+		`CREATE INDEX IF NOT EXISTS idx_downloads_dest   ON downloads(dest);`,
 	}
 	for _, s := range stmts {
-		if _, err := db.Exec(s); err != nil { return err }
+		if _, err := db.Exec(s); err != nil {
+			return err
+		}
 	}
 	// Try to add new columns in case of existing DB without them
 	_, _ = db.Exec(`ALTER TABLE downloads ADD COLUMN actual_sha256 TEXT`)
 	_, _ = db.Exec(`ALTER TABLE downloads ADD COLUMN retries INTEGER DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE downloads ADD COLUMN last_error TEXT`)
 	return nil
+}
+
+func (db *DB) prepareStatements() error {
+	var err error
+	db.stmtUpsertDownload, err = db.SQL.Prepare(`INSERT INTO downloads(url, dest, expected_sha256, actual_sha256, etag, last_modified, size, status, last_error, created_at, updated_at)
+                VALUES(?,?,?,?,?,?,?,?,?,?,?)
+                ON CONFLICT(url, dest) DO UPDATE SET expected_sha256=excluded.expected_sha256, actual_sha256=excluded.actual_sha256, etag=excluded.etag, last_modified=excluded.last_modified, size=excluded.size, status=excluded.status, last_error=excluded.last_error, updated_at=?`)
+	if err != nil {
+		return err
+	}
+	db.stmtIncDownloadRetries, err = db.SQL.Prepare(`UPDATE downloads SET retries = COALESCE(retries,0) + ?, updated_at=strftime('%s','now') WHERE url=? AND dest=?`)
+	if err != nil {
+		return err
+	}
+	db.stmtListDownloads, err = db.SQL.Prepare(`SELECT url, dest,
+    COALESCE(expected_sha256, ''),
+    COALESCE(actual_sha256, ''),
+    COALESCE(etag, ''),
+    COALESCE(last_modified, ''),
+    COALESCE(size, 0),
+    COALESCE(status, ''),
+    COALESCE(retries, 0),
+    created_at,
+    updated_at,
+    COALESCE(last_error, '')
+  FROM downloads
+  ORDER BY updated_at DESC`)
+	return err
 }
 
 type DownloadRow struct {
@@ -78,17 +131,16 @@ type DownloadRow struct {
 
 func (db *DB) UpsertDownload(row DownloadRow) error {
 	now := time.Now().Unix()
-	_, err := db.SQL.Exec(`INSERT INTO downloads(url, dest, expected_sha256, actual_sha256, etag, last_modified, size, status, last_error, created_at, updated_at)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?)
-		ON CONFLICT(url, dest) DO UPDATE SET expected_sha256=excluded.expected_sha256, actual_sha256=excluded.actual_sha256, etag=excluded.etag, last_modified=excluded.last_modified, size=excluded.size, status=excluded.status, last_error=excluded.last_error, updated_at=?`,
-		row.URL, row.Dest, row.ExpectedSHA256, row.ActualSHA256, row.ETag, row.LastModified, row.Size, row.Status, row.LastError, now, now, now)
+	_, err := db.stmtUpsertDownload.Exec(row.URL, row.Dest, row.ExpectedSHA256, row.ActualSHA256, row.ETag, row.LastModified, row.Size, row.Status, row.LastError, now, now, now)
 	return err
 }
 
 // IncDownloadRetries increments the retries counter for a download row.
 func (db *DB) IncDownloadRetries(url, dest string, delta int64) error {
-	if delta == 0 { return nil }
-	_, err := db.SQL.Exec(`UPDATE downloads SET retries = COALESCE(retries,0) + ?, updated_at=strftime('%s','now') WHERE url=? AND dest=?`, delta, url, dest)
+	if delta == 0 {
+		return nil
+	}
+	_, err := db.stmtIncDownloadRetries.Exec(delta, url, dest)
 	return err
 }
 
@@ -100,27 +152,18 @@ func (db *DB) DeleteDownload(url, dest string) error {
 
 // ListDownloads returns a snapshot of the downloads table
 func (db *DB) ListDownloads() ([]DownloadRow, error) {
-rows, err := db.SQL.Query(`SELECT url, dest,
-    COALESCE(expected_sha256, ''),
-    COALESCE(actual_sha256, ''),
-    COALESCE(etag, ''),
-    COALESCE(last_modified, ''),
-    COALESCE(size, 0),
-    COALESCE(status, ''),
-    COALESCE(retries, 0),
-    created_at,
-    updated_at,
-    COALESCE(last_error, '')
-  FROM downloads
-  ORDER BY updated_at DESC`)
-	if err != nil { return nil, err }
+	rows, err := db.stmtListDownloads.Query()
+	if err != nil {
+		return nil, err
+	}
 	defer rows.Close()
 	var out []DownloadRow
 	for rows.Next() {
 		var r DownloadRow
-		if err := rows.Scan(&r.URL, &r.Dest, &r.ExpectedSHA256, &r.ActualSHA256, &r.ETag, &r.LastModified, &r.Size, &r.Status, &r.Retries, &r.CreatedAt, &r.UpdatedAt, &r.LastError); err != nil { return nil, err }
+		if err := rows.Scan(&r.URL, &r.Dest, &r.ExpectedSHA256, &r.ActualSHA256, &r.ETag, &r.LastModified, &r.Size, &r.Status, &r.Retries, &r.CreatedAt, &r.UpdatedAt, &r.LastError); err != nil {
+			return nil, err
+		}
 		out = append(out, r)
 	}
 	return out, rows.Err()
 }
-


### PR DESCRIPTION
## Summary
- add indices for downloads status and dest columns
- reuse prepared statements for common downloads queries
- document schema changes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b46be0a0a4832c9957844ffb74fe99