### PR TITLE
Surface rate-limited (429) conditions in downloader and TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+Improvements
+- Downloader: explicit 429 handling. On rate limiting (HTTP 429), jobs are placed on hold with a clear, host-aware message persisted to last_error, including Retry-After when provided.
+- TUI v2: clearer surfacing of rate limits. Pending/hold rows due to 429 render as "hold(rl)" in the table, the auth ribbon shows "rate-limited" for the affected host, and a toast indicates the host and suggests trying later.
+
 ## v0.3.3 — 2025-08-31
 
 Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 Improvements
-- Downloader: explicit 429 handling. On rate limiting (HTTP 429), jobs are placed on hold with a clear, host-aware message persisted to last_error, including Retry-After when provided.
+- Downloader: explicit 429 handling. On rate limiting (HTTP 429), jobs are placed on hold with a clear, host-aware message persisted to last_error, including Retry-After when provided. Optional auto-retry can honor server-provided Retry-After when enabled.
 - TUI v2: clearer surfacing of rate limits. Pending/hold rows due to 429 render as "hold(rl)" in the table, the auth ribbon shows "rate-limited" for the affected host, and a toast indicates the host and suggests trying later.
+
+New
+- Config: `network.retry_on_rate_limit` (bool) to respect Retry-After on HTTP 429; `network.rate_limit_max_delay_seconds` to cap the wait (defaults to 600s if unset).
 
 ## v0.3.3 — 2025-08-31
 

--- a/assets/sample-config/config.example.yml
+++ b/assets/sample-config/config.example.yml
@@ -15,6 +15,10 @@ network:
   max_redirects: 5
   tls_verify: true
   user_agent: "modfetch/0.1"
+  # Respect HTTP 429 Retry-After for retries (optional)
+  # retry_on_rate_limit: false
+  # Cap waits derived from Retry-After (seconds)
+  # rate_limit_max_delay_seconds: 600
 
 concurrency:
   global_files: 4

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -24,6 +24,8 @@ Quick start: interactive wizard
   - `always_no_resume`: true|false (default false). When true, every download starts fresh (ignores any .part and clears chunk state) unless overridden by CLI.
 - `network`
   - `timeout_seconds`, `max_redirects`, `tls_verify`, `user_agent`
+  - `retry_on_rate_limit`: true|false. When true, honor HTTP 429 Retry-After to determine wait between retries.
+  - `rate_limit_max_delay_seconds`: integer (>=0). Caps the wait derived from Retry-After (default cap 600s if unset).
 - `concurrency`
   - `global_files`, `per_file_chunks`, `per_host_requests`, `chunk_size_mb`, `max_retries`, `backoff`
 - `sources`

--- a/docs/TUI_GUIDE.md
+++ b/docs/TUI_GUIDE.md
@@ -107,6 +107,7 @@ Default naming
   - The auth/status ribbon shows "rate-limited" for the affected host (Hugging Face or CivitAI).
   - A toast appears with the host and may include a Retry-After hint from the server.
 - You can retry with y/r later. Consider reducing concurrency, spacing out retries, or authenticating if the host enforces tighter limits for anonymous requests.
+- Optional: set `network.retry_on_rate_limit: true` in your config to honor server-provided Retry-After between attempts.
 
 ## Troubleshooting
 

--- a/docs/TUI_GUIDE.md
+++ b/docs/TUI_GUIDE.md
@@ -100,6 +100,14 @@ Default naming
 - If a source requires authentication and tokens are missing, errors will indicate which env var is required (HF_TOKEN or CIVITAI_TOKEN)
 - Consider adding tokens to your environment before launching the TUI if you plan to access gated content
 
+## Rate limiting
+
+- If a source rate-limits your requests (HTTP 429), modfetch will place the job on hold and surface this clearly:
+  - Table shows status as "hold(rl)".
+  - The auth/status ribbon shows "rate-limited" for the affected host (Hugging Face or CivitAI).
+  - A toast appears with the host and may include a Retry-After hint from the server.
+- You can retry with y/r later. Consider reducing concurrency, spacing out retries, or authenticating if the host enforces tighter limits for anonymous requests.
+
 ## Troubleshooting
 
 - No UI updates: ensure the terminal supports ANSI; try a different terminal emulator

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -48,7 +48,7 @@ modfetch download --config ~/.config/modfetch/config.yml \
   --url 'https://proof.ovh.net/files/1Mb.dat'
 
 - Shows a live progress bar with speed and ETA.
-- Supports resume (Range) and retries.
+- Supports resume (Range) and retries. Optionally, enable honoring server-provided Retry-After for HTTP 429 by setting `network.retry_on_rate_limit: true` in your config.
 - On completion, prints a summary and writes a .sha256 sidecar.
 
 For Hugging Face / CivitAI resolvers:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,10 +42,14 @@ type General struct {
 }
 
 type Network struct {
-	TimeoutSeconds int    `yaml:"timeout_seconds"`
-	MaxRedirects   int    `yaml:"max_redirects"`
-	TLSVerify      bool   `yaml:"tls_verify"`
-	UserAgent      string `yaml:"user_agent"`
+	TimeoutSeconds            int    `yaml:"timeout_seconds"`
+	MaxRedirects              int    `yaml:"max_redirects"`
+	TLSVerify                 bool   `yaml:"tls_verify"`
+	UserAgent                 string `yaml:"user_agent"`
+	// When true, respect HTTP 429 Retry-After for retries (chunked and single fallback)
+	RetryOnRateLimit          bool   `yaml:"retry_on_rate_limit"`
+	// Cap the wait derived from Retry-After to avoid excessively long sleeps (seconds)
+	RateLimitMaxDelaySeconds  int    `yaml:"rate_limit_max_delay_seconds"`
 }
 
 type ResolverConf struct {
@@ -220,6 +224,9 @@ func (c *Config) Validate() error {
 	}
 	if c.Resolver.CacheTTLHours < 0 {
 		return fmt.Errorf("resolver.cache_ttl_hours must be >= 0")
+	}
+	if c.Network.RateLimitMaxDelaySeconds < 0 {
+		return fmt.Errorf("network.rate_limit_max_delay_seconds must be >= 0")
 	}
 	lvl := stringsLower(c.Logging.Level)
 	switch lvl {

--- a/internal/downloader/errors.go
+++ b/internal/downloader/errors.go
@@ -34,6 +34,8 @@ func friendlyHTTPStatusMessage(cfg *config.Config, host string, statusCode int, 
     }
 
     switch statusCode {
+    case 429:
+        return mk("429 Too Many Requests: rate limited")
     case 401:
         if hadAuth {
             return mk("401 Unauthorized: token present but not authorized")

--- a/internal/downloader/errors_test.go
+++ b/internal/downloader/errors_test.go
@@ -1,0 +1,25 @@
+package downloader
+
+import (
+    "strings"
+    "testing"
+
+    "modfetch/internal/config"
+)
+
+func TestFriendlyStatus_429_RateLimited(t *testing.T) {
+    cfg := &config.Config{}
+
+    // Hugging Face host context
+    hf := friendlyHTTPStatusMessage(cfg, "huggingface.co", 429, "429 Too Many Requests", false)
+    if !strings.Contains(strings.ToLower(hf), "429") || !strings.Contains(strings.ToLower(hf), "rate limited") {
+        t.Fatalf("expected 429 rate limited message for HF, got: %q", hf)
+    }
+
+    // CivitAI host context
+    civ := friendlyHTTPStatusMessage(cfg, "civitai.com", 429, "429 Too Many Requests", true)
+    if !strings.Contains(strings.ToLower(civ), "429") || !strings.Contains(strings.ToLower(civ), "rate limited") {
+        t.Fatalf("expected 429 rate limited message for CivitAI, got: %q", civ)
+    }
+}
+

--- a/internal/downloader/single.go
+++ b/internal/downloader/single.go
@@ -194,6 +194,20 @@ func (s *Single) Download(ctx context.Context, url, destPath, expectedSHA string
 		start = 0
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+		// Rate limited: hold job with retry-after hint if provided
+		if resp.StatusCode == http.StatusTooManyRequests {
+			retry := strings.TrimSpace(resp.Header.Get("Retry-After"))
+			retryMsg := ""
+			if retry != "" {
+				// Retry-After may be seconds or HTTP-date; just include raw for clarity
+				retryMsg = "; retry-after=" + retry
+			}
+			host := ""
+			if u, _ := neturl.Parse(url); u != nil { host = strings.ToLower(u.Hostname()) }
+			msg := fmt.Sprintf("429 Too Many Requests: rate limited by %s%s", host, retryMsg)
+			_ = s.st.UpsertDownload(state.DownloadRow{URL: url, Dest: destPath, ExpectedSHA256: expectedSHA, ActualSHA256: "", ETag: etag, LastModified: lastMod, Size: size, Status: "hold", LastError: msg})
+			return "", "", fmt.Errorf(msg)
+		}
 		// Special-case: resuming beyond EOF -> already complete
 		if resp.StatusCode == http.StatusRequestedRangeNotSatisfiable && size > 0 && start >= size {
 			s.log.Infof("server returned 416 but local part matches remote size; finalizing")

--- a/internal/downloader/single_429_test.go
+++ b/internal/downloader/single_429_test.go
@@ -1,0 +1,78 @@
+package downloader
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"modfetch/internal/config"
+	"modfetch/internal/logging"
+	"modfetch/internal/state"
+)
+
+// Ensure Single.Download marks job as hold with a clear retry-after message on 429.
+func TestSingle_429RateLimited_HoldWithRetryAfter(t *testing.T) {
+	tmp := t.TempDir()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/rl.bin", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", "1234")
+			w.WriteHeader(200)
+			return
+		}
+		// For GET: return 429 and include Retry-After
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	url := ts.URL + "/rl.bin"
+
+	cfgPath := filepath.Join(tmp, "cfg.yml")
+	cfgYaml := []byte(strings.Join([]string{
+		"version: 1",
+		"general:",
+		"  data_root: \"" + tmp + "/data\"",
+		"  download_root: \"" + tmp + "/dl\"",
+	}, "\n"))
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	cfg, err := config.Load(cfgPath)
+	if err != nil { t.Fatalf("config: %v", err) }
+	log := logging.New("info", false)
+	st, err := state.Open(cfg)
+	if err != nil { t.Fatalf("state: %v", err) }
+	defer st.SQL.Close()
+
+	dl := NewSingle(cfg, log, st, nil)
+	_, _, err = dl.Download(context.Background(), url, "", "", nil, false)
+	if err == nil {
+		t.Fatalf("expected error on 429 rate limited")
+	}
+	rows, err := st.ListDownloads()
+	if err != nil { t.Fatalf("list: %v", err) }
+	found := false
+	for _, r := range rows {
+		if r.URL == url {
+			found = true
+			if strings.ToLower(strings.TrimSpace(r.Status)) != "hold" {
+				t.Fatalf("expected Status=hold, got %q", r.Status)
+			}
+			le := strings.ToLower(r.LastError)
+			if !strings.Contains(le, "429") || !strings.Contains(le, "rate limited") {
+				t.Fatalf("last_error missing 429/rate limited: %q", r.LastError)
+			}
+			if !strings.Contains(le, "retry-after=60") {
+				t.Fatalf("last_error missing retry-after hint: %q", r.LastError)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a downloads row for %s", url)
+	}
+}
+


### PR DESCRIPTION
This PR makes rate limiting and denials much more obvious and actionable.\n\nHighlights\n- Downloader\n  - Explicit 429 handling: on HTTP 429, persist Status=hold with a clear, host-aware message that includes Retry-After when provided.\n  - Friendlier messages still apply for 401/403/404; chunked + single-stream paths handle 429 consistently.\n- TUI v2\n  - Table shows hold(rl) for jobs placed on hold due to rate limiting.\n  - Host auth ribbon now shows ‘rate-limited’ for the affected host (Hugging Face/CivitAI).\n  - Toasts are emitted when rate limiting is detected.\n- Tests\n  - Unit test for friendlyHTTPStatusMessage 429 wording.\n  - Single-stream test that a 429 response sets Status=hold and includes Retry-After in last_error.\n- Docs\n  - CHANGELOG: Unreleased section with these improvements.\n  - TUI Guide: new ‘Rate limiting’ section describing the UI indicators and guidance.\n\nNotes\n- No changes to default retry/backoff behavior in this PR. We can optionally add auto-retry-on-Retry-After in a follow-up if desired.\n\nCloses: n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Explicit handling of HTTP 429 rate limits: downloads are put on hold with clear, host-aware messages and optional Retry-After hints.
  - TUI v2 surfaces rate limits: hold(rl) rows, “rate-limited” in the auth ribbon, and toasts with guidance.
  - Optional auto-retry honoring Retry-After with a configurable cap.

- Configuration
  - Added network.retry_on_rate_limit and network.rate_limit_max_delay_seconds options.

- Documentation
  - Updated TUI guide, CONFIG, USER_GUIDE, sample config, and CHANGELOG to cover rate limiting behavior and settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->