### PR TITLE
feat: resolver naming patterns + CLI/TUI auth preflight; TUI v2 polish and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Usage (see docs/USER_GUIDE.md for details)
     - direct URLs use the basename of the final resolved URL; query/fragment is stripped and the name is sanitized
     - TUI and importer try a HEAD request for CivitAI direct endpoints to use server‑provided filenames when available
   - Quiet mode: add `--quiet`
+  - Auth preflight: runs a lightweight HEAD/0–0 probe and fails early on 401/403 with guidance; disable with `--no-auth-preflight`
   - On completion, a summary is printed (dest, size, SHA256, duration, average speed)
   - Cancel with Ctrl+C (SIGINT/SIGTERM); partial files are cleaned up
 - Place artifacts into apps:

--- a/docs/BATCH.md
+++ b/docs/BATCH.md
@@ -51,6 +51,10 @@ jobs:
 See also: `assets/sample-config/jobs.example.yml` in this repository.
 
 ## Running a batch
+
+- You can override default resolver naming per import with `--naming-pattern "..."` (applies when dest is omitted).
+  - CivitAI tokens: `{model_name}`, `{version_name}`, `{version_id}`, `{file_name}`, `{file_type}`
+  - Hugging Face tokens: `{owner}`, `{repo}`, `{path}`, `{rev}`, `{file_name}`
 - Place your jobs file at a convenient path, e.g., `/opt/modfetch/jobs/uat.yml` or within your repo.
 - Execute with your YAML config and optionally enable global placement for all jobs via --place:
 

--- a/docs/RESOLVERS.md
+++ b/docs/RESOLVERS.md
@@ -1,5 +1,51 @@
 # Resolvers: hf:// and civitai://
 
+This guide documents the resolver URI formats and configurable naming patterns.
+
+Supported schemes
+- Hugging Face: `hf://{owner}/{repo}/{path}?rev=main`
+- CivitAI: `civitai://model/{id}[?version=ID][&file=substring]`
+
+Configurable naming patterns
+- You can control the default filename used when `--dest` is omitted.
+- Configure per source in config:
+  - `sources.huggingface.naming.pattern`
+  - `sources.civitai.naming.pattern`
+- Or override per run with `--naming-pattern "..."` on `modfetch download` and `modfetch batch import`.
+
+Available tokens
+- CivitAI: `{model_name}`, `{version_name}`, `{version_id}`, `{file_name}`, `{file_type}`
+- Hugging Face: `{owner}`, `{repo}`, `{path}`, `{rev}`, `{file_name}`
+
+Examples
+```yaml path=null start=null
+sources:
+  civitai:
+    enabled: true
+    token_env: CIVITAI_TOKEN
+    naming:
+      pattern: "{model_name} - {file_name}"
+  huggingface:
+    enabled: true
+    token_env: HF_TOKEN
+    naming:
+      pattern: "{repo} - {file_name}"
+```
+
+CLI override
+```bash path=null start=null
+# Use repo-prefixed naming for this run
+modfetch download --config ~/.config/modfetch/config.yml \
+  --url 'hf://bigscience/bloom/LICENSE?rev=main' \
+  --naming-pattern '{repo} - {file_name}'
+```
+
+Notes
+- Resolvers populate metadata so patterns can be expanded accurately.
+- Final filenames are sanitized and de-duplicated; collision-safe suffixes are added when needed.
+
+# Resolvers: hf:// and civitai://
+
 This project supports two URI schemes that resolve to HTTP(S) download URLs with optional Authorization headers.
 
 Supported schemes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,8 +77,17 @@ type Sources struct {
 }
 
 type SourceWithToken struct {
-	Enabled  bool   `yaml:"enabled"`
-	TokenEnv string `yaml:"token_env"`
+	Enabled  bool          `yaml:"enabled"`
+	TokenEnv string        `yaml:"token_env"`
+	Naming   SourceNaming  `yaml:"naming"`
+}
+
+type SourceNaming struct {
+	// Pattern controls default filename generation when dest is omitted.
+	// Supported tokens vary by resolver:
+	// - CivitAI: {model_name}, {version_name}, {version_id}, {file_name}, {file_type}
+	// - HuggingFace: {owner}, {repo}, {path}, {rev}, {file_name}
+	Pattern string `yaml:"pattern"`
 }
 
 type ClassifierConfig struct {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -18,6 +18,11 @@ type Resolved struct {
 	FileName          string
 	FileType          string // Source-specific type (e.g., CivitAI file.type: Model|VAE|TextualInversion)
 	SuggestedFilename string
+	// Optional metadata for Hugging Face
+	RepoOwner string
+	RepoName  string
+	RepoPath  string
+	Rev       string
 }
 
 type Resolver interface {

--- a/internal/tui/v2/model_inspector_test.go
+++ b/internal/tui/v2/model_inspector_test.go
@@ -1,0 +1,61 @@
+package tui2
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/bubbles/progress"
+	"modfetch/internal/config"
+	"modfetch/internal/state"
+)
+
+func newTestModel() *Model {
+	cfg := &config.Config{Version: 1}
+	cfg.General.DataRoot = "/tmp" // unused in these tests
+	m := &Model{
+		cfg:       cfg,
+		th:        defaultTheme(),
+		activeTab: -1,
+		prog:      progress.New(progress.WithDefaultGradient(), progress.WithWidth(16)),
+	}
+	return m
+}
+
+func TestInspectorCompletedShowsAvgSpeed(t *testing.T) {
+	m := newTestModel()
+	now := time.Now().Unix()
+	row := state.DownloadRow{
+		URL:       "https://example.com/file",
+		Dest:      "/dest/file",
+		Size:      1024 * 1024,
+		Status:    "complete",
+		CreatedAt: now - 10,
+		UpdatedAt: now,
+	}
+	m.rows = []state.DownloadRow{row}
+	m.selected = 0
+	out := m.renderInspector()
+	if !strings.Contains(out, "Avg Speed:") {
+		t.Fatalf("expected inspector to include Avg Speed for completed job; got:\n%s", out)
+	}
+}
+
+func TestInspectorRunningShowsStarted(t *testing.T) {
+	m := newTestModel()
+	now := time.Now().Unix()
+	row := state.DownloadRow{
+		URL:       "https://example.com/file",
+		Dest:      "/dest/file",
+		Size:      2048,
+		Status:    "running",
+		CreatedAt: now - 5,
+		UpdatedAt: now - 1,
+	}
+	m.rows = []state.DownloadRow{row}
+	m.selected = 0
+	out := m.renderInspector()
+	if !strings.Contains(out, "Started:") {
+		t.Fatalf("expected inspector to include Started time for running job; got:\n%s", out)
+	}
+}

--- a/internal/util/naming.go
+++ b/internal/util/naming.go
@@ -1,0 +1,16 @@
+package util
+
+import "strings"
+
+// ExpandPattern replaces tokens in the form {token} with values from the map.
+// Unknown tokens are left as-is. Nil or empty maps produce the original pattern.
+func ExpandPattern(pattern string, tokens map[string]string) string {
+	p := pattern
+	if strings.TrimSpace(p) == "" {
+		return ""
+	}
+	for k, v := range tokens {
+		p = strings.ReplaceAll(p, "{"+k+"}", strings.TrimSpace(v))
+	}
+	return p
+}


### PR DESCRIPTION
Configurable naming patterns for hf:// and civitai://; --naming-pattern override; generalized SuggestedFilename usage across CLI/batch; early auth preflight with friendly guidance (CLI + TUI v2); inspector tests; docs updates (CONFIG, BATCH, RESOLVERS, README).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added --naming-pattern to customize filenames (CivitAI/Hugging Face) when dest is omitted, with token support and safer defaults.
  - Introduced early auth preflight to surface 401/403 errors with guidance (HF_TOKEN/CIVITAI_TOKEN); can be disabled via --no-auth-preflight.
  - Per-source YAML config now supports naming patterns.
- Documentation
  - Expanded resolver docs (hf://, civitai://), naming tokens/patterns, examples, and auth token guidance.
  - Updated batch docs for --naming-pattern usage.
- Tests
  - Added TUI inspector tests for running/completed download details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->