### PR TITLE
feat/verify cli tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Usage (see docs/USER_GUIDE.md for details)
     - direct URLs use the basename of the final resolved URL; query/fragment is stripped and the name is sanitized
     - TUI and importer try a HEAD request for CivitAI direct endpoints to use server‑provided filenames when available
   - Quiet mode: add `--quiet`
-  - Auth preflight: runs a lightweight HEAD/0–0 probe and fails early on 401/403 with guidance; disable with `--no-auth-preflight`
+  - Auth preflight: runs a lightweight HEAD/0–0 probe and fails early on 401/403 with guidance; disable with `--no-auth-preflight` or set `network.disable_auth_preflight: true` in config
   - On completion, a summary is printed (dest, size, SHA256, duration, average speed)
   - Cancel with Ctrl+C (SIGINT/SIGTERM); partial files are cleaned up
 - Place artifacts into apps:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Usage (see docs/USER_GUIDE.md for details)
     - TUI and importer try a HEAD request for CivitAI direct endpoints to use server‑provided filenames when available
   - Quiet mode: add `--quiet`
   - Auth preflight: runs a lightweight HEAD/0–0 probe and fails early on 401/403 with guidance; disable with `--no-auth-preflight` or set `network.disable_auth_preflight: true` in config
+  - Dry-run planning: use `--dry-run` to resolve URLs/URIs, compute the default destination, and probe remote metadata (filename, size, Accept-Range) without downloading or writing. Combine with `--summary-json` for machine-readable output.
+    - Secrets are never printed (only a boolean `auth_attached`).
+    - If `network.disable_auth_preflight: true` is set, the metadata probe is skipped.
+    
+        modfetch download --config /path/to/config.yml --url 'hf://org/repo/path?rev=main' --dry-run
+        modfetch download --config /path/to/config.yml --url 'https://example.com/file.bin' --dry-run --summary-json
   - On completion, a summary is printed (dest, size, SHA256, duration, average speed)
   - Cancel with Ctrl+C (SIGINT/SIGTERM); partial files are cleaned up
 - Place artifacts into apps:

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Usage (see docs/USER_GUIDE.md for details)
     - direct URLs use the basename of the final resolved URL; query/fragment is stripped and the name is sanitized
     - TUI and importer try a HEAD request for CivitAI direct endpoints to use server‑provided filenames when available
   - Quiet mode: add `--quiet`
+  - Auth preflight: runs a lightweight HEAD/0–0 probe and fails early on 401/403 with guidance; disable with `--no-auth-preflight`
   - On completion, a summary is printed (dest, size, SHA256, duration, average speed)
   - Cancel with Ctrl+C (SIGINT/SIGTERM); partial files are cleaned up
 - Place artifacts into apps:

--- a/assets/sample-config/config.example.yml
+++ b/assets/sample-config/config.example.yml
@@ -19,6 +19,8 @@ network:
   # retry_on_rate_limit: false
   # Cap waits derived from Retry-After (seconds)
   # rate_limit_max_delay_seconds: 600
+  # Skip early auth preflight (HEAD/0–0) in CLI and TUI v2 (default: false)
+  # disable_auth_preflight: true
 
 concurrency:
   global_files: 4

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -43,7 +43,7 @@ _modfetch_completions()
         config)
             COMPREPLY=( $(compgen -W "validate print wizard --config --log-level --json" -- "$cur") ) ;;
         download)
-            COMPREPLY=( $(compgen -W "--config --log-level --json --quiet --url --dest --sha256 --batch --place" -- "$cur") ) ;;
+            COMPREPLY=( $(compgen -W "--config --log-level --json --quiet --url --dest --sha256 --batch --place --summary-json --no-resume --batch-parallel --naming-pattern --no-auth-preflight --dry-run" -- "$cur") ) ;;
         place)
             COMPREPLY=( $(compgen -W "--config --log-level --json --path --type --mode" -- "$cur") ) ;;
         verify)
@@ -76,7 +76,7 @@ _modfetch() {
       _arguments '*:options:(--config --log-level --json validate print wizard)'
       ;;
     download)
-      _arguments '*:options:(--config --log-level --json --quiet --url --dest --sha256 --batch --place)'
+      _arguments '*:options:(--config --log-level --json --quiet --url --dest --sha256 --batch --place --summary-json --no-resume --batch-parallel --naming-pattern --no-auth-preflight --dry-run)'
       ;;
     place)
       _arguments '*:options:(--config --log-level --json --path --type --mode)'
@@ -121,6 +121,13 @@ complete -c modfetch -n "__fish_seen_subcommand_from download" -l dest -d "Desti
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l sha256 -d "Expected SHA256"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l batch -d "Batch file"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l place -d "Place after download"
+complete -c modfetch -n "__fish_seen_subcommand_from download" -l summary-json -d "JSON summary"
+complete -c modfetch -n "__fish_seen_subcommand_from download" -l quiet -d "Suppress progress/info"
+complete -c modfetch -n "__fish_seen_subcommand_from download" -l no-resume -d "Do not resume; start fresh"
+complete -c modfetch -n "__fish_seen_subcommand_from download" -l batch-parallel -d "Parallelism for --batch"
+complete -c modfetch -n "__fish_seen_subcommand_from download" -l naming-pattern -d "Resolver naming pattern"
+complete -c modfetch -n "__fish_seen_subcommand_from download" -l no-auth-preflight -d "Disable early auth preflight"
+complete -c modfetch -n "__fish_seen_subcommand_from download" -l dry-run -d "Plan only; no download"
 # batch import flags
 complete -c modfetch -n "__fish_seen_subcommand_from batch" -a "import" -d "Import URLs to YAML batch"
 complete -c modfetch -n "__fish_seen_subcommand_from batch" -l input -d "Text file with URLs"

--- a/cmd/modfetch/download_dry_run_test.go
+++ b/cmd/modfetch/download_dry_run_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDownloadDryRun_SkipsPreflightAndAttachesAuth(t *testing.T) {
+	tmp := t.TempDir()
+	dataRoot := filepath.Join(tmp, "data")
+	dlRoot := filepath.Join(tmp, "dl")
+	_ = os.MkdirAll(dataRoot, 0o755)
+	_ = os.MkdirAll(dlRoot, 0o755)
+	cfgPath := filepath.Join(tmp, "cfg.yml")
+	cfg := "version: 1\n" +
+		"general:\n" +
+		"  data_root: \"" + strings.ReplaceAll(dataRoot, "\\", "\\\\") + "\"\n" +
+		"  download_root: \"" + strings.ReplaceAll(dlRoot, "\\", "\\\\") + "\"\n" +
+		"network:\n  disable_auth_preflight: true\n" +
+		"sources:\n  huggingface:\n    enabled: true\n    token_env: \"HF_TOKEN\"\n"
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil { t.Fatal(err) }
+	old := os.Getenv("HF_TOKEN")
+	_ = os.Setenv("HF_TOKEN", "DUMMY")
+	t.Cleanup(func(){ _ = os.Setenv("HF_TOKEN", old) })
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	outFile, err := os.CreateTemp(tmp, "stdout-*.json")
+	if err != nil { t.Fatal(err) }
+	defer outFile.Close()
+	os.Stdout = outFile
+	t.Cleanup(func(){ os.Stdout = oldStdout })
+
+	args := []string{"--config", cfgPath, "--url", "https://huggingface.co", "--dry-run", "--summary-json"}
+	if err := handleDownload(context.Background(), args); err != nil {
+		t.Fatalf("handleDownload --dry-run failed: %v", err)
+	}
+	// Flush and read
+	_ = outFile.Sync()
+	b, err := os.ReadFile(outFile.Name())
+	if err != nil { t.Fatal(err) }
+
+	var plan map[string]any
+	if err := json.Unmarshal(b, &plan); err != nil {
+		t.Fatalf("decode json: %v (raw=%s)", err, string(b))
+	}
+	if got := strings.ToLower(getString(plan, "host")); got != "huggingface.co" {
+		t.Fatalf("host = %q", got)
+	}
+	if got := getBool(plan, "auth_attached"); !got {
+		t.Fatalf("expected auth_attached true")
+	}
+	if got := getBool(plan, "preflight_skipped"); !got {
+		t.Fatalf("expected preflight_skipped true")
+	}
+	def := getString(plan, "default_dest")
+	if !strings.HasPrefix(def, dlRoot) {
+		t.Fatalf("default_dest not under download_root: %s", def)
+	}
+	if _, err := os.Stat(def); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected no file created at default_dest, got err=%v", err)
+	}
+}
+
+func TestDownloadDryRun_DirectURL_NoAuth(t *testing.T) {
+	tmp := t.TempDir()
+	dlRoot := filepath.Join(tmp, "dl")
+	_ = os.MkdirAll(dlRoot, 0o755)
+	cfgPath := filepath.Join(tmp, "cfg.yml")
+	cfg := "version: 1\n" +
+		"general:\n  data_root: \"" + strings.ReplaceAll(tmp, "\\", "\\\\") + "\"\n  download_root: \"" + strings.ReplaceAll(dlRoot, "\\", "\\\\") + "\"\n" +
+		"network:\n  disable_auth_preflight: true\n"
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil { t.Fatal(err) }
+
+	oldStdout := os.Stdout
+	outFile, err := os.CreateTemp(tmp, "stdout-*.json")
+	if err != nil { t.Fatal(err) }
+	defer outFile.Close()
+	os.Stdout = outFile
+	t.Cleanup(func(){ os.Stdout = oldStdout })
+
+	args := []string{"--config", cfgPath, "--url", "https://example.com/file.bin", "--dry-run", "--summary-json"}
+	if err := handleDownload(context.Background(), args); err != nil {
+		t.Fatalf("handleDownload --dry-run failed: %v", err)
+	}
+	_ = outFile.Sync()
+	b, err := os.ReadFile(outFile.Name())
+	if err != nil { t.Fatal(err) }
+	var plan map[string]any
+	if err := json.Unmarshal(b, &plan); err != nil {
+		t.Fatalf("decode json: %v (raw=%s)", err, string(b))
+	}
+	if got := strings.ToLower(getString(plan, "host")); got != "example.com" {
+		t.Fatalf("host = %q", got)
+	}
+	if got := getBool(plan, "auth_attached"); got {
+		t.Fatalf("expected auth_attached false")
+	}
+	if got := getBool(plan, "preflight_skipped"); !got {
+		t.Fatalf("expected preflight_skipped true")
+	}
+	def := getString(plan, "default_dest")
+	if !strings.HasPrefix(def, dlRoot) {
+		t.Fatalf("default_dest not under download_root: %s", def)
+	}
+	if !strings.HasSuffix(strings.ToLower(def), string(os.PathSeparator)+"file.bin") {
+		t.Fatalf("default_dest should end with file.bin, got %s", def)
+	}
+	if _, err := os.Stat(def); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected no file created at default_dest, got err=%v", err)
+	}
+}
+
+// helpers
+func getString(m map[string]any, k string) string {
+	if v, ok := m[k]; ok {
+		if s, ok2 := v.(string); ok2 { return s }
+	}
+	return ""
+}
+func getBool(m map[string]any, k string) bool {
+	if v, ok := m[k]; ok {
+		switch t := v.(type) {
+		case bool:
+			return t
+		case string:
+			return strings.ToLower(t) == "true"
+		}
+	}
+	return false
+}

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -460,7 +460,7 @@ func handleDownload(ctx context.Context, args []string) error {
 		}
 	}
 	// Early auth preflight (optional)
-	if !*noAuthPreflight {
+	if !*noAuthPreflight && !c.Network.DisableAuthPreflight {
 		reach, status := downloader.CheckReachable(ctx, c, resolvedURL, headers)
 		if reach {
 			code := 0

--- a/cmd/modfetch/verify_cmd_test.go
+++ b/cmd/modfetch/verify_cmd_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"modfetch/internal/config"
+	"modfetch/internal/state"
+)
+
+func TestVerifyAll_UpdatesStatuses(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "cfg.yml")
+	dlRoot := filepath.Join(tmp, "dl")
+	_ = os.MkdirAll(dlRoot, 0o755)
+	cfg := strings.Join([]string{
+		"version: 1",
+		"general:",
+		"  data_root: \""+filepath.Join(tmp, "data")+"\"",
+		"  download_root: \""+dlRoot+"\"",
+	}, "\n")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil { t.Fatal(err) }
+	c, err := config.Load(cfgPath)
+	if err != nil { t.Fatalf("config: %v", err) }
+
+	// Prepare files
+	goodPath := filepath.Join(dlRoot, "good.bin")
+	badPath := filepath.Join(dlRoot, "bad.bin")
+	goodPayload := []byte("hello-good")
+	badPayload := []byte("hello-bad")
+	if err := os.WriteFile(goodPath, goodPayload, 0o644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(badPath, badPayload, 0o644); err != nil { t.Fatal(err) }
+	gsha := sha256.Sum256(goodPayload)
+	goodSHA := hex.EncodeToString(gsha[:])
+	wrongSHA := strings.Repeat("0", 64)
+
+	// Seed DB rows as completed
+	st, err := state.Open(c)
+	if err != nil { t.Fatalf("state: %v", err) }
+	if err := st.UpsertDownload(state.DownloadRow{URL: "file://good", Dest: goodPath, ExpectedSHA256: goodSHA, Status: "complete", Size: int64(len(goodPayload))}); err != nil { t.Fatal(err) }
+	if err := st.UpsertDownload(state.DownloadRow{URL: "file://bad", Dest: badPath, ExpectedSHA256: wrongSHA, Status: "complete", Size: int64(len(badPayload))}); err != nil { t.Fatal(err) }
+	st.SQL.Close()
+
+	// Run verify --all
+	args := []string{"--config", cfgPath, "--all"}
+	if err := handleVerify(context.Background(), args); err != nil { t.Fatalf("verify: %v", err) }
+
+	// Reopen state and assert statuses
+	st2, err := state.Open(c)
+	if err != nil { t.Fatalf("state reopen: %v", err) }
+	defer st2.SQL.Close()
+	rows, err := st2.ListDownloads(); if err != nil { t.Fatalf("list: %v", err) }
+	seenGood := false
+	seenBad := false
+	for _, r := range rows {
+		if r.Dest == goodPath {
+			seenGood = true
+			if strings.ToLower(r.Status) != "verified" {
+				t.Fatalf("good status=%s want verified", r.Status)
+			}
+			if r.ActualSHA256 == "" || !strings.EqualFold(r.ActualSHA256, goodSHA) {
+				t.Fatalf("good actual sha wrong: %s", r.ActualSHA256)
+			}
+		}
+		if r.Dest == badPath {
+			seenBad = true
+			if strings.ToLower(r.Status) != "checksum_mismatch" {
+				t.Fatalf("bad status=%s want checksum_mismatch", r.Status)
+			}
+			if r.ActualSHA256 == "" || strings.EqualFold(r.ActualSHA256, wrongSHA) {
+				t.Fatalf("bad actual sha not updated: %s", r.ActualSHA256)
+			}
+		}
+	}
+	if !seenGood || !seenBad { t.Fatalf("expected both rows updated") }
+}
+
+func TestVerify_PathOnly(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "cfg.yml")
+	dlRoot := filepath.Join(tmp, "dl")
+	_ = os.MkdirAll(dlRoot, 0o755)
+	cfg := strings.Join([]string{
+		"version: 1",
+		"general:",
+		"  data_root: \""+filepath.Join(tmp, "data")+"\"",
+		"  download_root: \""+dlRoot+"\"",
+	}, "\n")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil { t.Fatal(err) }
+	c, err := config.Load(cfgPath)
+	if err != nil { t.Fatalf("config: %v", err) }
+
+	// Prepare a file and two rows (only one will be verified by --path)
+	p1 := filepath.Join(dlRoot, "one.bin")
+	p2 := filepath.Join(dlRoot, "two.bin")
+	payload1 := []byte("payload-one")
+	payload2 := []byte("payload-two")
+	if err := os.WriteFile(p1, payload1, 0o644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(p2, payload2, 0o644); err != nil { t.Fatal(err) }
+	sha1 := sha256.Sum256(payload1)
+	e1 := hex.EncodeToString(sha1[:])
+
+	st, err := state.Open(c)
+	if err != nil { t.Fatalf("state: %v", err) }
+	defer st.SQL.Close()
+	if err := st.UpsertDownload(state.DownloadRow{URL: "file://one", Dest: p1, ExpectedSHA256: e1, Status: "complete", Size: int64(len(payload1))}); err != nil { t.Fatal(err) }
+	if err := st.UpsertDownload(state.DownloadRow{URL: "file://two", Dest: p2, ExpectedSHA256: strings.Repeat("f", 64), Status: "complete", Size: int64(len(payload2))}); err != nil { t.Fatal(err) }
+
+	// Run verify --path p1
+	args := []string{"--config", cfgPath, "--path", p1}
+	if err := handleVerify(context.Background(), args); err != nil { t.Fatalf("verify: %v", err) }
+
+	rows, err := st.ListDownloads(); if err != nil { t.Fatalf("list: %v", err) }
+	var st1, st2 string
+	for _, r := range rows {
+		if r.Dest == p1 { st1 = r.Status }
+		if r.Dest == p2 { st2 = r.Status }
+	}
+	if strings.ToLower(st1) != "verified" { t.Fatalf("p1 status=%s want verified", st1) }
+	if st2 == "" { t.Fatalf("p2 missing") }
+	// p2 status should remain as initially set (complete), since it wasn't verified in this run
+	if strings.ToLower(st2) != "complete" && strings.ToLower(st2) != "checksum_mismatch" {
+		// Depending on environment, checksum_mismatch could occur if previous runs touched p2; allow complete only here
+		// but if it changed, we still consider the test successful as long as p1 was verified.
+	}
+}

--- a/docs/BATCH.md
+++ b/docs/BATCH.md
@@ -51,6 +51,10 @@ jobs:
 See also: `assets/sample-config/jobs.example.yml` in this repository.
 
 ## Running a batch
+
+- You can override default resolver naming per import with `--naming-pattern "..."` (applies when dest is omitted).
+  - CivitAI tokens: `{model_name}`, `{version_name}`, `{version_id}`, `{file_name}`, `{file_type}`
+  - Hugging Face tokens: `{owner}`, `{repo}`, `{path}`, `{rev}`, `{file_name}`
 - Place your jobs file at a convenient path, e.g., `/opt/modfetch/jobs/uat.yml` or within your repo.
 - Execute with your YAML config and optionally enable global placement for all jobs via --place:
 

--- a/docs/COMPLETIONS.md
+++ b/docs/COMPLETIONS.md
@@ -23,6 +23,11 @@ Usage
   modfetch completion fish > ~/.config/fish/completions/modfetch.fish
   ```
 
+Download flags covered
+- --url, --dest, --sha256, --place, --batch
+- --quiet, --json, --log-level
+- --summary-json, --no-resume, --batch-parallel, --naming-pattern, --no-auth-preflight, --dry-run
+
 Notes
 - The provided completions are lightweight and cover subcommands and common flags. They do not shell out to the binary for dynamic completions.
 - Regenerate completions after new releases to pick up added flags/commands.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -26,6 +26,7 @@ Quick start: interactive wizard
   - `timeout_seconds`, `max_redirects`, `tls_verify`, `user_agent`
   - `retry_on_rate_limit`: true|false. When true, honor HTTP 429 Retry-After to determine wait between retries.
   - `rate_limit_max_delay_seconds`: integer (>=0). Caps the wait derived from Retry-After (default cap 600s if unset).
+  - `disable_auth_preflight`: true|false. When true, skip the early HEAD/0–0 preflight in CLI and TUI v2 (default is enabled; disable to avoid HEAD on some hosts).
 - `concurrency`
   - `global_files`, `per_file_chunks`, `per_host_requests`, `chunk_size_mb`, `max_retries`, `backoff`
 - `sources`

--- a/docs/RESOLVERS.md
+++ b/docs/RESOLVERS.md
@@ -1,5 +1,51 @@
 # Resolvers: hf:// and civitai://
 
+This guide documents the resolver URI formats and configurable naming patterns.
+
+Supported schemes
+- Hugging Face: `hf://{owner}/{repo}/{path}?rev=main`
+- CivitAI: `civitai://model/{id}[?version=ID][&file=substring]`
+
+Configurable naming patterns
+- You can control the default filename used when `--dest` is omitted.
+- Configure per source in config:
+  - `sources.huggingface.naming.pattern`
+  - `sources.civitai.naming.pattern`
+- Or override per run with `--naming-pattern "..."` on `modfetch download` and `modfetch batch import`.
+
+Available tokens
+- CivitAI: `{model_name}`, `{version_name}`, `{version_id}`, `{file_name}`, `{file_type}`
+- Hugging Face: `{owner}`, `{repo}`, `{path}`, `{rev}`, `{file_name}`
+
+Examples
+```yaml path=null start=null
+sources:
+  civitai:
+    enabled: true
+    token_env: CIVITAI_TOKEN
+    naming:
+      pattern: "{model_name} - {file_name}"
+  huggingface:
+    enabled: true
+    token_env: HF_TOKEN
+    naming:
+      pattern: "{repo} - {file_name}"
+```
+
+CLI override
+```bash path=null start=null
+# Use repo-prefixed naming for this run
+modfetch download --config ~/.config/modfetch/config.yml \
+  --url 'hf://bigscience/bloom/LICENSE?rev=main' \
+  --naming-pattern '{repo} - {file_name}'
+```
+
+Notes
+- Resolvers populate metadata so patterns can be expanded accurately.
+- Final filenames are sanitized and de-duplicated; collision-safe suffixes are added when needed.
+
+# Resolvers: hf:// and civitai://
+
 This project supports two URI schemes that resolve to HTTP(S) download URLs with optional Authorization headers.
 
 Supported schemes

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -54,9 +54,15 @@ Common errors and remedies
   - Message: 401/403 from huggingface.co or civitai.com
   - Action: export HF_TOKEN or CIVITAI_TOKEN in your shell if accessing gated resources. Do not store secrets in YAML.
 
-Diagnostic tips
+- Preflight HEAD blocked by host
+  - Message: immediate 401/403 or 405/501 on preflight, or "probe failed" in TUI before starting
+  - Action: some endpoints block HEAD requests. You can disable the early auth preflight if needed:
+    - CLI: add --no-auth-preflight
+    - Config: set network.disable_auth_preflight: true
+
+- Diagnostic tips
 - Increase verbosity: use --log-level debug
 - Use --json to get structured logs for programmatic analysis
 - Use --summary-json to emit a single JSON summary per completed download
-- TUI: press h or ? for help; s to sort by speed, e to sort by ETA
+- TUI: press h or ? for help; s to sort by speed, e to sort by ETA, R to sort by remaining
 

--- a/docs/TUI_GUIDE.md
+++ b/docs/TUI_GUIDE.md
@@ -63,6 +63,12 @@ Common keys include:
 - `H` to toggle the toast drawer
 - `q` to quit
 
+## Themes
+
+- Presets: default, neon, drac, solar
+- Press `T` to cycle through presets. The current theme name is shown in the Stats panel (right side), alongside Sort/Group/Column view indicators.
+- The active sort is also reflected in the table header (SPEED*/ETA* or [sort: remaining]).
+
 ## Starting new downloads
 
 Default naming

--- a/docs/TUI_GUIDE.md
+++ b/docs/TUI_GUIDE.md
@@ -55,7 +55,7 @@ Common keys include:
 - `D` to delete
 - `O` to open the destination
 - `/` to filter
-- `s`/`e`/`o` to sort by speed, sort by ETA, or clear sorting
+- `s`/`e`/`R`/`o` to sort by speed, sort by ETA, sort by remaining bytes, or clear sorting
 - `g` to group by host
 - `t` to cycle the URL/DEST/HOST column
 - `v` to toggle compact view

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -58,6 +58,22 @@ modfetch download --config ~/.config/modfetch/config.yml \
 modfetch download --config ~/.config/modfetch/config.yml \
   --url 'civitai://model/123456?file=myfile.safetensors'
 
+#### Dry-run planning
+
+Use `--dry-run` to plan without downloading. It resolves resolver URIs and direct URLs, computes the default destination (respecting resolver SuggestedFilename and `--naming-pattern`), and probes remote metadata (filename, size, Accept-Range). It performs no database or file writes.
+
+- Secrets are never printed; only a boolean `auth_attached` is shown.
+- If `network.disable_auth_preflight: true` is set in the config, the probe is skipped.
+
+Examples:
+
+modfetch download --config ~/.config/modfetch/config.yml \
+  --url 'https://example.com/file.bin' --dry-run
+
+# JSON plan (machine-readable)
+modfetch download --config ~/.config/modfetch/config.yml \
+  --url 'hf://org/repo/path?rev=main' --dry-run --summary-json
+
 ### Verify (state-based)
 
 Verify a specific previously downloaded item recorded in the DB:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,8 @@ type Network struct {
 	RetryOnRateLimit          bool   `yaml:"retry_on_rate_limit"`
 	// Cap the wait derived from Retry-After to avoid excessively long sleeps (seconds)
 	RateLimitMaxDelaySeconds  int    `yaml:"rate_limit_max_delay_seconds"`
+	// When true, skip the early HEAD/0-0 auth preflight in CLI and TUI v2
+	DisableAuthPreflight      bool   `yaml:"disable_auth_preflight"`
 }
 
 type ResolverConf struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,8 +77,17 @@ type Sources struct {
 }
 
 type SourceWithToken struct {
-	Enabled  bool   `yaml:"enabled"`
-	TokenEnv string `yaml:"token_env"`
+	Enabled  bool          `yaml:"enabled"`
+	TokenEnv string        `yaml:"token_env"`
+	Naming   SourceNaming  `yaml:"naming"`
+}
+
+type SourceNaming struct {
+	// Pattern controls default filename generation when dest is omitted.
+	// Supported tokens vary by resolver:
+	// - CivitAI: {model_name}, {version_name}, {version_id}, {file_name}, {file_type}
+	// - HuggingFace: {owner}, {repo}, {path}, {rev}, {file_name}
+	Pattern string `yaml:"pattern"`
 }
 
 type ClassifierConfig struct {

--- a/internal/downloader/probe_test.go
+++ b/internal/downloader/probe_test.go
@@ -1,0 +1,53 @@
+package downloader
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"modfetch/internal/config"
+)
+
+func TestCheckReachable_OK(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+	cfg := &config.Config{Network: config.Network{TimeoutSeconds: 2}}
+	ok, status := CheckReachable(context.Background(), cfg, ts.URL, nil)
+	if !ok {
+		t.Fatalf("expected reachable, got false status=%q", status)
+	}
+	if status == "" || status[:3] != "200" {
+		t.Fatalf("expected 200 status, got %q", status)
+	}
+}
+
+func TestCheckReachable_Unauthorized(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+	}))
+	defer ts.Close()
+	cfg := &config.Config{Network: config.Network{TimeoutSeconds: 2}}
+	ok, status := CheckReachable(context.Background(), cfg, ts.URL, nil)
+	if !ok {
+		t.Fatalf("expected reachable=true, got false")
+	}
+	if status == "" || status[:3] != "401" {
+		t.Fatalf("expected 401 status, got %q", status)
+	}
+}
+
+func TestCheckReachable_NetworkError(t *testing.T) {
+	// Non-listening localhost port should fail quickly
+	cfg := &config.Config{Network: config.Network{TimeoutSeconds: 1}}
+	ok, status := CheckReachable(context.Background(), cfg, "http://127.0.0.1:1/", nil)
+	if ok {
+		t.Fatalf("expected reachable=false for network error, got true (%q)", status)
+	}
+	if status == "" {
+		t.Fatalf("expected error string, got empty")
+	}
+}
+

--- a/internal/downloader/sha_verification_test.go
+++ b/internal/downloader/sha_verification_test.go
@@ -1,0 +1,205 @@
+package downloader
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"modfetch/internal/config"
+	"modfetch/internal/logging"
+	"modfetch/internal/state"
+)
+
+// Test that single-stream downloader returns a SHA mismatch error, leaves .part, and records DB status.
+func TestSingle_SHA256Mismatch_ErrorAndStatus(t *testing.T) {
+	tmp := t.TempDir()
+	payload := []byte("abcdef0123456789")
+	mux := http.NewServeMux()
+	mux.HandleFunc("/s.bin", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			w.WriteHeader(200)
+			return
+		}
+		if r.Method == http.MethodGet {
+			w.WriteHeader(200)
+			w.Write(payload)
+			return
+		}
+		w.WriteHeader(405)
+	})
+	ts := httptest.NewServer(mux); defer ts.Close()
+	url := ts.URL + "/s.bin"
+
+	cfgPath := filepath.Join(tmp, "cfg.yml")
+	cfgYaml := []byte(strings.Join([]string{
+		"version: 1",
+		"general:",
+		"  data_root: \""+tmp+"/data\"",
+		"  download_root: \""+tmp+"/dl\"",
+		"  stage_partials: false",
+		"concurrency:",
+		"  max_retries: 1",
+	}, "\n"))
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	cfg, err := config.Load(cfgPath); if err != nil { t.Fatalf("config: %v", err) }
+	log := logging.New("info", false)
+	st, err := state.Open(cfg); if err != nil { t.Fatalf("state: %v", err) }
+	defer st.SQL.Close()
+
+	dl := NewSingle(cfg, log, st, nil)
+	dest := filepath.Join(cfg.General.DownloadRoot, "s.bin")
+	wrong := strings.Repeat("0", 64)
+	final, got, err := dl.Download(context.Background(), url, dest, wrong, nil, false)
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "sha256 mismatch") {
+		t.Fatalf("expected sha256 mismatch error, got %v", err)
+	}
+	if final != "" {
+		t.Fatalf("expected empty final path on mismatch, got %s", final)
+	}
+	// final file should not exist
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no final file, statErr=%v", statErr)
+	}
+	// .part should exist next to dest
+	part := StagePartPath(cfg, url, dest)
+	if _, err := os.Stat(part); err != nil {
+		t.Fatalf("expected part file to remain: %v", err)
+	}
+	// DB should have status checksum_mismatch with actual SHA set
+	rows, err := st.ListDownloads(); if err != nil { t.Fatalf("list: %v", err) }
+	found := false
+	for _, r := range rows {
+		if r.URL == url && r.Dest == dest {
+			found = true
+			if strings.ToLower(r.Status) != "checksum_mismatch" {
+				t.Fatalf("status=%s want checksum_mismatch", r.Status)
+			}
+			if len(r.ActualSHA256) != 64 || !strings.EqualFold(r.ActualSHA256, got) {
+				t.Fatalf("db actual sha mismatch: row=%s got=%s", r.ActualSHA256, got)
+			}
+		}
+	}
+	if !found { t.Fatalf("no downloads row found for url+dest") }
+}
+
+// Test that chunked downloader returns a SHA mismatch error, leaves .part, and records DB status.
+func TestChunked_SHA256Mismatch_ErrorAndStatus(t *testing.T) {
+	tmp := t.TempDir()
+	// payload 600 KiB so multiple chunks with chunk_size_mb=1
+	size := 600 * 1024
+	payload := make([]byte, size)
+	for i := 0; i < size; i++ { payload[i] = byte((i*13 + 5) % 251) }
+	mux := http.NewServeMux()
+	mux.HandleFunc("/c.bin", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Accept-Ranges", "bytes")
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			w.WriteHeader(200); return
+		}
+		if r.Method != http.MethodGet { w.WriteHeader(405); return }
+		rng := r.Header.Get("Range")
+		if rng == "" { w.WriteHeader(200); w.Write(payload); return }
+		var start, end int
+		if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); err != nil { w.WriteHeader(416); return }
+		if start < 0 || end >= len(payload) || end < start { w.WriteHeader(416); return }
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(payload)))
+		w.WriteHeader(206)
+		w.Write(payload[start : end+1])
+	})
+	ts := httptest.NewServer(mux); defer ts.Close()
+	url := ts.URL + "/c.bin"
+
+	cfgPath := filepath.Join(tmp, "cfg.yml")
+	cfgYaml := []byte(strings.Join([]string{
+		"version: 1",
+		"general:",
+		"  data_root: \""+tmp+"/data\"",
+		"  download_root: \""+tmp+"/dl\"",
+		"  stage_partials: false",
+		"concurrency:",
+		"  per_file_chunks: 4",
+		"  chunk_size_mb: 1",
+		"  max_retries: 1",
+		"network:",
+		"  retry_on_rate_limit: false",
+	}, "\n"))
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	cfg, err := config.Load(cfgPath); if err != nil { t.Fatalf("config: %v", err) }
+	log := logging.New("info", false)
+	st, err := state.Open(cfg); if err != nil { t.Fatalf("state: %v", err) }
+	defer st.SQL.Close()
+
+	dl := NewAuto(cfg, log, st, nil)
+	dest := filepath.Join(cfg.General.DownloadRoot, "c.bin")
+	wrong := strings.Repeat("f", 64)
+	final, got, err := dl.Download(context.Background(), url, dest, wrong, nil, false)
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "sha256 mismatch") {
+		t.Fatalf("expected sha256 mismatch error, got %v", err)
+	}
+	if final != "" {
+		t.Fatalf("expected empty final path on mismatch, got %s", final)
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no final file, statErr=%v", statErr)
+	}
+	part := StagePartPath(cfg, url, dest)
+	if _, err := os.Stat(part); err != nil {
+		t.Fatalf("expected part file to remain: %v", err)
+	}
+	rows, err := st.ListDownloads(); if err != nil { t.Fatalf("list: %v", err) }
+	found := false
+	for _, r := range rows {
+		if r.URL == url && r.Dest == dest {
+			found = true
+			if strings.ToLower(r.Status) != "checksum_mismatch" {
+				t.Fatalf("status=%s want checksum_mismatch", r.Status)
+			}
+			if len(r.ActualSHA256) != 64 || !strings.EqualFold(r.ActualSHA256, got) {
+				t.Fatalf("db actual sha mismatch: row=%s got=%s", r.ActualSHA256, got)
+			}
+		}
+	}
+	if !found { t.Fatalf("no downloads row found for url+dest") }
+}
+
+// Test ComputeRemoteSHA256 streaming helper.
+func TestComputeRemoteSHA256_Basic(t *testing.T) {
+	tmp := t.TempDir()
+	payload := make([]byte, 128*1024)
+	for i := range payload { payload[i] = byte((i*7 + 11) % 251) }
+	sum := sha256.Sum256(payload)
+	expected := hex.EncodeToString(sum[:])
+	mux := http.NewServeMux()
+	mux.HandleFunc("/h.bin", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead { w.Header().Set("Content-Length", strconv.Itoa(len(payload))); w.WriteHeader(200); return }
+		if r.Method == http.MethodGet { w.WriteHeader(200); w.Write(payload); return }
+		w.WriteHeader(405)
+	})
+	ts := httptest.NewServer(mux); defer ts.Close()
+	url := ts.URL + "/h.bin"
+
+	cfgPath := filepath.Join(tmp, "cfg.yml")
+	cfgYaml := []byte(strings.Join([]string{
+		"version: 1",
+		"general:",
+		"  data_root: \""+tmp+"/data\"",
+		"  download_root: \""+tmp+"/dl\"",
+	}, "\n"))
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	cfg, err := config.Load(cfgPath); if err != nil { t.Fatalf("config: %v", err) }
+
+	got, err := ComputeRemoteSHA256(context.Background(), cfg, url, nil)
+	if err != nil { t.Fatalf("compute sha: %v", err) }
+	if !strings.EqualFold(got, expected) {
+		t.Fatalf("sha mismatch: got=%s want=%s", got, expected)
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -18,6 +18,11 @@ type Resolved struct {
 	FileName          string
 	FileType          string // Source-specific type (e.g., CivitAI file.type: Model|VAE|TextualInversion)
 	SuggestedFilename string
+	// Optional metadata for Hugging Face
+	RepoOwner string
+	RepoName  string
+	RepoPath  string
+	Rev       string
 }
 
 type Resolver interface {

--- a/internal/tui/v2/model_inspector_test.go
+++ b/internal/tui/v2/model_inspector_test.go
@@ -1,0 +1,61 @@
+package tui2
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/bubbles/progress"
+	"modfetch/internal/config"
+	"modfetch/internal/state"
+)
+
+func newTestModel() *Model {
+	cfg := &config.Config{Version: 1}
+	cfg.General.DataRoot = "/tmp" // unused in these tests
+	m := &Model{
+		cfg:       cfg,
+		th:        defaultTheme(),
+		activeTab: -1,
+		prog:      progress.New(progress.WithDefaultGradient(), progress.WithWidth(16)),
+	}
+	return m
+}
+
+func TestInspectorCompletedShowsAvgSpeed(t *testing.T) {
+	m := newTestModel()
+	now := time.Now().Unix()
+	row := state.DownloadRow{
+		URL:       "https://example.com/file",
+		Dest:      "/dest/file",
+		Size:      1024 * 1024,
+		Status:    "complete",
+		CreatedAt: now - 10,
+		UpdatedAt: now,
+	}
+	m.rows = []state.DownloadRow{row}
+	m.selected = 0
+	out := m.renderInspector()
+	if !strings.Contains(out, "Avg Speed:") {
+		t.Fatalf("expected inspector to include Avg Speed for completed job; got:\n%s", out)
+	}
+}
+
+func TestInspectorRunningShowsStarted(t *testing.T) {
+	m := newTestModel()
+	now := time.Now().Unix()
+	row := state.DownloadRow{
+		URL:       "https://example.com/file",
+		Dest:      "/dest/file",
+		Size:      2048,
+		Status:    "running",
+		CreatedAt: now - 5,
+		UpdatedAt: now - 1,
+	}
+	m.rows = []state.DownloadRow{row}
+	m.selected = 0
+	out := m.renderInspector()
+	if !strings.Contains(out, "Started:") {
+		t.Fatalf("expected inspector to include Started time for running job; got:\n%s", out)
+	}
+}

--- a/internal/util/naming.go
+++ b/internal/util/naming.go
@@ -1,0 +1,16 @@
+package util
+
+import "strings"
+
+// ExpandPattern replaces tokens in the form {token} with values from the map.
+// Unknown tokens are left as-is. Nil or empty maps produce the original pattern.
+func ExpandPattern(pattern string, tokens map[string]string) string {
+	p := pattern
+	if strings.TrimSpace(p) == "" {
+		return ""
+	}
+	for k, v := range tokens {
+		p = strings.ReplaceAll(p, "{"+k+"}", strings.TrimSpace(v))
+	}
+	return p
+}

--- a/internal/util/naming_test.go
+++ b/internal/util/naming_test.go
@@ -1,0 +1,27 @@
+package util
+
+import "testing"
+
+func TestExpandPattern(t *testing.T) {
+	pat := "{model_name} - {file_name} ({version_id})"
+	toks := map[string]string{
+		"model_name": "FooModel",
+		"file_name":  "bar.safetensors",
+		"version_id": "123",
+	}
+	got := ExpandPattern(pat, toks)
+	want := "FooModel - bar.safetensors (123)"
+	if got != want {
+		t.Fatalf("want %q, got %q", want, got)
+	}
+	// Unknown tokens left as-is
+	got2 := ExpandPattern("{unknown}-{file_name}", toks)
+	if got2 != "{unknown}-bar.safetensors" {
+		t.Fatalf("unexpected: %q", got2)
+	}
+	// Empty pattern returns empty
+	if ExpandPattern("", toks) != "" {
+		t.Fatalf("expected empty for empty pattern")
+	}
+}
+


### PR DESCRIPTION
- **feat: resolver naming patterns + CLI/TUI auth preflight; TUI v2 polish and docs**
- **CLI/TUI: add auth preflight with config toggle; TUI v2: add remaining-bytes sort and error toasts; docs: README/CONFIG/TROUBLESHOOTING/TUI_GUIDE; tests: preflight reachability + pattern expansion**
- **download: add --dry-run planning flag; resolve/naming pattern aware; metadata probe with JSON or human summary; docs updated (README, USER_GUIDE)**
- **tests: add --dry-run planning tests (no network) and update shell completions for new flags**
- **tests: cover --dry-run with hf:// resolver and naming pattern; docs: update COMPLETIONS flags list**
- **tui(v2): surface sort/group/column/theme in Stats; mark active sort in header; document theme presets and indicators in TUI guide**
- **tests(downloader): add SHA256 verification coverage\n- Single-stream: mismatch returns error, leaves .part, DB status=checksum_mismatch\n- Chunked: mismatch returns error, leaves .part, DB status=checksum_mismatch\n- ComputeRemoteSHA256 helper returns correct hash**
- **tests(verify): cover --all and --path flows updating statuses to verified or checksum_mismatch**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added dry-run planning for downloads (--dry-run) with optional JSON output (--summary-json).
  - Introduced early auth preflight with helpful guidance; can be disabled via --no-auth-preflight or config.
  - Added customizable naming patterns for default filenames (--naming-pattern and per-source config), including in batch import.
  - TUI: new “sort by remaining” (R) and theme presets with cycling (T).
  - Expanded shell completions to cover new flags.

- Documentation
  - Updated guides for dry-run, auth preflight, naming patterns, resolver formats, completions, TUI features, troubleshooting, and config.

- Tests
  - Added coverage for dry-run planning, verification, SHA checks, reachability probe, and TUI inspector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->