### PR TITLE
Increase default chunk size to 16MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ network:
   timeout_seconds: 60
 concurrency:
   per_file_chunks: 4
-  chunk_size_mb: 8
+  chunk_size_mb: 16
 sources:
   huggingface: { enabled: true, token_env: "HF_TOKEN" }
   civitai:     { enabled: true, token_env: "CIVITAI_TOKEN" }

--- a/assets/sample-config/config.example.yml
+++ b/assets/sample-config/config.example.yml
@@ -24,7 +24,7 @@ concurrency:
   global_files: 4
   per_file_chunks: 4
   per_host_requests: 8
-  chunk_size_mb: 8
+  chunk_size_mb: 16
   max_retries: 8
   backoff:
     min_ms: 200

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -133,7 +133,6 @@ This document tracks the backlog of enhancements, grouped by priority. It mirror
 
 - Add `--dry-run` flag to download command
 - Add `--force` flag to skip SHA256 verification
-- Increase default chunk size to 16MB (better for modern connections)
 - Add download time estimation to CLI output
 - Fix TUI selected item persistence when filtering
 - Add Ctrl+C graceful shutdown handler

--- a/internal/tui/configwizard/wizard.go
+++ b/internal/tui/configwizard/wizard.go
@@ -58,7 +58,7 @@ func New(defaults *config.Config) *Wizard {
 	fields = append(fields, mk("sources.civitai.enabled (true|false)", cvEn))
 	fields = append(fields, mk("sources.civitai.token_env", cvTok))
 	// chunk params
-	csm := 8
+	csm := 16
 	pfc := 4
 	if defaults != nil {
 		if defaults.Concurrency.ChunkSizeMB > 0 { csm = defaults.Concurrency.ChunkSizeMB }
@@ -145,7 +145,7 @@ func (w *Wizard) buildConfig() *config.Config {
 	o.Sources.HuggingFace.TokenEnv = get(4)
 	o.Sources.CivitAI.Enabled = parseBool(get(5))
 	o.Sources.CivitAI.TokenEnv = get(6)
-	o.Concurrency.ChunkSizeMB = parseInt(get(7), 8)
+	o.Concurrency.ChunkSizeMB = parseInt(get(7), 16)
 	o.Concurrency.PerFileChunks = parseInt(get(8), 4)
 	return o
 }

--- a/scripts/dev_server_setup.sh
+++ b/scripts/dev_server_setup.sh
@@ -112,7 +112,7 @@ network:
 concurrency:
   global_files: 4
   per_file_chunks: 4
-  chunk_size_mb: 8
+  chunk_size_mb: 16
   max_retries: 8
   backoff:
     min_ms: 200


### PR DESCRIPTION
## Summary
- raise default chunk size to 16MB in sample config, config wizard, README, and dev server setup
- remove completed quick win from backlog

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b6bf2f0518832cb6ed8160b80724b4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Increased default concurrency chunk size to 16 MB across configuration defaults, setup script, and the interactive configuration wizard. Existing user configs remain unchanged unless explicitly set.
- Documentation
  - Updated README Quickstart and sample configuration to reflect the new 16 MB default.
  - Removed the completed backlog item related to increasing the default chunk size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->