### PR TITLE
Handle interrupts gracefully with context cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Highlights
 - Batch YAML execution with verify and status
 - Rich TUI dashboard and CLI progress with throughput and ETA
 - Structured logging, metrics, and resilient SQLite state
+- Graceful cancellation on SIGINT/SIGTERM cleans up partial downloads
 
 Status: MVP feature‑complete for resolvers and downloads; ongoing polish in TUI and docs.
 
@@ -87,6 +88,7 @@ Usage (see docs/USER_GUIDE.md for details)
     - others use the basename of the resolved URL
   - Quiet mode: add `--quiet`
   - On completion, a summary is printed (dest, size, SHA256, duration, average speed)
+  - Cancel with Ctrl+C (SIGINT/SIGTERM); partial files are cleaned up
 - Place artifacts into apps:
   
   modfetch place --config /path/to/config.yml --path /path/to/model.safetensors

--- a/cmd/modfetch/batch_cmd.go
+++ b/cmd/modfetch/batch_cmd.go
@@ -21,18 +21,20 @@ import (
 	"modfetch/internal/util"
 )
 
-func handleBatch(args []string) error {
-	if len(args) == 0 { return errors.New("batch subcommand required: import") }
+func handleBatch(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return errors.New("batch subcommand required: import")
+	}
 	sub := args[0]
 	switch sub {
 	case "import":
-		return handleBatchImport(args[1:])
+		return handleBatchImport(ctx, args[1:])
 	default:
 		return fmt.Errorf("unknown batch subcommand: %s", sub)
 	}
 }
 
-func handleBatchImport(args []string) error {
+func handleBatchImport(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("batch import", flag.ContinueOnError)
 	cfgPath := fs.String("config", "", "Path to YAML config file")
 	logLevel := fs.String("log-level", "info", "log level")
@@ -45,36 +47,59 @@ func handleBatchImport(args []string) error {
 	defPlace := fs.Bool("place", false, "Default place flag for jobs (override per-line via place=")
 	defMode := fs.String("mode", "", "Default placement mode: symlink|hardlink|copy (override per-line via mode=")
 	noResolvePages := fs.Bool("no-resolve-pages", false, "Disable civitai.com model page -> civitai:// uri normalization")
-	if err := fs.Parse(args); err != nil { return err }
-	if *cfgPath == "" { if env := os.Getenv("MODFETCH_CONFIG"); env != "" { *cfgPath = env } }
-	if *cfgPath == "" { return errors.New("--config is required or set MODFETCH_CONFIG") }
-	if *inPath == "" { return errors.New("--input is required") }
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *cfgPath == "" {
+		if env := os.Getenv("MODFETCH_CONFIG"); env != "" {
+			*cfgPath = env
+		}
+	}
+	if *cfgPath == "" {
+		return errors.New("--config is required or set MODFETCH_CONFIG")
+	}
+	if *inPath == "" {
+		return errors.New("--input is required")
+	}
 	c, err := config.Load(*cfgPath)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	log := logging.New(*logLevel, *jsonOut)
 
 	f, err := os.Open(*inPath)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	defer f.Close()
 	s := bufio.NewScanner(f)
 	s.Buffer(make([]byte, 0, 1024), 1024*1024)
 
 	// defaults
 	out := &batch.File{Version: 1}
-	ctx := context.Background()
 	root := strings.TrimSpace(*destDir)
-	if root == "" { root = c.General.DownloadRoot }
-	if err := os.MkdirAll(root, 0o755); err != nil { return err }
+	if root == "" {
+		root = c.General.DownloadRoot
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return err
+	}
 
 	lineNum := 0
 	for s.Scan() {
 		lineNum++
 		line := strings.TrimSpace(s.Text())
-		if line == "" { continue }
-		if strings.HasPrefix(strings.TrimSpace(line), "#") { continue }
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
 		// Split into tokens
 		toks := strings.Fields(line)
-		if len(toks) == 0 { continue }
+		if len(toks) == 0 {
+			continue
+		}
 		uri := toks[0]
 		jDest := ""
 		jSHA := ""
@@ -82,16 +107,26 @@ func handleBatchImport(args []string) error {
 		jPlace := *defPlace
 		jMode := strings.TrimSpace(*defMode)
 		for _, t := range toks[1:] {
-			if !strings.Contains(t, "=") { continue }
+			if !strings.Contains(t, "=") {
+				continue
+			}
 			kv := strings.SplitN(t, "=", 2)
 			k := strings.ToLower(strings.TrimSpace(kv[0]))
-			v := ""; if len(kv) > 1 { v = strings.TrimSpace(kv[1]) }
+			v := ""
+			if len(kv) > 1 {
+				v = strings.TrimSpace(kv[1])
+			}
 			switch k {
-			case "dest": jDest = v
-			case "sha256": jSHA = v
-			case "type": jType = v
-			case "place": jPlace = strings.EqualFold(v, "true") || v == "1" || strings.EqualFold(v, "yes")
-			case "mode": jMode = v
+			case "dest":
+				jDest = v
+			case "sha256":
+				jSHA = v
+			case "type":
+				jType = v
+			case "place":
+				jPlace = strings.EqualFold(v, "true") || v == "1" || strings.EqualFold(v, "yes")
+			case "mode":
+				jMode = v
 			}
 		}
 
@@ -106,9 +141,14 @@ func handleBatchImport(args []string) error {
 					if len(parts) >= 2 {
 						modelID := parts[1]
 						q := u.Query()
-						ver := q.Get("modelVersionId"); if ver == "" { ver = q.Get("version") }
-					civ := "civitai://model/" + modelID
-						if strings.TrimSpace(ver) != "" { civ += "?version=" + neturl.QueryEscape(ver) }
+						ver := q.Get("modelVersionId")
+						if ver == "" {
+							ver = q.Get("version")
+						}
+						civ := "civitai://model/" + modelID
+						if strings.TrimSpace(ver) != "" {
+							civ += "?version=" + neturl.QueryEscape(ver)
+						}
 						resolvedURI = civ
 					}
 				}
@@ -147,12 +187,16 @@ func handleBatchImport(args []string) error {
 				}
 			}
 			res, err := resolver.Resolve(ctx, resolvedURI, c)
-			if err != nil { return fmt.Errorf("line %d: resolve: %w", lineNum, err) }
+			if err != nil {
+				return fmt.Errorf("line %d: resolve: %w", lineNum, err)
+			}
 			probeURL = res.URL
 			headers = res.Headers
 			// For civitai, if no dest given, prefer SuggestedFilename with version hint
 			if jDest == "" && strings.HasPrefix(resolvedURI, "civitai://") && strings.TrimSpace(res.SuggestedFilename) != "" {
-				if p, err := util.UniquePath(root, res.SuggestedFilename, res.VersionID); err == nil { jDest = p }
+				if p, err := util.UniquePath(root, res.SuggestedFilename, res.VersionID); err == nil {
+					jDest = p
+				}
 			}
 		} else {
 			// Attach auth headers for known hosts (direct URLs)
@@ -189,12 +233,16 @@ func handleBatchImport(args []string) error {
 			name := strings.TrimSpace(meta.Filename)
 			if name == "" {
 				base := meta.FinalURL
-				if base == "" { base = probeURL }
+				if base == "" {
+					base = probeURL
+				}
 				name = filepath.Base(base)
 			}
 			name = util.SafeFileName(name)
 			p, err := util.UniquePath(root, name, "")
-			if err != nil { return fmt.Errorf("line %d: dest compute: %w", lineNum, err) }
+			if err != nil {
+				return fmt.Errorf("line %d: dest compute: %w", lineNum, err)
+			}
 			jDest = p
 		}
 
@@ -202,22 +250,30 @@ func handleBatchImport(args []string) error {
 		if strings.EqualFold(strings.TrimSpace(*shaMode), "compute") && strings.TrimSpace(jSHA) == "" {
 			log.Infof("computing sha256 for %s (this may take a while)", uri)
 			sha, err := downloader.ComputeRemoteSHA256(ctx, c, probeURL, headers)
-			if err != nil { return fmt.Errorf("line %d: compute sha: %w", lineNum, err) }
+			if err != nil {
+				return fmt.Errorf("line %d: compute sha: %w", lineNum, err)
+			}
 			jSHA = sha
 		}
 
 		out.Jobs = append(out.Jobs, batch.BatchJob{URI: resolvedURI, Dest: jDest, SHA256: jSHA, Type: jType, Place: jPlace, Mode: jMode})
 	}
-	if err := s.Err(); err != nil { return err }
+	if err := s.Err(); err != nil {
+		return err
+	}
 
 	// Emit YAML
 	if strings.TrimSpace(*outPath) == "" {
 		// stdout
 		enc, _ := yamlEncoder()
-		if err := enc.Encode(out); err != nil { return err }
+		if err := enc.Encode(out); err != nil {
+			return err
+		}
 		return nil
 	}
-	if err := batch.Save(*outPath, out); err != nil { return err }
+	if err := batch.Save(*outPath, out); err != nil {
+		return err
+	}
 	fmt.Fprintf(os.Stderr, "wrote batch: %s (%d jobs)\n", *outPath, len(out.Jobs))
 	return nil
 }
@@ -228,4 +284,3 @@ func yamlEncoder() (*yaml.Encoder, error) {
 	enc.SetIndent(2)
 	return enc, nil
 }
-

--- a/cmd/modfetch/batch_cmd_test.go
+++ b/cmd/modfetch/batch_cmd_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,12 +15,16 @@ func TestBatchImport_FromTextURLs_NoNetworkRequired(t *testing.T) {
 	d := t.TempDir()
 	cfgPath := filepath.Join(d, "config.yaml")
 	downloadRoot := filepath.Join(d, "dlroot")
-	if err := os.MkdirAll(downloadRoot, 0o755); err != nil { t.Fatal(err) }
+	if err := os.MkdirAll(downloadRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	cfg := "version: 1\n" +
 		"general:\n" +
 		"  data_root: " + strings.ReplaceAll(d, "\\", "\\\\") + "\n" +
 		"  download_root: " + strings.ReplaceAll(downloadRoot, "\\", "\\\\") + "\n"
-	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	inPath := filepath.Join(d, "input.txt")
 	// Use simple URLs; importer tolerates probe failures
@@ -28,7 +33,9 @@ func TestBatchImport_FromTextURLs_NoNetworkRequired(t *testing.T) {
 		"https://example.com/b.bin",
 		"https://example.com/path/c.bin",
 	}, "\n")
-	if err := os.WriteFile(inPath, []byte(input), 0o644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(inPath, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	outPath := filepath.Join(d, "batch.yaml")
 	args := []string{
@@ -38,12 +45,20 @@ func TestBatchImport_FromTextURLs_NoNetworkRequired(t *testing.T) {
 		"--dest-dir", downloadRoot,
 		"--sha-mode", "none",
 	}
-	if err := handleBatchImport(args); err != nil { t.Fatalf("batch import failed: %v", err) }
+	if err := handleBatchImport(context.Background(), args); err != nil {
+		t.Fatalf("batch import failed: %v", err)
+	}
 
 	bf, err := batch.Load(outPath)
-	if err != nil { t.Fatalf("load batch: %v", err) }
-	if bf.Version != 1 { t.Fatalf("bad version: %d", bf.Version) }
-	if len(bf.Jobs) != 3 { t.Fatalf("expected 3 jobs; got %d", len(bf.Jobs)) }
+	if err != nil {
+		t.Fatalf("load batch: %v", err)
+	}
+	if bf.Version != 1 {
+		t.Fatalf("bad version: %d", bf.Version)
+	}
+	if len(bf.Jobs) != 3 {
+		t.Fatalf("expected 3 jobs; got %d", len(bf.Jobs))
+	}
 	for i, j := range bf.Jobs {
 		if !strings.HasPrefix(j.Dest, downloadRoot) {
 			t.Fatalf("job %d dest not under dest-dir: %s", i, j.Dest)
@@ -53,4 +68,3 @@ func TestBatchImport_FromTextURLs_NoNetworkRequired(t *testing.T) {
 		}
 	}
 }
-

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -1,15 +1,20 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
 )
 
-func handleCompletion(args []string) error {
+func handleCompletion(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("completion", flag.ContinueOnError)
-	if err := fs.Parse(args); err != nil { return err }
-	if fs.NArg() < 1 { return errors.New("usage: modfetch completion [bash|zsh|fish]") }
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() < 1 {
+		return errors.New("usage: modfetch completion [bash|zsh|fish]")
+	}
 	shell := fs.Arg(0)
 	switch shell {
 	case "bash":
@@ -132,4 +137,3 @@ complete -c modfetch -n "__fish_seen_subcommand_from place" -l mode -d "Placemen
 complete -c modfetch -n "__fish_seen_subcommand_from verify" -l path -d "File to verify"
 complete -c modfetch -n "__fish_seen_subcommand_from verify" -l all -d "Verify all"
 `
-

--- a/cmd/modfetch/config_wizard.go
+++ b/cmd/modfetch/config_wizard.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -12,17 +13,19 @@ import (
 	cw "modfetch/internal/tui/configwizard"
 )
 
-func handleConfigWizard(args []string) error {
+func handleConfigWizard(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("config wizard", flag.ContinueOnError)
 	out := fs.String("out", "", "write YAML to this path instead of stdout")
-	if err := fs.Parse(args); err != nil { return err }
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
 
 	// Use simple defaults
 	defaults := &config.Config{
 		Version: 1,
 		General: config.General{
-			DataRoot:     "~/modfetch/data",
-			DownloadRoot: "~/modfetch/downloads",
+			DataRoot:      "~/modfetch/data",
+			DownloadRoot:  "~/modfetch/downloads",
 			PlacementMode: "symlink",
 		},
 		Concurrency: config.Concurrency{ChunkSizeMB: 8, PerFileChunks: 4},
@@ -30,19 +33,28 @@ func handleConfigWizard(args []string) error {
 	w := cw.New(defaults)
 	p := tea.NewProgram(w)
 	m, err := p.Run()
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	wiz, ok := m.(*cw.Wizard)
-	if !ok { return errors.New("unexpected model type from wizard") }
+	if !ok {
+		return errors.New("unexpected model type from wizard")
+	}
 	cfg := wiz.Config()
-	if cfg == nil { return errors.New("no config produced") }
+	if cfg == nil {
+		return errors.New("no config produced")
+	}
 	b, err := yaml.Marshal(cfg)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	if *out == "" {
 		fmt.Print(string(b))
 		return nil
 	}
-	if err := os.WriteFile(*out, b, 0o644); err != nil { return err }
+	if err := os.WriteFile(*out, b, 0o644); err != nil {
+		return err
+	}
 	fmt.Printf("wrote config to %s\n", *out)
 	return nil
 }
-

--- a/cmd/modfetch/hostcaps.go
+++ b/cmd/modfetch/hostcaps.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -12,38 +13,59 @@ import (
 	"modfetch/internal/state"
 )
 
-func handleHostCaps(args []string) error {
+func handleHostCaps(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("hostcaps", flag.ContinueOnError)
 	cfgPath := fs.String("config", "", "Path to YAML config file")
 	list := fs.Bool("list", false, "List cached host capabilities")
 	clear := fs.String("clear", "", "Clear cache for a specific host")
 	clearAll := fs.Bool("clear-all", false, "Clear cache for all hosts")
 	jsonOut := fs.Bool("json", false, "JSON output")
-	if err := fs.Parse(args); err != nil { return err }
-	if *cfgPath == "" { if env := os.Getenv("MODFETCH_CONFIG"); env != "" { *cfgPath = env } }
-	if *cfgPath == "" { return errors.New("--config is required or set MODFETCH_CONFIG") }
-	if _, err := os.Stat(*cfgPath); err != nil { return fmt.Errorf("config file not found: %s", *cfgPath) }
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *cfgPath == "" {
+		if env := os.Getenv("MODFETCH_CONFIG"); env != "" {
+			*cfgPath = env
+		}
+	}
+	if *cfgPath == "" {
+		return errors.New("--config is required or set MODFETCH_CONFIG")
+	}
+	if _, err := os.Stat(*cfgPath); err != nil {
+		return fmt.Errorf("config file not found: %s", *cfgPath)
+	}
 	c, err := config.Load(*cfgPath)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	st, err := state.Open(c)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	defer st.SQL.Close()
 	if *clearAll {
-		if err := st.ClearHostCaps(); err != nil { return err }
+		if err := st.ClearHostCaps(); err != nil {
+			return err
+		}
 		fmt.Println("hostcaps: cleared all")
 		return nil
 	}
 	if *clear != "" {
 		h := strings.ToLower(strings.TrimSpace(*clear))
-		if err := st.DeleteHostCaps(h); err != nil { return err }
+		if err := st.DeleteHostCaps(h); err != nil {
+			return err
+		}
 		fmt.Printf("hostcaps: cleared %s\n", h)
 		return nil
 	}
 	if *list || fs.NArg() == 0 {
 		hc, err := st.ListHostCaps()
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 		if *jsonOut {
-			enc := json.NewEncoder(os.Stdout); enc.SetIndent("", "  ")
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
 			return enc.Encode(hc)
 		}
 		for _, h := range hc {

--- a/cmd/modfetch/tui_cmd.go
+++ b/cmd/modfetch/tui_cmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -13,11 +14,11 @@ import (
 	"modfetch/internal/logging"
 	"modfetch/internal/state"
 	ui "modfetch/internal/tui"
-	uiv2 "modfetch/internal/tui/v2"
 	cw "modfetch/internal/tui/configwizard"
+	uiv2 "modfetch/internal/tui/v2"
 )
 
-func handleTUI(args []string) error {
+func handleTUI(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("tui", flag.ContinueOnError)
 	cfgPath := fs.String("config", "", "Path to YAML config file")
 	logLevel := fs.String("log-level", "info", "log level")
@@ -25,13 +26,20 @@ func handleTUI(args []string) error {
 	// --v2 kept for compatibility but unused since v2 is default
 	_ = fs.Bool("v2", false, "Use TUI v2 (default)")
 	useV1 := fs.Bool("v1", false, "Use legacy TUI v1 (fallback)")
-	if err := fs.Parse(args); err != nil { return err }
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
 	if *cfgPath == "" {
-		if env := os.Getenv("MODFETCH_CONFIG"); env != "" { *cfgPath = env }
+		if env := os.Getenv("MODFETCH_CONFIG"); env != "" {
+			*cfgPath = env
+		}
 	}
 	// If still empty, default to ~/.config/modfetch/config.yml
 	if *cfgPath == "" {
-		h, err := os.UserHomeDir(); if err != nil { return errors.New("--config is required or set MODFETCH_CONFIG") }
+		h, err := os.UserHomeDir()
+		if err != nil {
+			return errors.New("--config is required or set MODFETCH_CONFIG")
+		}
 		*cfgPath = filepath.Join(h, ".config", "modfetch", "config.yml")
 	}
 	// Try to load config. If not found, offer to create via wizard with sensible defaults.
@@ -44,22 +52,39 @@ func handleTUI(args []string) error {
 			wiz := cw.New(defaults)
 			p := tea.NewProgram(wiz)
 			m, werr := p.Run()
-			if werr != nil { return werr }
-			w, ok := m.(*cw.Wizard); if !ok { return errors.New("unexpected wizard model") }
-			cfg := w.Config(); if cfg == nil { return errors.New("config wizard was cancelled") }
-			b, merr := yaml.Marshal(cfg); if merr != nil { return merr }
-			if err := os.WriteFile(*cfgPath, b, 0o644); err != nil { return err }
+			if werr != nil {
+				return werr
+			}
+			w, ok := m.(*cw.Wizard)
+			if !ok {
+				return errors.New("unexpected wizard model")
+			}
+			cfg := w.Config()
+			if cfg == nil {
+				return errors.New("config wizard was cancelled")
+			}
+			b, merr := yaml.Marshal(cfg)
+			if merr != nil {
+				return merr
+			}
+			if err := os.WriteFile(*cfgPath, b, 0o644); err != nil {
+				return err
+			}
 			fmt.Printf("wrote config to %s\n", *cfgPath)
 			// Reload expanded config
 			c, err = config.Load(*cfgPath)
-			if err != nil { return err }
+			if err != nil {
+				return err
+			}
 		} else {
 			return err
 		}
 	}
 	_ = logging.New(*logLevel, *jsonOut) // placeholder for future log routing
 	st, err := state.Open(c)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	defer st.SQL.Close()
 	var m tea.Model
 	// Default to v2 unless legacy v1 explicitly requested
@@ -72,4 +97,3 @@ func handleTUI(args []string) error {
 	_, err = p.Run()
 	return err
 }
-

--- a/cmd/modfetch/verify.go
+++ b/cmd/modfetch/verify.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -20,10 +21,11 @@ import (
 
 // handleVerify verifies downloaded files.
 // Options:
-//   --path PATH       verify a specific file in state
-//   --all             verify all completed downloads
-//   --safetensors     additionally perform a minimal .safetensors structure check
-func handleVerify(args []string) error {
+//
+//	--path PATH       verify a specific file in state
+//	--all             verify all completed downloads
+//	--safetensors     additionally perform a minimal .safetensors structure check
+func handleVerify(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("verify", flag.ContinueOnError)
 	cfgPath := fs.String("config", "", "Path to YAML config file")
 	pathFlag := fs.String("path", "", "Specific file to verify (optional)")
@@ -37,29 +39,47 @@ func handleVerify(args []string) error {
 	summary := fs.Bool("summary", false, "Print a summary of total scanned and error count")
 	logLevel := fs.String("log-level", "info", "log level")
 	jsonOut := fs.Bool("json", false, "json logs")
-	if err := fs.Parse(args); err != nil { return err }
-	if *cfgPath == "" { if env := os.Getenv("MODFETCH_CONFIG"); env != "" { *cfgPath = env } }
-	if *cfgPath == "" { return errors.New("--config is required or set MODFETCH_CONFIG") }
-	if _, err := os.Stat(*cfgPath); err != nil { return fmt.Errorf("config file not found: %s", *cfgPath) }
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *cfgPath == "" {
+		if env := os.Getenv("MODFETCH_CONFIG"); env != "" {
+			*cfgPath = env
+		}
+	}
+	if *cfgPath == "" {
+		return errors.New("--config is required or set MODFETCH_CONFIG")
+	}
+	if _, err := os.Stat(*cfgPath); err != nil {
+		return fmt.Errorf("config file not found: %s", *cfgPath)
+	}
 	c, err := config.Load(*cfgPath)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	_ = logging.New(*logLevel, *jsonOut)
 	// If scanning an arbitrary directory, DB is not required; open only for state-backed modes.
 	var st *state.DB
 	if *scanDir == "" {
 		var err error
 		st, err = state.Open(c)
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 		defer st.SQL.Close()
 	}
 
 	report := map[string]any{}
 	verifyOne := func(row state.DownloadRow) error {
 		f, err := os.Open(row.Dest)
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 		defer f.Close()
 		h := sha256.New()
-		if _, err := io.Copy(h, f); err != nil { return err }
+		if _, err := io.Copy(h, f); err != nil {
+			return err
+		}
 		actual := hex.EncodeToString(h.Sum(nil))
 		status := "verified"
 		if row.ExpectedSHA256 != "" && !equalFoldHex(row.ExpectedSHA256, actual) {
@@ -70,13 +90,17 @@ func handleVerify(args []string) error {
 		if *checkST && (filepath.Ext(row.Dest) == ".safetensors" || filepath.Ext(row.Dest) == ".sft") {
 			ok, herr := sanityCheckSafeTensors(row.Dest)
 			res["safetensors_ok"] = ok
-			if herr != nil { res["safetensors_error"] = herr.Error() }
+			if herr != nil {
+				res["safetensors_error"] = herr.Error()
+			}
 		}
 		if *checkSTDeep && (filepath.Ext(row.Dest) == ".safetensors" || filepath.Ext(row.Dest) == ".sft") {
 			ok, need, derr := deepVerifySafeTensors(row.Dest)
 			res["safetensors_deep_ok"] = ok
 			res["safetensors_declared_size"] = need
-			if derr != nil { res["safetensors_deep_error"] = derr.Error() }
+			if derr != nil {
+				res["safetensors_deep_error"] = derr.Error()
+			}
 		}
 		report[row.Dest] = res
 		return nil
@@ -85,22 +109,41 @@ func handleVerify(args []string) error {
 	if *scanDir != "" {
 		// directory scan mode (no DB required)
 		res, err := scanSafetensorsDir(*scanDir, *checkSTDeep, *repair, *quarantineIncomplete)
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 		// merge results into report
-		for k, v := range res { report[k] = v }
+		for k, v := range res {
+			report[k] = v
+		}
 	} else if *pathFlag != "" {
 		rows, err := st.ListDownloads()
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 		var found *state.DownloadRow
-		for i := range rows { if rows[i].Dest == *pathFlag { found = &rows[i]; break } }
-		if found == nil { return fmt.Errorf("no download record for %s", *pathFlag) }
-		if err := verifyOne(*found); err != nil { return err }
+		for i := range rows {
+			if rows[i].Dest == *pathFlag {
+				found = &rows[i]
+				break
+			}
+		}
+		if found == nil {
+			return fmt.Errorf("no download record for %s", *pathFlag)
+		}
+		if err := verifyOne(*found); err != nil {
+			return err
+		}
 	} else if *all {
 		rows, err := st.ListDownloads()
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 		for _, r := range rows {
 			if strings.EqualFold(r.Status, "complete") || strings.EqualFold(r.Status, "verified") || strings.EqualFold(r.Status, "checksum_mismatch") {
-				if err := verifyOne(r); err != nil { return err }
+				if err := verifyOne(r); err != nil {
+					return err
+				}
 			}
 		}
 	} else {
@@ -108,7 +151,8 @@ func handleVerify(args []string) error {
 	}
 
 	if *jsonOut {
-		enc := json.NewEncoder(os.Stdout); enc.SetIndent("", "  ")
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
 		return enc.Encode(report)
 	}
 	// Human-readable output with optional filtering and summary
@@ -122,13 +166,21 @@ func handleVerify(args []string) error {
 		}
 		// safetensors basic
 		if *checkST {
-			if ok, okp := m["safetensors_ok"].(bool); okp && !ok { return true }
-			if _, has := m["safetensors_error"]; has { return true }
+			if ok, okp := m["safetensors_ok"].(bool); okp && !ok {
+				return true
+			}
+			if _, has := m["safetensors_error"]; has {
+				return true
+			}
 		}
 		// safetensors deep
 		if *checkSTDeep {
-			if ok, okp := m["safetensors_deep_ok"].(bool); okp && !ok { return true }
-			if _, has := m["safetensors_deep_error"]; has { return true }
+			if ok, okp := m["safetensors_deep_ok"].(bool); okp && !ok {
+				return true
+			}
+			if _, has := m["safetensors_deep_error"]; has {
+				return true
+			}
 		}
 		return false
 	}
@@ -138,9 +190,13 @@ func handleVerify(args []string) error {
 		err := isErr(m)
 		if err {
 			errCount++
-			if p, ok := m["path"].(string); ok { errPaths = append(errPaths, p) }
+			if p, ok := m["path"].(string); ok {
+				errPaths = append(errPaths, p)
+			}
 		}
-		if *onlyErrors && !err { continue }
+		if *onlyErrors && !err {
+			continue
+		}
 		path := m["path"]
 		if _, hasSize := m["size"]; hasSize {
 			fmt.Printf("%s size=%v sha256=%v status=%v\n", path, m["size"], m["sha256"], m["status"])
@@ -152,8 +208,12 @@ func handleVerify(args []string) error {
 		}
 		if *checkSTDeep {
 			fmt.Printf("  safetensors_deep_ok=%v declared_size=%v error=%v", m["safetensors_deep_ok"], m["safetensors_declared_size"], m["safetensors_deep_error"])
-			if rv, ok := m["repaired"]; ok { fmt.Printf(" repaired=%v", rv) }
-			if qv, ok := m["quarantined"]; ok { fmt.Printf(" quarantined=%v", qv) }
+			if rv, ok := m["repaired"]; ok {
+				fmt.Printf(" repaired=%v", rv)
+			}
+			if qv, ok := m["quarantined"]; ok {
+				fmt.Printf(" quarantined=%v", qv)
+			}
 			fmt.Print("\n")
 		}
 	}
@@ -161,7 +221,9 @@ func handleVerify(args []string) error {
 		fmt.Printf("Summary: scanned=%d errors=%d\n", total, errCount)
 		if errCount > 0 {
 			fmt.Println("Error paths:")
-			for _, p := range errPaths { fmt.Printf("  %s\n", p) }
+			for _, p := range errPaths {
+				fmt.Printf("  %s\n", p)
+			}
 		}
 	}
 	return nil
@@ -170,16 +232,29 @@ func handleVerify(args []string) error {
 // sanityCheckSafeTensors: minimal header sanity checks
 func sanityCheckSafeTensors(p string) (bool, error) {
 	f, err := os.Open(p)
-	if err != nil { return false, err }
+	if err != nil {
+		return false, err
+	}
 	defer f.Close()
 	var hdrLen uint64
-	if err := binary.Read(f, binary.LittleEndian, &hdrLen); err != nil { return false, err }
-	fi, err := f.Stat(); if err != nil { return false, err }
-	if hdrLen == 0 || hdrLen > uint64(fi.Size()) || hdrLen > 64*1024*1024 { return false, fmt.Errorf("invalid safetensors header length: %d", hdrLen) }
+	if err := binary.Read(f, binary.LittleEndian, &hdrLen); err != nil {
+		return false, err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false, err
+	}
+	if hdrLen == 0 || hdrLen > uint64(fi.Size()) || hdrLen > 64*1024*1024 {
+		return false, fmt.Errorf("invalid safetensors header length: %d", hdrLen)
+	}
 	hdr := make([]byte, hdrLen)
-	if _, err := io.ReadFull(f, hdr); err != nil { return false, err }
+	if _, err := io.ReadFull(f, hdr); err != nil {
+		return false, err
+	}
 	var js any
-	if err := json.Unmarshal(hdr, &js); err != nil { return false, err }
+	if err := json.Unmarshal(hdr, &js); err != nil {
+		return false, err
+	}
 	return true, nil
 }
 
@@ -187,50 +262,87 @@ func sanityCheckSafeTensors(p string) (bool, error) {
 // Returns ok, declared_total_size, error (nil if ok)
 func deepVerifySafeTensors(p string) (bool, int64, error) {
 	f, err := os.Open(p)
-	if err != nil { return false, 0, err }
+	if err != nil {
+		return false, 0, err
+	}
 	defer f.Close()
 	fi, err := f.Stat()
-	if err != nil { return false, 0, err }
-	if fi.Size() < 8 { return false, 0, fmt.Errorf("file too small: %d", fi.Size()) }
+	if err != nil {
+		return false, 0, err
+	}
+	if fi.Size() < 8 {
+		return false, 0, fmt.Errorf("file too small: %d", fi.Size())
+	}
 	var hdrLen uint64
-	if err := binary.Read(f, binary.LittleEndian, &hdrLen); err != nil { return false, 0, err }
+	if err := binary.Read(f, binary.LittleEndian, &hdrLen); err != nil {
+		return false, 0, err
+	}
 	if hdrLen == 0 || hdrLen > uint64(fi.Size()-8) || hdrLen > 64*1024*1024 {
 		return false, 0, fmt.Errorf("invalid safetensors header length: %d", hdrLen)
 	}
 	hdr := make([]byte, hdrLen)
-	if _, err := io.ReadFull(f, hdr); err != nil { return false, 0, err }
+	if _, err := io.ReadFull(f, hdr); err != nil {
+		return false, 0, err
+	}
 	var meta map[string]any
-	if err := json.Unmarshal(hdr, &meta); err != nil { return false, 0, fmt.Errorf("header json: %w", err) }
+	if err := json.Unmarshal(hdr, &meta); err != nil {
+		return false, 0, fmt.Errorf("header json: %w", err)
+	}
 	dataLen := fi.Size() - 8 - int64(hdrLen)
-	if dataLen < 0 { return false, 0, fmt.Errorf("negative data length") }
+	if dataLen < 0 {
+		return false, 0, fmt.Errorf("negative data length")
+	}
 	var maxEnd int64
 	for k, v := range meta {
 		lk := strings.ToLower(k)
-		if lk == "metadata" || lk == "__metadata__" { continue }
+		if lk == "metadata" || lk == "__metadata__" {
+			continue
+		}
 		m, ok := v.(map[string]any)
-		if !ok { continue }
+		if !ok {
+			continue
+		}
 		off, ok := m["data_offsets"].([]any)
-		if !ok || len(off) != 2 { continue }
+		if !ok || len(off) != 2 {
+			continue
+		}
 		start, ok1 := toInt64(off[0])
 		end, ok2 := toInt64(off[1])
-		if !ok1 || !ok2 { return false, 0, fmt.Errorf("tensor %q: invalid data_offsets", k) }
-		if start < 0 || end < 0 || end < start { return false, 0, fmt.Errorf("tensor %q: invalid range %d-%d", k, start, end) }
-		if end > dataLen { return false, 0, fmt.Errorf("tensor %q: data end %d beyond data length %d", k, end, dataLen) }
+		if !ok1 || !ok2 {
+			return false, 0, fmt.Errorf("tensor %q: invalid data_offsets", k)
+		}
+		if start < 0 || end < 0 || end < start {
+			return false, 0, fmt.Errorf("tensor %q: invalid range %d-%d", k, start, end)
+		}
+		if end > dataLen {
+			return false, 0, fmt.Errorf("tensor %q: data end %d beyond data length %d", k, end, dataLen)
+		}
 		// Optional: validate dtype/shape size if present
 		if dtRaw, ok := m["dtype"].(string); ok {
 			if shp, ok := m["shape"].([]any); ok {
 				exp := dtypeBytes(dtRaw)
 				if exp > 0 {
 					var cnt int64 = 1
-					for _, dim := range shp { d, ok := toInt64(dim); if !ok || d <= 0 { cnt = 0; break }; cnt *= d }
+					for _, dim := range shp {
+						d, ok := toInt64(dim)
+						if !ok || d <= 0 {
+							cnt = 0
+							break
+						}
+						cnt *= d
+					}
 					if cnt > 0 {
 						sz := end - start
-						if sz != cnt*exp { return false, 0, fmt.Errorf("tensor %q: size %d != %d*%d", k, sz, cnt, exp) }
+						if sz != cnt*exp {
+							return false, 0, fmt.Errorf("tensor %q: size %d != %d*%d", k, sz, cnt, exp)
+						}
 					}
 				}
 			}
 		}
-		if end > maxEnd { maxEnd = end }
+		if end > maxEnd {
+			maxEnd = end
+		}
 	}
 	declared := int64(8) + int64(hdrLen) + maxEnd
 	if fi.Size() < declared {
@@ -244,15 +356,24 @@ func deepVerifySafeTensors(p string) (bool, int64, error) {
 
 func dtypeBytes(dt string) int64 {
 	switch strings.ToUpper(strings.TrimSpace(dt)) {
-	case "F64": return 8
-	case "F32": return 4
-	case "F16", "BF16": return 2
-	case "F8", "F8_E4M3FN", "F8_E5M2": return 1
-	case "I64": return 8
-	case "I32": return 4
-	case "I16": return 2
-	case "I8", "U8", "BOOL": return 1
-	default: return 0
+	case "F64":
+		return 8
+	case "F32":
+		return 4
+	case "F16", "BF16":
+		return 2
+	case "F8", "F8_E4M3FN", "F8_E5M2":
+		return 1
+	case "I64":
+		return 8
+	case "I32":
+		return 4
+	case "I16":
+		return 2
+	case "I8", "U8", "BOOL":
+		return 1
+	default:
+		return 0
 	}
 }
 
@@ -273,18 +394,30 @@ func toInt64(v any) (int64, bool) {
 // If repair is true, trims extra bytes to declared size when encountered.
 // If quarantineIncomplete is true, moves incomplete files to .incomplete.
 func scanSafetensorsDir(root string, deep bool, repair bool, quarantineIncomplete bool) (map[string]any, error) {
-	if root == "" { return nil, errors.New("scan-dir is empty") }
+	if root == "" {
+		return nil, errors.New("scan-dir is empty")
+	}
 	abs, err := filepath.Abs(root)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	out := map[string]any{}
 	walkErr := filepath.WalkDir(abs, func(p string, d os.DirEntry, err error) error {
-		if err != nil { return err }
-		if d.IsDir() { return nil }
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
 		low := strings.ToLower(p)
-		if !(strings.HasSuffix(low, ".safetensors") || strings.HasSuffix(low, ".sft")) { return nil }
+		if !(strings.HasSuffix(low, ".safetensors") || strings.HasSuffix(low, ".sft")) {
+			return nil
+		}
 		ok, need, derr := deepVerifySafeTensors(p)
 		m := map[string]any{"path": p, "safetensors_deep_ok": ok, "safetensors_declared_size": need}
-		if derr != nil { m["safetensors_deep_error"] = derr.Error() }
+		if derr != nil {
+			m["safetensors_deep_error"] = derr.Error()
+		}
 		// Attempt repair if requested
 		if deep && repair && derr != nil && strings.Contains(strings.ToLower(derr.Error()), "extra bytes") && need > 0 {
 			fi, statErr := os.Stat(p)
@@ -297,7 +430,11 @@ func scanSafetensorsDir(root string, deep bool, repair bool, quarantineIncomplet
 						ok2, need2, derr2 := deepVerifySafeTensors(p)
 						m["safetensors_deep_ok"] = ok2
 						m["safetensors_declared_size"] = need2
-						if derr2 != nil { m["safetensors_deep_error"] = derr2.Error() } else { delete(m, "safetensors_deep_error") }
+						if derr2 != nil {
+							m["safetensors_deep_error"] = derr2.Error()
+						} else {
+							delete(m, "safetensors_deep_error")
+						}
 					}
 					_ = f.Close()
 				}
@@ -312,7 +449,9 @@ func scanSafetensorsDir(root string, deep bool, repair bool, quarantineIncomplet
 		out[p] = m
 		return nil
 	})
-	if walkErr != nil { return nil, walkErr }
+	if walkErr != nil {
+		return nil, walkErr
+	}
 	return out, nil
 }
 
@@ -320,13 +459,20 @@ func scanSafetensorsDir(root string, deep bool, repair bool, quarantineIncomplet
 func equalFoldHex(a, b string) bool {
 	a = strings.TrimSpace(a)
 	b = strings.TrimSpace(b)
-	if len(a) != len(b) { return false }
+	if len(a) != len(b) {
+		return false
+	}
 	for i := 0; i < len(a); i++ {
 		ca, cb := a[i], b[i]
-		if ca >= 'A' && ca <= 'F' { ca += 32 }
-		if cb >= 'A' && cb <= 'F' { cb += 32 }
-		if ca != cb { return false }
+		if ca >= 'A' && ca <= 'F' {
+			ca += 32
+		}
+		if cb >= 'A' && cb <= 'F' {
+			cb += 32
+		}
+		if ca != cb {
+			return false
+		}
 	}
 	return true
 }
-

--- a/internal/downloader/single.go
+++ b/internal/downloader/single.go
@@ -24,23 +24,31 @@ import (
 func probeRangeGET(client *http.Client, url string, headers map[string]string, ua string) (size int64, ok bool) {
 	req, _ := http.NewRequest(http.MethodGet, url, nil)
 	req.Header.Set("User-Agent", ua)
-	for k, v := range headers { req.Header.Set(k, v) }
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 	req.Header.Set("Range", "bytes=0-0")
 	resp, err := client.Do(req)
-	if err != nil { return 0, false }
+	if err != nil {
+		return 0, false
+	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusPartialContent { return 0, false }
+	if resp.StatusCode != http.StatusPartialContent {
+		return 0, false
+	}
 	cr := resp.Header.Get("Content-Range")
 	var s, e, total int64
-	if _, err := fmt.Sscanf(cr, "bytes %d-%d/%d", &s, &e, &total); err != nil || total <= 0 { return 0, false }
+	if _, err := fmt.Sscanf(cr, "bytes %d-%d/%d", &s, &e, &total); err != nil || total <= 0 {
+		return 0, false
+	}
 	return total, true
 }
 
 type Single struct {
-	cfg    *config.Config
-	log    *logging.Logger
-	client *http.Client
-	st     *state.DB
+	cfg     *config.Config
+	log     *logging.Logger
+	client  *http.Client
+	st      *state.DB
 	metrics interface {
 		AddBytes(int64)
 		IncDownloadsSuccess()
@@ -49,16 +57,21 @@ type Single struct {
 	}
 }
 
-func NewSingle(cfg *config.Config, log *logging.Logger, st *state.DB, m interface{ AddBytes(int64); IncDownloadsSuccess(); ObserveDownloadSeconds(float64); Write() error }) *Single {
+func NewSingle(cfg *config.Config, log *logging.Logger, st *state.DB, m interface {
+	AddBytes(int64)
+	IncDownloadsSuccess()
+	ObserveDownloadSeconds(float64)
+	Write() error
+}) *Single {
 	timeout := time.Duration(cfg.Network.TimeoutSeconds) * time.Second
 	if timeout <= 0 {
 		timeout = 60 * time.Second
 	}
 	return &Single{
-		cfg: cfg,
-		log: log,
-		st:  st,
-		client: newHTTPClient(cfg),
+		cfg:     cfg,
+		log:     log,
+		st:      st,
+		client:  newHTTPClient(cfg),
 		metrics: m,
 	}
 }
@@ -66,16 +79,29 @@ func NewSingle(cfg *config.Config, log *logging.Logger, st *state.DB, m interfac
 // Download downloads a single file from url to destPath. If destPath is empty, it uses cfg.General.DownloadRoot + last URL segment.
 // It resumes if a .part file exists and the server supports Range requests.
 func (s *Single) Download(ctx context.Context, url, destPath, expectedSHA string, headers map[string]string, noResume bool) (string, string, error) {
-	if url == "" { return "", "", errors.New("url required") }
+	if url == "" {
+		return "", "", errors.New("url required")
+	}
 	if destPath == "" {
 		seg := lastURLSegment(url)
-		if seg == "" { return "", "", errors.New("cannot infer destination filename") }
+		if seg == "" {
+			return "", "", errors.New("cannot infer destination filename")
+		}
 		destPath = filepath.Join(s.cfg.General.DownloadRoot, seg)
 	}
-	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil { return "", "", err }
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return "", "", err
+	}
 	startTime := time.Now()
 	// metrics: mark active
-	if a, ok := s.metrics.(interface{ IncActive(int64); Write() error }); ok { a.IncActive(1); _ = a.Write(); defer func(){ a.IncActive(-1); _ = a.Write() }() }
+	if a, ok := s.metrics.(interface {
+		IncActive(int64)
+		Write() error
+	}); ok {
+		a.IncActive(1)
+		_ = a.Write()
+		defer func() { a.IncActive(-1); _ = a.Write() }()
+	}
 
 	part := stagePartPath(s.cfg, url, destPath)
 	if noResume {
@@ -88,6 +114,15 @@ func (s *Single) Download(ctx context.Context, url, destPath, expectedSHA string
 	s.log.Debugf("HEAD: etag=%s last-mod=%s size=%d range=%v", etag, lastMod, size, rangeOK)
 	_ = s.st.UpsertDownload(state.DownloadRow{URL: url, Dest: destPath, ExpectedSHA256: expectedSHA, ETag: etag, LastModified: lastMod, Size: size, Status: "planning"})
 
+	// Cleanup on cancellation
+	defer func() {
+		if ctx.Err() != nil {
+			_ = os.Remove(part)
+			_ = s.st.DeleteChunks(url, destPath)
+			_ = s.st.UpsertDownload(state.DownloadRow{URL: url, Dest: destPath, ExpectedSHA256: expectedSHA, ActualSHA256: "", ETag: etag, LastModified: lastMod, Size: size, Status: "canceled"})
+		}
+	}()
+
 	// Prepare hasher and file
 	var hasher = sha256.New()
 	var start int64 = 0
@@ -98,26 +133,47 @@ func (s *Single) Download(ctx context.Context, url, destPath, expectedSHA string
 		s.log.Infof("resuming: %s (have %d bytes)", part, start)
 		// Prime hasher with existing bytes
 		f, err := os.Open(part)
-		if err != nil { return "", "", err }
-		if _, err := io.Copy(hasher, f); err != nil { _ = f.Close(); return "", "", err }
+		if err != nil {
+			return "", "", err
+		}
+		if _, err := io.Copy(hasher, f); err != nil {
+			_ = f.Close()
+			return "", "", err
+		}
 		_ = f.Close()
 	}
 
 	// Open file for append/create
 	f, err := os.OpenFile(part, os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil { return "", "", err }
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", "", ctx.Err()
+		}
+		return "", "", err
+	}
 	defer f.Close()
-	if _, err := f.Seek(start, io.SeekStart); err != nil { return "", "", err }
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return "", "", err
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil { return "", "", err }
+	if err != nil {
+		return "", "", err
+	}
 	req.Header.Set("User-Agent", userAgent(s.cfg))
-	for k, v := range headers { req.Header.Set(k, v) }
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 	if start > 0 && rangeOK {
 		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", start))
 	}
 	resp, err := s.client.Do(req)
-	if err != nil { return "", "", err }
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", "", ctx.Err()
+		}
+		return "", "", err
+	}
 	defer resp.Body.Close()
 
 	// Mark as running once we have a good response
@@ -128,8 +184,12 @@ func (s *Single) Download(ctx context.Context, url, destPath, expectedSHA string
 	if start > 0 && resp.StatusCode == http.StatusOK {
 		// Server ignored Range; restart from 0
 		s.log.Warnf("server ignored Range; restarting from beginning")
-		if _, err := f.Seek(0, io.SeekStart); err != nil { return "", "", err }
-		if err := f.Truncate(0); err != nil { return "", "", err }
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return "", "", err
+		}
+		if err := f.Truncate(0); err != nil {
+			return "", "", err
+		}
 		hasher = sha256.New()
 		start = 0
 	}
@@ -138,16 +198,27 @@ func (s *Single) Download(ctx context.Context, url, destPath, expectedSHA string
 		if resp.StatusCode == http.StatusRequestedRangeNotSatisfiable && size > 0 && start >= size {
 			s.log.Infof("server returned 416 but local part matches remote size; finalizing")
 			_ = f.Sync()
-			if err := renameOrCopy(part, destPath); err != nil { return "", "", err }
+			if err := renameOrCopy(part, destPath); err != nil {
+				return "", "", err
+			}
 			_ = os.Remove(part)
-			if _, err := adjustSafetensors(destPath, s.log); err != nil { return "", "", err }
+			if _, err := adjustSafetensors(destPath, s.log); err != nil {
+				return "", "", err
+			}
 			ff, err := os.Open(destPath)
-			if err != nil { return "", "", err }
+			if err != nil {
+				return "", "", err
+			}
 			h := sha256.New()
-			if _, err := io.Copy(h, ff); err != nil { _ = ff.Close(); return "", "", err }
+			if _, err := io.Copy(h, ff); err != nil {
+				_ = ff.Close()
+				return "", "", err
+			}
 			_ = ff.Close()
 			actualSHA := hex.EncodeToString(h.Sum(nil))
-			if err := writeAndSync(destPath+".sha256", []byte(actualSHA+"  "+filepath.Base(destPath)+"\n")); err != nil { return "", "", err }
+			if err := writeAndSync(destPath+".sha256", []byte(actualSHA+"  "+filepath.Base(destPath)+"\n")); err != nil {
+				return "", "", err
+			}
 			_ = fsyncDir(filepath.Dir(destPath))
 			_ = s.st.UpsertDownload(state.DownloadRow{URL: url, Dest: destPath, ExpectedSHA256: expectedSHA, ActualSHA256: actualSHA, ETag: etag, LastModified: lastMod, Size: size, Status: "complete"})
 			if s.metrics != nil {
@@ -159,10 +230,14 @@ func (s *Single) Download(ctx context.Context, url, destPath, expectedSHA string
 		}
 		// Provide friendlier hints for auth/permission statuses and persist error status
 		host := ""
-		if u, _ := neturl.Parse(url); u != nil { host = strings.ToLower(u.Hostname()) }
+		if u, _ := neturl.Parse(url); u != nil {
+			host = strings.ToLower(u.Hostname())
+		}
 		hadAuth := false
-		if _, ok := headers["Authorization"]; ok && strings.TrimSpace(headers["Authorization"]) != "" { hadAuth = true }
-msg := friendlyHTTPStatusMessage(s.cfg, host, resp.StatusCode, resp.Status, hadAuth)
+		if _, ok := headers["Authorization"]; ok && strings.TrimSpace(headers["Authorization"]) != "" {
+			hadAuth = true
+		}
+		msg := friendlyHTTPStatusMessage(s.cfg, host, resp.StatusCode, resp.Status, hadAuth)
 		_ = s.st.UpsertDownload(state.DownloadRow{URL: url, Dest: destPath, ExpectedSHA256: expectedSHA, ActualSHA256: "", ETag: etag, LastModified: lastMod, Size: size, Status: "error", LastError: msg})
 		return "", "", fmt.Errorf(msg)
 	}
@@ -170,14 +245,22 @@ msg := friendlyHTTPStatusMessage(s.cfg, host, resp.StatusCode, resp.Status, hadA
 	// Do not preallocate for single-stream so that .part size reflects real progress
 	mw := io.MultiWriter(f, hasher)
 	nWritten, err := io.Copy(mw, resp.Body)
-	if s.metrics != nil && nWritten > 0 { s.metrics.AddBytes(nWritten) }
+	if s.metrics != nil && nWritten > 0 {
+		s.metrics.AddBytes(nWritten)
+	}
 	if err != nil {
-ioMsg := friendlyIOError(err).Error()
+		if ctx.Err() != nil {
+			return "", "", ctx.Err()
+		}
+		ioMsg := friendlyIOError(err).Error()
 		_ = s.st.UpsertDownload(state.DownloadRow{URL: url, Dest: destPath, ExpectedSHA256: expectedSHA, ActualSHA256: "", ETag: etag, LastModified: lastMod, Size: size, Status: "error", LastError: ioMsg})
 		return "", "", fmt.Errorf(ioMsg)
 	}
 	// Ensure file data is durable before rename
 	_ = f.Sync()
+	if ctx.Err() != nil {
+		return "", "", ctx.Err()
+	}
 
 	actualSHA := hex.EncodeToString(hasher.Sum(nil))
 	if expectedSHA != "" && !equalSHA(expectedSHA, actualSHA) {
@@ -186,10 +269,14 @@ ioMsg := friendlyIOError(err).Error()
 	}
 
 	// Move to final (cross-filesystem safe)
-	if err := renameOrCopy(part, destPath); err != nil { return "", "", err }
+	if err := renameOrCopy(part, destPath); err != nil {
+		return "", "", err
+	}
 	_ = os.Remove(part)
 	// If safetensors, trim any trailing bytes beyond header-declared size (and fail if incomplete)
-	if _, err := adjustSafetensors(destPath, s.log); err != nil { return "", "", err }
+	if _, err := adjustSafetensors(destPath, s.log); err != nil {
+		return "", "", err
+	}
 	// Optional deep verify for safetensors
 	if s.cfg.Validation.SafetensorsDeepVerifyAfterDownload && (strings.HasSuffix(strings.ToLower(destPath), ".safetensors") || strings.HasSuffix(strings.ToLower(destPath), ".sft")) {
 		ok, _, verr := deepVerifySafetensors(destPath)
@@ -201,9 +288,14 @@ ioMsg := friendlyIOError(err).Error()
 	// Recompute SHA after any adjustment
 	{
 		ff, err := os.Open(destPath)
-		if err != nil { return "", "", err }
+		if err != nil {
+			return "", "", err
+		}
 		h := sha256.New()
-		if _, err := io.Copy(h, ff); err != nil { _ = ff.Close(); return "", "", err }
+		if _, err := io.Copy(h, ff); err != nil {
+			_ = ff.Close()
+			return "", "", err
+		}
 		_ = ff.Close()
 		actualSHA = hex.EncodeToString(h.Sum(nil))
 	}
@@ -225,7 +317,9 @@ ioMsg := friendlyIOError(err).Error()
 func (s *Single) head(ctx context.Context, url string, headers map[string]string) (etag, lastMod string, size int64, rangeOK bool) {
 	req, _ := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
 	req.Header.Set("User-Agent", userAgent(s.cfg))
-	for k, v := range headers { req.Header.Set(k, v) }
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 	resp, err := s.client.Do(req)
 	if err == nil {
 		defer resp.Body.Close()
@@ -262,7 +356,6 @@ func equalSHA(exp, got string) bool {
 	return strings.EqualFold(strings.TrimSpace(exp), strings.TrimSpace(got))
 }
 
-
 func friendlyIOError(err error) error {
 	// Map ENOSPC to a friendlier message
 	if errors.Is(err, os.ErrClosed) {
@@ -275,4 +368,3 @@ func friendlyIOError(err error) error {
 	}
 	return err
 }
-


### PR DESCRIPTION
## Summary
- establish a root context that listens for SIGINT/SIGTERM and propagate it to all CLI subcommands
- downloader workers watch `ctx.Done()` and remove partial files when cancelled
- document signal handling and Ctrl+C cleanup behavior

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b46bde4c1c832cb1ecae03eb853bee