### PR TITLE
CI/lint/docs: add golangci-lint job, Makefile targets, document new CLI/TUI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,22 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.x'
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59.1
+          args: --timeout=5m
+
   test:
+    needs: [lint]
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 Improvements
-- Downloader: explicit 429 handling. On rate limiting (HTTP 429), jobs are placed on hold with a clear, host-aware message persisted to `last_error`, including `Retry-After` when provided. Optional auto-retry honors server-provided `Retry-After` when `network.retry_on_rate_limit` is enabled.
-- TUI v2: clearer surfacing of rate limits. Rows placed on hold due to 429 render as `hold(rl)` in the table; the auth ribbon shows `rate-limited` for the affected host; a toast indicates the host and suggests trying later.
+- CLI: `status` supports `--only-errors` (filter) and `--summary` (totals and error count). JSON includes `{ total, errors, rows }` when `--summary` is set.
+- CLI: `download` accepts `--sha256-file` to read an expected hash from a file (supports .sha256 "hash  filename" format).
+- CLI: `clean` adds `--sidecars` to remove orphan `.sha256` sidecar files; JSON output now includes `sidecars_removed`.
+- CLI: `verify` adds `--fix-sidecar` to rewrite `<dest>.sha256` for verified files.
+- TUI v2: clearer surfacing of rate limits and view indicators; table header marks active sort (SPEED*/ETA*/[sort: remaining]); Stats panel shows Sort/Group/Column/Theme.
+- CI: introduce `golangci-lint` job and cache setup; keep vet/test/build/govulncheck; Makefile adds `fmt`, `fmt-check`, `vet`, `lint`, and `ci` targets.
 
 New
 - Config: `network.retry_on_rate_limit` (bool) to respect `Retry-After` on HTTP 429; `network.rate_limit_max_delay_seconds` to cap the wait (defaults to 600s if unset; 0 uses the default).

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Usage (see docs/USER_GUIDE.md for details)
     - civitai:// uses `<ModelName> - <OriginalFileName>` if `--dest` is omitted (with collision‑safe suffixes)
     - direct URLs use the basename of the final resolved URL; query/fragment is stripped and the name is sanitized
     - TUI and importer try a HEAD request for CivitAI direct endpoints to use server‑provided filenames when available
+  - SHA256 expectation:
+    - pass `--sha256 <HEX>` or `--sha256-file <path>` (.sha256 "hash  filename" format supported)
   - Quiet mode: add `--quiet`
   - On completion, a summary is printed (dest, size, SHA256, duration, average speed)
   - Cancel with Ctrl+C (SIGINT/SIGTERM); partial files are cleaned up
@@ -105,13 +107,14 @@ Usage (see docs/USER_GUIDE.md for details)
   
   - Keys:
     - Navigation: j/k (select), / (filter), m (menu), h/? (help)
-    - Sorting: s (sort by speed), e (sort by ETA), o (clear sort)
+    - Sorting: s (sort by speed), e (sort by ETA), R (remaining bytes), o (clear sort)
     - Actions: n (new), r (refresh), d (details), g (group by status), t (toggle columns)
     - Per‑row actions: p (pause/cancel), y (retry), C (copy path), U (copy URL), O (open/reveal), D (delete staged), X (clear row)
   - Behavior:
     - Resolving spinner appears immediately, then planning → running
     - Live speed and ETA for both chunked and single‑stream fallback downloads
     - Accepts CivitAI model page URLs (https://civitai.com/models/ID) and rewrites them internally to the correct direct download URL
+    - The header marks the active sort (SPEED*/ETA*/[sort: remaining]); the Stats panel shows View indicators (Sort/Group/Column/Theme)
   - See the full TUI guide: docs/TUI_GUIDE.md
   - Preview the next‑gen TUI v2 (experimental):
     
@@ -121,6 +124,7 @@ Usage (see docs/USER_GUIDE.md for details)
   modfetch verify --config /path/to/config.yml --all
   
   - Use `--only-errors` to show only problematic files; add `--summary` for totals and paths
+  - Write/refresh a sidecar: add `--fix-sidecar` to rewrite `<dest>.sha256` once verified
 - Deep‑verify safetensors and scan/repair a directory:
   
   modfetch verify --config /path/to/config.yml --scan-dir /path/to/models --safetensors-deep
@@ -134,6 +138,10 @@ Usage (see docs/USER_GUIDE.md for details)
 - Placement dry‑run:
   
   modfetch place --config /path/to/config.yml --path /path/to/model.safetensors --dry-run
+  
+- Clean partials and orphan sidecars:
+  
+  modfetch clean --config /path/to/config.yml --days 7 --include-next-to-dest --sidecars
   
 
 Resolvers


### PR DESCRIPTION
- Makefile: add fmt, fmt-check, vet, lint, ci\n- CI: add golangci-lint job; keep vet/test/build/govulncheck\n- Docs: README and CHANGELOG updated (status --only-errors/--summary, download --sha256-file, clean --sidecars, verify --fix-sidecar; TUI indicators)\n\nBuild and tests pass (go test ./...).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - CLI: status adds --only-errors and --summary (with totals in JSON); download supports --sha256-file (.sha256 format); verify adds --fix-sidecar; clean adds --sidecars.
- UI Updates
  - TUI v2: clearer rate-limit indicators; header marks active sort; Stats panel shows Sort/Group/Column/Theme; new sort by remaining bytes.
- Configuration
  - Added network.retry_on_rate_limit and network.rate_limit_max_delay_seconds.
- Documentation
  - Updated guides for new flags, sidecar handling, and TUI indicators.
- Chores
  - CI now runs linting and vet/tests; added formatting and lint targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->