### PR TITLE
Polish: friendly 429 messaging, tests, docs, and state index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 Improvements
-- Downloader: explicit 429 handling. On rate limiting (HTTP 429), jobs are placed on hold with a clear, host-aware message persisted to last_error, including Retry-After when provided. Optional auto-retry can honor server-provided Retry-After when enabled.
-- TUI v2: clearer surfacing of rate limits. Pending/hold rows due to 429 render as "hold(rl)" in the table, the auth ribbon shows "rate-limited" for the affected host, and a toast indicates the host and suggests trying later.
+- Downloader: explicit 429 handling. On rate limiting (HTTP 429), jobs are placed on hold with a clear, host-aware message persisted to `last_error`, including `Retry-After` when provided. Optional auto-retry honors server-provided `Retry-After` when `network.retry_on_rate_limit` is enabled.
+- TUI v2: clearer surfacing of rate limits. Rows placed on hold due to 429 render as `hold(rl)` in the table; the auth ribbon shows `rate-limited` for the affected host; a toast indicates the host and suggests trying later.
 
 New
-- Config: `network.retry_on_rate_limit` (bool) to respect Retry-After on HTTP 429; `network.rate_limit_max_delay_seconds` to cap the wait (defaults to 600s if unset).
+- Config: `network.retry_on_rate_limit` (bool) to respect `Retry-After` on HTTP 429; `network.rate_limit_max_delay_seconds` to cap the wait (defaults to 600s if unset; 0 uses the default).
 
 ## v0.3.3 — 2025-08-31
 

--- a/docs/TUI_GUIDE.md
+++ b/docs/TUI_GUIDE.md
@@ -17,11 +17,7 @@ export MODFETCH_CONFIG=~/.config/modfetch/config.yml
 modfetch tui
 ```
 
-- Preview the next‑gen TUI v2 (experimental):
-
-```bash
-modfetch tui --config /path/to/config.yml --v2
-```
+<!-- TUI v2 is the default; no flag required -->
 
 ## Layout overview
 
@@ -41,7 +37,7 @@ Row columns include status, progress, speed, ETA, size, and destination path.
 
 Notes:
 - Ephemeral rows are keyed by URL|Dest to avoid collisions and are cleared precisely when the corresponding DB row completes.
-- CivitAI model page URLs (https://civitai.com/models/ID) are accepted and auto-resolved to a direct file URL.
+- Civitai model page URLs (https://civitai.com/models/ID) are accepted and auto-resolved to a direct file URL.
 
 ## Keybindings
 
@@ -73,7 +69,7 @@ Default naming
 - The TUI derives a safe default destination inside your configured download_root.
 - For civitai:// URIs, it uses the resolver’s SuggestedFilename (`<ModelName> - <OriginalFileName>`) with collision-safe suffixes when needed.
 - For direct URLs, it uses the clean basename of the final URL (query/fragment stripped, sanitized).
-- For CivitAI direct download endpoints (`https://civitai.com/api/download/...`), the TUI tries a HEAD request to use the server-provided filename (Content-Disposition) when available; otherwise it falls back to the clean basename.
+- For Civitai direct download endpoints (`https://civitai.com/api/download/...`), the TUI tries a HEAD request to use the server-provided filename (`Content-Disposition`) when available; otherwise it falls back to the clean basename.
 
 - Press n to open the new-download modal
 - Paste a URL (hf://org/repo/path?rev=... or civitai://model/ID[?file=...]) or a public HTTP/HTTPS URL
@@ -102,12 +98,12 @@ Default naming
 
 ## Rate limiting
 
-- If a source rate-limits your requests (HTTP 429), modfetch will place the job on hold and surface this clearly:
-  - Table shows status as "hold(rl)".
-  - The auth/status ribbon shows "rate-limited" for the affected host (Hugging Face or CivitAI).
-  - A toast appears with the host and may include a Retry-After hint from the server.
-- You can retry with y/r later. Consider reducing concurrency, spacing out retries, or authenticating if the host enforces tighter limits for anonymous requests.
-- Optional: set `network.retry_on_rate_limit: true` in your config to honor server-provided Retry-After between attempts.
+- If a source rate-limits your requests (HTTP 429), modfetch places the job on hold and surfaces this clearly:
+  - Table shows status as `hold(rl)`.
+  - The auth/status ribbon shows `rate-limited` for the affected host (Hugging Face or Civitai).
+  - A toast appears with the host and may include a `Retry-After` hint from the server.
+- You can retry with `y` or `r` later. Consider reducing concurrency, spacing out retries, or authenticating if the host enforces tighter limits for anonymous requests.
+- Optional: set `network.retry_on_rate_limit: true` in your config to honor server-provided `Retry-After` between attempts.
 
 ## Troubleshooting
 

--- a/internal/downloader/errors_test.go
+++ b/internal/downloader/errors_test.go
@@ -9,17 +9,23 @@ import (
 
 func TestFriendlyStatus_429_RateLimited(t *testing.T) {
     cfg := &config.Config{}
-
-    // Hugging Face host context
-    hf := friendlyHTTPStatusMessage(cfg, "huggingface.co", 429, "429 Too Many Requests", false)
-    if !strings.Contains(strings.ToLower(hf), "429") || !strings.Contains(strings.ToLower(hf), "rate limited") {
-        t.Fatalf("expected 429 rate limited message for HF, got: %q", hf)
+    cases := []struct{
+        name string
+        host string
+        hadAuth bool
+    }{
+        {"HF anon", "huggingface.co", false},
+        {"Civitai authed", "civitai.com", true},
+        {"Generic host", "example.com", false},
     }
-
-    // CivitAI host context
-    civ := friendlyHTTPStatusMessage(cfg, "civitai.com", 429, "429 Too Many Requests", true)
-    if !strings.Contains(strings.ToLower(civ), "429") || !strings.Contains(strings.ToLower(civ), "rate limited") {
-        t.Fatalf("expected 429 rate limited message for CivitAI, got: %q", civ)
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            out := friendlyHTTPStatusMessage(cfg, tc.host, 429, "429 Too Many Requests", tc.hadAuth)
+            lo := strings.ToLower(out)
+            if !strings.Contains(lo, "429") || !strings.Contains(lo, "rate limited") {
+                t.Fatalf("expected 429 rate limited message for %s, got: %q", tc.host, out)
+            }
+        })
     }
 }
 


### PR DESCRIPTION
This PR applies CodeRabbit follow-ups post-#33.\n\nChanges\n- friendlyHTTPStatusMessage\n  - Default: return server-provided status text verbatim (no "unexpected status").\n  - 429: neutral base message (no auth hint): "429 Too Many Requests: rate limited".\n  - Civitai branding in 401/403/404 guidance.\n- Retry-After parsing\n  - parseRetryAfter uses strconv.Atoi for delta-seconds; retains HTTP-date support.\n- Tests\n  - errors_test: table-driven 429 coverage across hosts (HF anon, Civitai authed, generic).\n- TUI docs\n  - docs/TUI_GUIDE: remove v2 preview block, code-quote literal statuses/keys, use Civitai branding.\n- Changelog\n  - Unreleased: code-format keys and clarify that auto-retry honors Retry-After when network.retry_on_rate_limit is enabled.\n- State\n  - Add index on downloads(updated_at).\n  - UpdateDownloadStatus returns sql.ErrNoRows when no row was updated.\n\nAll tests pass: go test ./...\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Optional auto-retry on HTTP 429 now honors server Retry-After when `network.retry_on_rate_limit` is enabled; wait capped by `network.rate_limit_max_delay_seconds` (defaults 600s; 0 uses default).
* Improvements
  * Clearer rate-limit handling: held rows display as `hold(rl)`, auth ribbon shows `rate-limited` for the host, and a toast advises trying later. Error text is clearer and preserves raw status.
* Documentation
  * TUI v2 is now the default (no flag). Branding/casing cleanup and consistent inline code formatting. Config docs updated for the new rate-limit options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->