### PR TITLE
TUI auto-recovery + chunk planning txn + streaming SHA256; docs: auto_recover_on_start

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Troubleshooting
 - Resume: Re‑running the same download will resume and verify integrity.
 
 Roadmap
+- See docs/ROADMAP.md for the consolidated, prioritized roadmap
 - Further TUI enhancements
 - Placement/classifier refinements and presets
 - Release packaging for more distros

--- a/WARP.md
+++ b/WARP.md
@@ -1,0 +1,76 @@
+# WARP.md
+
+This file provides guidance to WARP (warp.dev) when working with code in this repository.
+
+Repository: modfetch — a Go CLI/TUI to reliably fetch, verify, and place models from Hugging Face and CivitAI.
+
+Common commands
+- Requirements: Go 1.22+ (Linux/macOS). Auth tokens are only needed for gated content: export HF_TOKEN and/or CIVITAI_TOKEN in your shell.
+- Build (produces ./bin/modfetch)
+  - make build
+- Run (public URL examples)
+  - ./bin/modfetch download --config ~/.config/modfetch/config.yml --url 'https://proof.ovh.net/files/1Mb.dat'
+  - ./bin/modfetch download --config ~/.config/modfetch/config.yml --url 'hf://gpt2/README.md?rev=main'
+  - TUI: ./bin/modfetch tui --config ~/.config/modfetch/config.yml
+- Tests
+  - All tests: make test (go test ./...)
+  - With coverage: go test ./... -cover
+  - Single package: go test ./internal/downloader -v
+  - Single test: go test ./internal/downloader -run 'TestName' -v
+- Lint/format/static analysis
+  - Format: make fmt
+  - Check formatting: make fmt-check (fails if gofmt would change files)
+  - Vet: make vet
+  - Lint: make lint (requires golangci-lint to be installed; see https://golangci-lint.run/)
+  - CI-style local check: make ci (runs vet, fmt-check, test)
+- Local CI mirror
+  - scripts/ci/run_all.sh (runs vet, tests with coverage, builds, and exercises non-network CLI paths)
+- Packaging/cross builds (artifacts in dist/)
+  - Linux: make linux (amd64, arm64)
+  - macOS: make darwin (amd64, arm64); make macos-universal to lipo a fat binary
+  - Checksums: make checksums; Full set: make release-dist
+- Smoke test and dev helpers
+  - Quick smoke: scripts/smoke.sh /path/to/config.yml
+  - Sample configs: assets/sample-config/config.example.yml and jobs.example.yml
+  - Linux dev bootstrap: scripts/dev_server_setup.sh
+
+Configuration and environment
+- Config file: pass with --config or set MODFETCH_CONFIG. Default resolution if unset attempts ~/.config/modfetch/config.yml.
+- YAML schema highlights (see docs/CONFIG.md for full details): general (data_root, download_root, placement_mode, stage_partials/partials_root, always_no_resume), network (timeouts, Retry-After handling, disable_auth_preflight), concurrency (per_file_chunks, per_host_requests, chunk_size_mb, retries/backoff), sources (huggingface, civitai with token_env), placement mapping, classifier overrides, metrics (Prometheus textfile), validation (safetensors deep verify), ui (refresh_hz, column_mode, compact/theme).
+
+Big-picture architecture
+- CLI entrypoint: cmd/modfetch (standard flag-based subcommands)
+  - Commands: config (validate|print|wizard), download, status, place, verify, tui, batch import, completion, hostcaps, clean, version.
+  - Global flags per command: --config, --log-level, --json. Some commands also support --quiet, --dry-run, --summary-json.
+- Resolver layer (internal/resolver)
+  - Supports hf://owner/repo/path?rev=... and civitai://model/{id}[?version=...&file=...].
+  - Attaches Authorization from env tokens when enabled in config; normalizes common page URLs to resolver URIs (e.g., huggingface blob pages, civitai model pages).
+  - Results cached to data_root/resolver-cache.json with configurable TTL.
+  - For CivitAI, returns SuggestedFilename based on config patterns or “ModelName - FileName”.
+- Downloader (internal/downloader)
+  - Prefers chunked parallel downloads with resume and per-chunk SHA256; falls back to single-stream when servers don’t honor Range or HEAD.
+  - Stages data to a .part file (either download_root/.parts or partials_root), verifies integrity, and atomically finalizes to dest; writes a .sha256 sidecar.
+  - Self-checks and repairs dirty chunks; optional deep verification for .safetensors; respects HTTP 429 Retry-After with a configurable cap.
+  - Concurrency governed by config (per_file_chunks, per_host_requests, backoff, retries).
+- State (internal/state)
+  - SQLite database under data_root/state.db tracks downloads (status, retries, sizes, errors), chunk plans/progress, and host capability cache (HEAD OK, Accept-Ranges).
+- Placement and classification
+  - internal/classifier detects artifact types (e.g., sd.checkpoint/lora/vae/controlnet, llm.gguf) with optional YAML regex overrides.
+  - internal/placer maps files into app directories via placement.mapping; supports symlink, hardlink, or copy per config/general. Placement fails if overwriting different content unless allow_overwrite is true.
+- TUI (internal/tui, internal/tui/v2)
+  - Bubble Tea–based dashboard; v2 adds richer sorting/grouping and theming. Refresh cadence and column mode configurable via ui.* in YAML. See docs/TUI_GUIDE.md.
+- Logging and metrics
+  - Text or JSON logs with level control; URLs are sanitized to avoid leaking secrets.
+  - Optional Prometheus textfile exporter writes counters/gauges to metrics.prometheus_textfile.path.
+
+Pointers to important docs
+- README.md: install/quickstart, project layout, TUI keys overview, and release notes pointer.
+- docs/CONFIG.md: full YAML schema and examples; token/env guidance; placement/classifier details; UI options.
+- docs/RESOLVERS.md: URI formats and auth behavior.
+- docs/TUI_GUIDE.md: keyboard shortcuts and workflow.
+- docs/TESTING.md: local/integration/UAT guidance and environment requirements.
+
+Notes for future Warp sessions
+- When working on features that touch resolvers or downloader, consider running a quick public download for smoke validation and use --dry-run/--summary-json to inspect plan output without network transfer.
+- If make lint fails due to missing golangci-lint, install it first or run only vet/fmt/test.
+

--- a/cmd/modfetch/batch_cmd.go
+++ b/cmd/modfetch/batch_cmd.go
@@ -214,7 +214,8 @@ func handleBatchImport(ctx context.Context, args []string) error {
 						name = util.SafeFileName(name2)
 					}
 				}
-				if p, err := util.UniquePath(root, name, res.VersionID); err == nil {
+				vHint := util.SafeFileName(strings.TrimSpace(res.VersionID))
+				if p, err := util.UniquePath(root, name, vHint); err == nil {
 					jDest = p
 				}
 			}

--- a/cmd/modfetch/batch_cmd.go
+++ b/cmd/modfetch/batch_cmd.go
@@ -210,9 +210,13 @@ func handleBatchImport(ctx context.Context, args []string) error {
 						"rev":          res.Rev,
 					}
 					name2 := util.ExpandPattern(*namingPattern, toks)
-					if strings.TrimSpace(name2) != "" { name = util.SafeFileName(name2) }
+					if strings.TrimSpace(name2) != "" {
+						name = util.SafeFileName(name2)
+					}
 				}
-				if p, err := util.UniquePath(root, name, res.VersionID); err == nil { jDest = p }
+				if p, err := util.UniquePath(root, name, res.VersionID); err == nil {
+					jDest = p
+				}
 			}
 		} else {
 			// Attach auth headers for known hosts (direct URLs)

--- a/cmd/modfetch/verify.go
+++ b/cmd/modfetch/verify.go
@@ -73,11 +73,11 @@ func handleVerify(ctx context.Context, args []string) error {
 
 	report := map[string]any{}
 	verifyOne := func(row state.DownloadRow) error {
-	f, err := os.Open(row.Dest)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
+		f, err := os.Open(row.Dest)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
 		h := sha256.New()
 		if _, err := io.Copy(h, f); err != nil {
 			return err

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -22,6 +22,7 @@ Quick start: interactive wizard
   - `stage_partials`: true|false (default true). When true, .part files are written under `download_root/.parts` (or `partials_root` if set) and moved atomically on completion.
   - `partials_root`: string (optional). Directory to store .part files instead of `download_root/.parts` (useful for a faster or larger filesystem).
   - `always_no_resume`: true|false (default false). When true, every download starts fresh (ignores any .part and clears chunk state) unless overridden by CLI.
+  - `auto_recover_on_start`: true|false (default false). When true, the TUI auto-resumes downloads found in state with status `running` or `hold` on startup.
 - `network`
   - `timeout_seconds`, `max_redirects`, `tls_verify`, `user_agent`
   - `retry_on_rate_limit`: true|false. When true, honor HTTP 429 Retry-After to determine wait between retries.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,81 @@
+# Roadmap (Consolidated)
+
+This document consolidates the project backlog and roadmap from multiple sources into a single, prioritized list. Source docs: docs/BACKLOG.md, docs/TODO.md, docs/TODO_NEXT.md, README.md (Roadmap), docs/PRD.md, docs/backlog/.
+
+Status key: [NEW] newly captured, [IMPL] implemented already (kept here for traceability), [WIP] in progress.
+
+Priority 1 — Critical reliability and performance
+- Concurrent download recovery [NEW]
+  - Persist/reattach TUI-initiated downloads after process restart; graceful recovery of work-in-progress.
+- Database transaction boundaries [NEW]
+  - Group related state updates in transactions to avoid inconsistent rows on crashes.
+- Streaming hashing [IMPL]
+  - Single and chunked downloaders perform streaming SHA256; keep for traceability.
+- Chunk corruption recovery [IMPL]
+  - Self-check and targeted re-fetch of dirty chunks is implemented in chunked downloader.
+
+Priority 2 — Core functionality gaps
+- Bandwidth throttling (per-download and global) [NEW]
+- Mirror/fallback URLs with ordered failover [NEW]
+- Partial verification during single-stream downloads [NEW]
+  - Periodic checkpoints; chunked mode already verifies per-chunk.
+- Connection pool management [NEW]
+  - Reuse a shared HTTP client/transport across downloaders; per-host limits.
+
+Priority 3 — User experience
+- TUI refactor and feature polish [NEW]
+  - Factor large models into smaller components; refine sort/group/columns; persistence of selection when filtering; progress accuracy during planning.
+- Progress persistence across sessions [NEW]
+- Adaptive retry/backoff by error type [NEW]
+- Download queue management with priorities [NEW]
+
+Priority 4 — Quality improvements
+- Rich, structured error context with remediation hints [NEW]
+- Test coverage expansion (resolvers/state/placer/downloaders) [NEW]
+- Metrics expansion (per-download stats, percentiles) [NEW]
+- Configuration validation hardening [NEW]
+
+Priority 5 — Advanced features
+- Archive extraction post-download (zip/tar/7z) [NEW]
+- Duplicate detection / content-addressable storage [NEW]
+- S3-compatible backend for storage [NEW]
+- Download scheduling (cron-like windows) [NEW]
+
+Priority 6 — Architecture
+- Context propagation pattern improvements [NEW]
+- Plugin architecture for resolvers [NEW]
+- Event-driven updates vs polling [NEW]
+
+Quick wins (remaining)
+- Add a flag to skip SHA256 verification intentionally for trusted sources (implemented as --force) [IMPL]
+- Fix TUI selected item persistence when filtering [NEW]
+- Fix progress bar showing 100% during chunk planning [NEW]
+
+Technical debt
+- Remove duplicate SafeFileName implementations (ensure all call util.SafeFileName) [NEW]
+- Consolidate HTTP client creation to a shared pool [NEW]
+- Standardize error wrapping and logging redaction [NEW]
+- Trim dead code in legacy TUI model [NEW]
+- Audit metrics writes/guards when disabled [NEW]
+
+Performance optimizations
+- Pre-allocate/truncate files in chunked mode (done) and consider parallel chunk verification [NEW]
+- DNS result caching for repeated hosts [NEW]
+- Adaptive chunk size based on throughput [NEW]
+
+Breaking changes to consider for v1.0
+- Config schema tidy-up
+- State DB schema simplification
+- Standardize CLI flags and naming
+
+Completed (from prior docs)
+- CivitAI model-aware default filenames and naming patterns (sources.*.naming.pattern) [IMPL]
+- Auth preflight/early 401 guidance with opt-out via network.disable_auth_preflight [IMPL]
+- Batch: --batch-parallel support; importer and summary behaviors [IMPL]
+- Single-stream: treat HTTP 416 on resume as completion [IMPL]
+- --quiet behavior aligned to suppress human summaries [IMPL]
+
+Notes
+- See docs/TODO_NEXT.md for CodeRabbit follow-ups and granular TUI tasks.
+- README “Roadmap” bullets map to the Priority 3/4 buckets here.
+

--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -13,30 +13,43 @@ type File struct {
 }
 
 type BatchJob struct {
-	URI      string `yaml:"uri"`
-	Dest     string `yaml:"dest"`
-	SHA256   string `yaml:"sha256"`
-	Type     string `yaml:"type"`
-	Place    bool   `yaml:"place"`
-	Mode     string `yaml:"mode"` // symlink|hardlink|copy
+	URI    string `yaml:"uri"`
+	Dest   string `yaml:"dest"`
+	SHA256 string `yaml:"sha256"`
+	Type   string `yaml:"type"`
+	Place  bool   `yaml:"place"`
+	Mode   string `yaml:"mode"` // symlink|hardlink|copy
 }
 
 func Load(path string) (*File, error) {
 	b, err := os.ReadFile(path)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	var f File
-	if err := yaml.Unmarshal(b, &f); err != nil { return nil, err }
-	if f.Version != 1 { return nil, fmt.Errorf("unsupported batch version: %d", f.Version) }
-	if len(f.Jobs) == 0 { return nil, fmt.Errorf("batch has no jobs") }
+	if err := yaml.Unmarshal(b, &f); err != nil {
+		return nil, err
+	}
+	if f.Version != 1 {
+		return nil, fmt.Errorf("unsupported batch version: %d", f.Version)
+	}
+	if len(f.Jobs) == 0 {
+		return nil, fmt.Errorf("batch has no jobs")
+	}
 	return &f, nil
 }
 
 // Save writes a batch File to path in YAML format.
 func Save(path string, f *File) error {
-	if f == nil { return fmt.Errorf("nil batch file") }
-	if f.Version == 0 { f.Version = 1 }
+	if f == nil {
+		return fmt.Errorf("nil batch file")
+	}
+	if f.Version == 0 {
+		f.Version = 1
+	}
 	b, err := yaml.Marshal(f)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	return os.WriteFile(path, b, 0o644)
 }
-

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -77,7 +77,7 @@ func detectMagic(p string) string {
 	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
 		return ""
 	}
-	if n >= 4 && (buf[0] == 'G' && buf[1] == 'G' && buf[2] == 'U' && buf[3] == 'F' || 
+	if n >= 4 && (buf[0] == 'G' && buf[1] == 'G' && buf[2] == 'U' && buf[3] == 'F' ||
 		strings.EqualFold(string(buf[:4]), "GGUF")) {
 		return "llm.gguf"
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,21 +37,22 @@ type General struct {
 	AllowOverwrite bool   `yaml:"allow_overwrite"`
 	DryRun         bool   `yaml:"dry_run"`
 	// Downloads behavior
-	StagePartials  bool `yaml:"stage_partials"`   // if true (default), write .part files under download_root/.parts or partials_root if set
-	AlwaysNoResume bool `yaml:"always_no_resume"` // if true, do not resume partials unless overridden on CLI
+	StagePartials      bool `yaml:"stage_partials"`        // if true (default), write .part files under download_root/.parts or partials_root if set
+	AlwaysNoResume     bool `yaml:"always_no_resume"`      // if true, do not resume partials unless overridden on CLI
+	AutoRecoverOnStart bool `yaml:"auto_recover_on_start"` // if true, TUI auto-resumes previously running downloads on startup
 }
 
 type Network struct {
-	TimeoutSeconds            int    `yaml:"timeout_seconds"`
-	MaxRedirects              int    `yaml:"max_redirects"`
-	TLSVerify                 bool   `yaml:"tls_verify"`
-	UserAgent                 string `yaml:"user_agent"`
+	TimeoutSeconds int    `yaml:"timeout_seconds"`
+	MaxRedirects   int    `yaml:"max_redirects"`
+	TLSVerify      bool   `yaml:"tls_verify"`
+	UserAgent      string `yaml:"user_agent"`
 	// When true, respect HTTP 429 Retry-After for retries (chunked and single fallback)
-	RetryOnRateLimit          bool   `yaml:"retry_on_rate_limit"`
+	RetryOnRateLimit bool `yaml:"retry_on_rate_limit"`
 	// Cap the wait derived from Retry-After to avoid excessively long sleeps (seconds)
-	RateLimitMaxDelaySeconds  int    `yaml:"rate_limit_max_delay_seconds"`
+	RateLimitMaxDelaySeconds int `yaml:"rate_limit_max_delay_seconds"`
 	// When true, skip the early HEAD/0-0 auth preflight in CLI and TUI v2
-	DisableAuthPreflight      bool   `yaml:"disable_auth_preflight"`
+	DisableAuthPreflight bool `yaml:"disable_auth_preflight"`
 }
 
 type ResolverConf struct {
@@ -79,9 +80,9 @@ type Sources struct {
 }
 
 type SourceWithToken struct {
-	Enabled  bool          `yaml:"enabled"`
-	TokenEnv string        `yaml:"token_env"`
-	Naming   SourceNaming  `yaml:"naming"`
+	Enabled  bool         `yaml:"enabled"`
+	TokenEnv string       `yaml:"token_env"`
+	Naming   SourceNaming `yaml:"naming"`
 }
 
 type SourceNaming struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,4 +15,3 @@ func TestLoadSampleConfig(t *testing.T) {
 		t.Fatalf("expected non-empty general paths")
 	}
 }
-

--- a/internal/downloader/chunked.go
+++ b/internal/downloader/chunked.go
@@ -494,6 +494,9 @@ func (e *Chunked) fetchChunk(ctx context.Context, url string, destPath string, h
 				if maxb <= 0 {
 					maxb = 30000
 				}
+				if maxb < min {
+					maxb = min
+				}
 				wait = time.Duration(min)*time.Millisecond + time.Duration(rand.Intn(maxb-min+1))*time.Millisecond
 			}
 			// Log and set DB status to hold while sleeping due to rate limiting
@@ -518,6 +521,9 @@ func (e *Chunked) fetchChunk(ctx context.Context, url string, destPath string, h
 		maxb := b.MaxMS
 		if maxb <= 0 {
 			maxb = 30000
+		}
+		if maxb < min {
+			maxb = min
 		}
 		dur := time.Duration(min)*time.Millisecond + time.Duration(rand.Intn(maxb-min+1))*time.Millisecond
 		select {
@@ -680,6 +686,9 @@ func (e *Chunked) singleWithRetry(ctx context.Context, url, destPath, expectedSH
 		maxb := b.MaxMS
 		if maxb <= 0 {
 			maxb = 30000
+		}
+		if maxb < min {
+			maxb = min
 		}
 		dur := time.Duration(min)*time.Millisecond + time.Duration(rand.Intn(maxb-min+1))*time.Millisecond
 		select {

--- a/internal/downloader/chunked_test.go
+++ b/internal/downloader/chunked_test.go
@@ -15,88 +15,123 @@ import (
 
 // Integration: chunked download of a 1MB test file with multiple chunks.
 func TestChunkedDownload1MB(t *testing.T) {
-	if testing.Short() { t.Skip("-short set") }
+	if testing.Short() {
+		t.Skip("-short set")
+	}
 	tmp := t.TempDir()
-	cfgYaml := []byte(""+
-		"version: 1\n"+
-		"general:\n"+
-		"  data_root: \""+tmp+"/data\"\n"+
-		"  download_root: \""+tmp+"/dl\"\n"+
-		"  placement_mode: \"symlink\"\n"+
-		"  quarantine: false\n"+
-		"  allow_overwrite: true\n"+
-		"concurrency:\n"+
-		"  per_file_chunks: 4\n"+
+	cfgYaml := []byte("" +
+		"version: 1\n" +
+		"general:\n" +
+		"  data_root: \"" + tmp + "/data\"\n" +
+		"  download_root: \"" + tmp + "/dl\"\n" +
+		"  placement_mode: \"symlink\"\n" +
+		"  quarantine: false\n" +
+		"  allow_overwrite: true\n" +
+		"concurrency:\n" +
+		"  per_file_chunks: 4\n" +
 		"  chunk_size_mb: 1\n") // 1 MB chunks
-	cfgPath := tmp+"/config.yml"
-	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	cfgPath := tmp + "/config.yml"
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	cfg, err := config.Load(cfgPath)
-	if err != nil { t.Fatalf("config load: %v", err) }
+	if err != nil {
+		t.Fatalf("config load: %v", err)
+	}
 	log := logging.New("info", false)
 	st, err := state.Open(cfg)
-	if err != nil { t.Fatalf("state: %v", err) }
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
 	defer func() { _ = st.SQL.Close() }()
 
 	dl := NewChunked(cfg, log, st, nil)
 	url := "https://proof.ovh.net/files/1Mb.dat"
 	dest, sha, err := dl.Download(context.Background(), url, "", "", nil, false)
-	if err != nil { t.Fatalf("download: %v", err) }
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
 	fi, err := os.Stat(dest)
-	if err != nil { t.Fatalf("stat: %v", err) }
-	if fi.Size() < 1000000 { t.Fatalf("expected ~1MB, got %d", fi.Size()) }
-	if len(sha) != 64 { t.Fatalf("sha length %d", len(sha)) }
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if fi.Size() < 1000000 {
+		t.Fatalf("expected ~1MB, got %d", fi.Size())
+	}
+	if len(sha) != 64 {
+		t.Fatalf("sha length %d", len(sha))
+	}
 }
 
 // Integration: corrupt a chunk and ensure repair when expected SHA is provided.
 func TestChunkedCorruptAndRepair(t *testing.T) {
-	if testing.Short() { t.Skip("-short set") }
+	if testing.Short() {
+		t.Skip("-short set")
+	}
 	tmp := t.TempDir()
-	cfgYaml := []byte(""+
-		"version: 1\n"+
-		"general:\n"+
-		"  data_root: \""+tmp+"/data\"\n"+
-		"  download_root: \""+tmp+"/dl\"\n"+
-		"  placement_mode: \"symlink\"\n"+
-		"  quarantine: false\n"+
-		"  allow_overwrite: true\n"+
-		"concurrency:\n"+
-		"  per_file_chunks: 8\n"+
+	cfgYaml := []byte("" +
+		"version: 1\n" +
+		"general:\n" +
+		"  data_root: \"" + tmp + "/data\"\n" +
+		"  download_root: \"" + tmp + "/dl\"\n" +
+		"  placement_mode: \"symlink\"\n" +
+		"  quarantine: false\n" +
+		"  allow_overwrite: true\n" +
+		"concurrency:\n" +
+		"  per_file_chunks: 8\n" +
 		"  chunk_size_mb: 1\n")
-	cfgPath := tmp+"/config.yml"
-	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	cfgPath := tmp + "/config.yml"
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	cfg, err := config.Load(cfgPath)
-	if err != nil { t.Fatalf("config load: %v", err) }
+	if err != nil {
+		t.Fatalf("config load: %v", err)
+	}
 	log := logging.New("info", false)
 	st, err := state.Open(cfg)
-	if err != nil { t.Fatalf("state: %v", err) }
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
 	defer func() { _ = st.SQL.Close() }()
 
 	dl := NewChunked(cfg, log, st, nil)
 	url := "https://proof.ovh.net/files/1Mb.dat"
 	// First download to get good SHA
 	dest, goodSHA, err := dl.Download(context.Background(), url, "", "", nil, false)
-	if err != nil { t.Fatalf("download1: %v", err) }
+	if err != nil {
+		t.Fatalf("download1: %v", err)
+	}
 	// Corrupt middle 64 bytes
 	f, err := os.OpenFile(dest, os.O_RDWR, 0)
-	if err != nil { t.Fatalf("open dest: %v", err) }
+	if err != nil {
+		t.Fatalf("open dest: %v", err)
+	}
 	defer func() { _ = f.Close() }()
-	if _, err := f.Seek(512*1024, 0); err != nil { t.Fatalf("seek: %v", err) }
+	if _, err := f.Seek(512*1024, 0); err != nil {
+		t.Fatalf("seek: %v", err)
+	}
 	bad := make([]byte, 64)
-	for i := range bad { bad[i] = 0xFF }
-	if _, err := f.Write(bad); err != nil { t.Fatalf("write corrupt: %v", err) }
+	for i := range bad {
+		bad[i] = 0xFF
+	}
+	if _, err := f.Write(bad); err != nil {
+		t.Fatalf("write corrupt: %v", err)
+	}
 	// Run downloader again with expected SHA; it should repair the corrupted chunk
 	_, fixedSHA, err := dl.Download(context.Background(), url, dest, goodSHA, nil, false)
-	if err != nil { t.Fatalf("download2(repair): %v", err) }
+	if err != nil {
+		t.Fatalf("download2(repair): %v", err)
+	}
 	if fixedSHA != goodSHA {
 		// confirm by local recompute
-	f2, _ := os.Open(dest)
-	defer func() { _ = f2.Close() }()
-	h := sha256.New()
-	_, _ = io.Copy(h, f2)
+		f2, _ := os.Open(dest)
+		defer func() { _ = f2.Close() }()
+		h := sha256.New()
+		_, _ = io.Copy(h, f2)
 		s := hex.EncodeToString(h.Sum(nil))
 		if s != goodSHA {
 			t.Fatalf("sha not repaired: got=%s want=%s", s, goodSHA)
 		}
 	}
 }
-

--- a/internal/downloader/civitai_resolve_download_test.go
+++ b/internal/downloader/civitai_resolve_download_test.go
@@ -18,25 +18,30 @@ import (
 )
 
 func TestCivitAIResolveAndDownload_WithAuthAndChunks(t *testing.T) {
-	if testing.Short() { t.Skip("-short set") }
+	if testing.Short() {
+		t.Skip("-short set")
+	}
 	// Prepare payload
 	size := 1024 * 1024 // 1MiB
 	payload := make([]byte, size)
-	for i := 0; i < size; i++ { payload[i] = byte(i % 251) }
+	for i := 0; i < size; i++ {
+		payload[i] = byte(i % 251)
+	}
 	token := "sekrit"
 
-// Server that requires Authorization and supports Range
+	// Server that requires Authorization and supports Range
 	var base string
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/models/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
-	_, _ = fmt.Fprintf(w, `{"modelVersions":[{"id":1,"files":[{"id":1,"name":"file.bin","type":"Model","primary":true,"downloadUrl":"%s/secure.bin"}]}]}` , base)
+		_, _ = fmt.Fprintf(w, `{"modelVersions":[{"id":1,"files":[{"id":1,"name":"file.bin","type":"Model","primary":true,"downloadUrl":"%s/secure.bin"}]}]}`, base)
 	})
 	mux.HandleFunc("/secure.bin", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodHead {
 			if got := r.Header.Get("Authorization"); got != "Bearer "+token {
-				w.WriteHeader(401); return
+				w.WriteHeader(401)
+				return
 			}
 			w.Header().Set("Accept-Ranges", "bytes")
 			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
@@ -47,22 +52,27 @@ func TestCivitAIResolveAndDownload_WithAuthAndChunks(t *testing.T) {
 		}
 		if r.Method == http.MethodGet {
 			if got := r.Header.Get("Authorization"); got != "Bearer "+token {
-				w.WriteHeader(401); return
+				w.WriteHeader(401)
+				return
 			}
 			rng := r.Header.Get("Range")
 			if rng == "" {
 				w.WriteHeader(200)
-	_, _ = w.Write(payload)
+				_, _ = w.Write(payload)
 				return
 			}
 			var start, end int
 			if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); err != nil {
-				w.WriteHeader(416); return
+				w.WriteHeader(416)
+				return
 			}
-			if start < 0 || end >= len(payload) || end < start { w.WriteHeader(416); return }
+			if start < 0 || end >= len(payload) || end < start {
+				w.WriteHeader(416)
+				return
+			}
 			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(payload)))
 			w.WriteHeader(206)
-	_, _ = w.Write(payload[start:end+1])
+			_, _ = w.Write(payload[start : end+1])
 			return
 		}
 		w.WriteHeader(405)
@@ -73,36 +83,52 @@ func TestCivitAIResolveAndDownload_WithAuthAndChunks(t *testing.T) {
 
 	// Override CivitAI base URL for resolver
 	old := resolverTestBaseSwap(ts.URL)
-	defer func(){ resolverTestBaseSwap(old) }()
+	defer func() { resolverTestBaseSwap(old) }()
 
 	// Config
 	tmp := t.TempDir()
 	cfgPath := filepath.Join(tmp, "cfg.yml")
-	cfgYaml := []byte("version: 1\n"+
-		"general:\n  data_root: \""+tmp+"/data\"\n  download_root: \""+tmp+"/dl\"\n"+
-		"network:\n  timeout_seconds: 10\n  user_agent: \"modfetch-test\"\n"+
-		"concurrency:\n  chunk_size_mb: 1\n  per_file_chunks: 4\n"+
+	cfgYaml := []byte("version: 1\n" +
+		"general:\n  data_root: \"" + tmp + "/data\"\n  download_root: \"" + tmp + "/dl\"\n" +
+		"network:\n  timeout_seconds: 10\n  user_agent: \"modfetch-test\"\n" +
+		"concurrency:\n  chunk_size_mb: 1\n  per_file_chunks: 4\n" +
 		"sources:\n  civitai:\n    enabled: true\n    token_env: \"CIVITAI_TEST_TOKEN\"\n")
-	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	_ = os.Setenv("CIVITAI_TEST_TOKEN", token)
 	cfg, err := config.Load(cfgPath)
-	if err != nil { t.Fatalf("config: %v", err) }
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
 	log := logging.New("info", false)
 	st, err := state.Open(cfg)
-	if err != nil { t.Fatalf("state: %v", err) }
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
 	defer func() { _ = st.SQL.Close() }()
 
 	// Resolve and download
 	uri := "civitai://model/xyz"
 	res, err := resolver.Resolve(context.Background(), uri, cfg)
-	if err != nil { t.Fatalf("resolve: %v", err) }
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
 	dl := NewChunked(cfg, log, st, nil)
 	dest, sha, err := dl.Download(context.Background(), res.URL, "", "", res.Headers, false)
-	if err != nil { t.Fatalf("download: %v", err) }
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
 	fi, err := os.Stat(dest)
-	if err != nil { t.Fatalf("stat: %v", err) }
-	if int(fi.Size()) != size { t.Fatalf("size mismatch: %d", fi.Size()) }
-	if len(sha) != 64 { t.Fatalf("sha length: %d", len(sha)) }
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if int(fi.Size()) != size {
+		t.Fatalf("size mismatch: %d", fi.Size())
+	}
+	if len(sha) != 64 {
+		t.Fatalf("sha length: %d", len(sha))
+	}
 }
 
 // helper to override resolver base url; returns previous value
@@ -111,4 +137,3 @@ func resolverTestBaseSwap(new string) string {
 	resolver.SetCivitaiBaseForTest(new)
 	return old
 }
-

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -16,14 +16,26 @@ type Interface interface {
 // Auto implements Interface by delegating to the chunked downloader which
 // already contains robust fallback to the single-stream downloader.
 // This centralizes the selection logic behind Interface.
-type Auto struct{
-	c *config.Config
-	l *logging.Logger
+type Auto struct {
+	c  *config.Config
+	l  *logging.Logger
 	st *state.DB
-	m interface{ AddBytes(int64); IncRetries(int64); IncDownloadsSuccess(); ObserveDownloadSeconds(float64); Write() error }
+	m  interface {
+		AddBytes(int64)
+		IncRetries(int64)
+		IncDownloadsSuccess()
+		ObserveDownloadSeconds(float64)
+		Write() error
+	}
 }
 
-func NewAuto(c *config.Config, l *logging.Logger, st *state.DB, m interface{ AddBytes(int64); IncRetries(int64); IncDownloadsSuccess(); ObserveDownloadSeconds(float64); Write() error }) *Auto {
+func NewAuto(c *config.Config, l *logging.Logger, st *state.DB, m interface {
+	AddBytes(int64)
+	IncRetries(int64)
+	IncDownloadsSuccess()
+	ObserveDownloadSeconds(float64)
+	Write() error
+}) *Auto {
 	return &Auto{c: c, l: l, st: st, m: m}
 }
 

--- a/internal/downloader/downloader_http_advanced_test.go
+++ b/internal/downloader/downloader_http_advanced_test.go
@@ -27,7 +27,9 @@ func TestChunked_RangeTransient5xxThenSuccess(t *testing.T) {
 	// 2 MiB payload to ensure multiple chunks
 	size := 2 << 20
 	payload := make([]byte, size)
-	for i := 0; i < size; i++ { payload[i] = byte((i*13 + 5) % 251) }
+	for i := 0; i < size; i++ {
+		payload[i] = byte((i*13 + 5) % 251)
+	}
 
 	var mu sync.Mutex
 	tries := map[int]int{}
@@ -36,34 +38,47 @@ func TestChunked_RangeTransient5xxThenSuccess(t *testing.T) {
 		if r.Method == http.MethodHead {
 			w.Header().Set("Accept-Ranges", "bytes")
 			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
-			w.WriteHeader(200); return
+			w.WriteHeader(200)
+			return
 		}
-		if r.Method != http.MethodGet { w.WriteHeader(405); return }
+		if r.Method != http.MethodGet {
+			w.WriteHeader(405)
+			return
+		}
 		rng := r.Header.Get("Range")
 		if rng == "" {
-	w.WriteHeader(200); _, _ = w.Write(payload); return
+			w.WriteHeader(200)
+			_, _ = w.Write(payload)
+			return
 		}
 		var start, end int
-		if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); err != nil { w.WriteHeader(416); return }
+		if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); err != nil {
+			w.WriteHeader(416)
+			return
+		}
 		mu.Lock()
 		tries[start]++
 		count := tries[start]
 		mu.Unlock()
 		// First attempt per start offset returns 503
-		if count == 1 { w.WriteHeader(503); return }
+		if count == 1 {
+			w.WriteHeader(503)
+			return
+		}
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(payload)))
 		w.WriteHeader(206)
-	_, _ = w.Write(payload[start:end+1])
+		_, _ = w.Write(payload[start : end+1])
 	})
-	ts := httptest.NewServer(mux); defer ts.Close()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
 	url := ts.URL + "/fivexx.bin"
 
 	cfgPath := filepath.Join(tmp, "cfg.yml")
 	cfgYaml := []byte(strings.Join([]string{
 		"version: 1",
 		"general:",
-		"  data_root: \""+tmp+"/data\"",
-		"  download_root: \""+tmp+"/dl\"",
+		"  data_root: \"" + tmp + "/data\"",
+		"  download_root: \"" + tmp + "/dl\"",
 		"network:",
 		"  timeout_seconds: 10",
 		"concurrency:",
@@ -74,19 +89,31 @@ func TestChunked_RangeTransient5xxThenSuccess(t *testing.T) {
 		"    min_ms: 1",
 		"    max_ms: 3",
 	}, "\n"))
-	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	cfg, err := config.Load(cfgPath)
-	if err != nil { t.Fatalf("config: %v", err) }
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
 	log := logging.New("info", false)
 	st, err := state.Open(cfg)
-	if err != nil { t.Fatalf("state: %v", err) }
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
 	defer func() { _ = st.SQL.Close() }()
 
 	dl := NewAuto(cfg, log, st, nil)
 	dest, sha, err := dl.Download(context.Background(), url, "", "", nil, false)
-	if err != nil { t.Fatalf("download: %v", err) }
-	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest: %v", err) }
-	if len(sha) != 64 { t.Fatalf("sha len: %d", len(sha)) }
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("dest: %v", err)
+	}
+	if len(sha) != 64 {
+		t.Fatalf("sha len: %d", len(sha))
+	}
 }
 
 // Slow body: server writes slowly but within timeout; download should succeed
@@ -95,62 +122,86 @@ func TestChunked_SlowBodyCompletes(t *testing.T) {
 	// 1 MiB payload
 	size := 1 << 20
 	payload := make([]byte, size)
-	for i := 0; i < size; i++ { payload[i] = byte((i*29 + 11) % 251) }
+	for i := 0; i < size; i++ {
+		payload[i] = byte((i*29 + 11) % 251)
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/slow.bin", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodHead {
 			w.Header().Set("Accept-Ranges", "bytes")
 			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
-			w.WriteHeader(200); return
+			w.WriteHeader(200)
+			return
 		}
 		rng := r.Header.Get("Range")
 		var start, end int
 		if rng == "" {
-			start = 0; end = len(payload)-1
+			start = 0
+			end = len(payload) - 1
 		} else {
-			if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); err != nil { w.WriteHeader(416); return }
+			if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); err != nil {
+				w.WriteHeader(416)
+				return
+			}
 			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(payload)))
 			w.WriteHeader(206)
 		}
-		if rng == "" { w.WriteHeader(200) }
+		if rng == "" {
+			w.WriteHeader(200)
+		}
 		// write in small chunks with small delays; total << client timeout
 		chunk := 64 * 1024
 		for off := start; off <= end; off += chunk {
 			to := off + chunk
-			if to > end+1 { to = end+1 }
-	_, _ = w.Write(payload[off:to])
+			if to > end+1 {
+				to = end + 1
+			}
+			_, _ = w.Write(payload[off:to])
 			time.Sleep(5 * time.Millisecond)
 		}
 	})
-	ts := httptest.NewServer(mux); defer ts.Close()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
 	url := ts.URL + "/slow.bin"
 
 	cfgPath := filepath.Join(tmp, "cfg.yml")
 	cfgYaml := []byte(strings.Join([]string{
 		"version: 1",
 		"general:",
-		"  data_root: \""+tmp+"/data\"",
-		"  download_root: \""+tmp+"/dl\"",
+		"  data_root: \"" + tmp + "/data\"",
+		"  download_root: \"" + tmp + "/dl\"",
 		"network:",
 		"  timeout_seconds: 5",
 		"concurrency:",
 		"  per_file_chunks: 2",
 		"  chunk_size_mb: 1",
 	}, "\n"))
-	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	cfg, err := config.Load(cfgPath)
-	if err != nil { t.Fatalf("config: %v", err) }
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
 	log := logging.New("info", false)
 	st, err := state.Open(cfg)
-	if err != nil { t.Fatalf("state: %v", err) }
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
 	defer func() { _ = st.SQL.Close() }()
 
 	dl := NewAuto(cfg, log, st, nil)
 	dest, sha, err := dl.Download(context.Background(), url, "", "", nil, false)
-	if err != nil { t.Fatalf("download: %v", err) }
-	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest: %v", err) }
-	if len(sha) != 64 { t.Fatalf("sha len: %d", len(sha)) }
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("dest: %v", err)
+	}
+	if len(sha) != 64 {
+		t.Fatalf("sha len: %d", len(sha))
+	}
 }
 
 // Truncated body mid-chunk on first attempt; retry then complete
@@ -159,7 +210,9 @@ func TestChunked_TruncatedBodyThenRetrySuccess(t *testing.T) {
 	// 1 MiB payload
 	size := 1 << 20
 	payload := make([]byte, size)
-	for i := 0; i < size; i++ { payload[i] = byte((i*7 + 19) % 251) }
+	for i := 0; i < size; i++ {
+		payload[i] = byte((i*7 + 19) % 251)
+	}
 	h := sha256.Sum256(payload)
 	expected := hex.EncodeToString(h[:])
 
@@ -169,14 +222,20 @@ func TestChunked_TruncatedBodyThenRetrySuccess(t *testing.T) {
 		if r.Method == http.MethodHead {
 			w.Header().Set("Accept-Ranges", "bytes")
 			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
-			w.WriteHeader(200); return
+			w.WriteHeader(200)
+			return
 		}
 		rng := r.Header.Get("Range")
 		var start, end int
 		if rng == "" {
-			start = 0; end = len(payload)-1; w.WriteHeader(200)
+			start = 0
+			end = len(payload) - 1
+			w.WriteHeader(200)
 		} else {
-			if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); err != nil { w.WriteHeader(416); return }
+			if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); err != nil {
+				w.WriteHeader(416)
+				return
+			}
 			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(payload)))
 			w.WriteHeader(206)
 		}
@@ -188,15 +247,16 @@ func TestChunked_TruncatedBodyThenRetrySuccess(t *testing.T) {
 		}
 		_, _ = w.Write(payload[start : end+1])
 	})
-	ts := httptest.NewServer(mux); defer ts.Close()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
 	url := ts.URL + "/trunc.bin"
 
 	cfgPath := filepath.Join(tmp, "cfg.yml")
 	cfgYaml := []byte(strings.Join([]string{
 		"version: 1",
 		"general:",
-		"  data_root: \""+tmp+"/data\"",
-		"  download_root: \""+tmp+"/dl\"",
+		"  data_root: \"" + tmp + "/data\"",
+		"  download_root: \"" + tmp + "/dl\"",
 		"network:",
 		"  timeout_seconds: 10",
 		"concurrency:",
@@ -207,17 +267,29 @@ func TestChunked_TruncatedBodyThenRetrySuccess(t *testing.T) {
 		"    min_ms: 1",
 		"    max_ms: 3",
 	}, "\n"))
-	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	cfg, err := config.Load(cfgPath)
-	if err != nil { t.Fatalf("config: %v", err) }
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
 	log := logging.New("info", false)
 	st, err := state.Open(cfg)
-	if err != nil { t.Fatalf("state: %v", err) }
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
 	defer func() { _ = st.SQL.Close() }()
 
 	dl := NewAuto(cfg, log, st, nil)
 	dest, sha, err := dl.Download(context.Background(), url, "", expected, nil, false)
-	if err != nil { t.Fatalf("download: %v", err) }
-	if sha != expected { t.Fatalf("expected sha %s got %s", expected, sha) }
-	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest: %v", err) }
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if sha != expected {
+		t.Fatalf("expected sha %s got %s", expected, sha)
+	}
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("dest: %v", err)
+	}
 }

--- a/internal/downloader/errors.go
+++ b/internal/downloader/errors.go
@@ -43,13 +43,14 @@ func parseRetryAfter(raw string) time.Duration {
 
 func friendlyHTTPStatusMessage(cfg *config.Config, host string, statusCode int, status string, hadAuth bool) string {
 	h := strings.ToLower(strings.TrimSpace(host))
-	hfEnv := strings.TrimSpace(cfg.Sources.HuggingFace.TokenEnv)
-	if hfEnv == "" {
-		hfEnv = "HF_TOKEN"
-	}
-	civEnv := strings.TrimSpace(cfg.Sources.CivitAI.TokenEnv)
-	if civEnv == "" {
-		civEnv = "CIVITAI_TOKEN"
+	hfEnv, civEnv := "HF_TOKEN", "CIVITAI_TOKEN"
+	if cfg != nil {
+		if v := strings.TrimSpace(cfg.Sources.HuggingFace.TokenEnv); v != "" {
+			hfEnv = v
+		}
+		if v := strings.TrimSpace(cfg.Sources.CivitAI.TokenEnv); v != "" {
+			civEnv = v
+		}
 	}
 
 	mk := func(base string) string {

--- a/internal/downloader/errors.go
+++ b/internal/downloader/errors.go
@@ -1,100 +1,109 @@
 package downloader
 
 import (
-    "fmt"
-    "strconv"
-    stdhttp "net/http"
-    neturl "net/url"
-    "strings"
-    "time"
+	"fmt"
+	stdhttp "net/http"
+	neturl "net/url"
+	"strconv"
+	"strings"
+	"time"
 
-    "modfetch/internal/config"
+	"modfetch/internal/config"
 )
 
 // friendlyHTTPStatusMessage creates a host-aware error message for common auth-related statuses.
 // hadAuth indicates whether an Authorization header was sent.
 // rateLimitedError represents a 429 with an optional suggested wait duration.
 type rateLimitedError struct {
-    after time.Duration
-    msg   string
+	after time.Duration
+	msg   string
 }
 
 func (e rateLimitedError) Error() string { return e.msg }
 
 func parseRetryAfter(raw string) time.Duration {
-    s := strings.TrimSpace(raw)
-    if s == "" { return 0 }
-    // If integer delta-seconds
-    if secs, err := strconv.Atoi(s); err == nil && secs >= 0 {
-        return time.Duration(secs) * time.Second
-    }
-    // Try HTTP-date
-    if t, err := time.Parse(stdhttp.TimeFormat, s); err == nil {
-        d := time.Until(t)
-        if d < 0 { return 0 }
-        return d
-    }
-    return 0
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return 0
+	}
+	// If integer delta-seconds
+	if secs, err := strconv.Atoi(s); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	// Try HTTP-date
+	if t, err := time.Parse(stdhttp.TimeFormat, s); err == nil {
+		d := time.Until(t)
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+	return 0
 }
 
 func friendlyHTTPStatusMessage(cfg *config.Config, host string, statusCode int, status string, hadAuth bool) string {
-    h := strings.ToLower(strings.TrimSpace(host))
-    hfEnv := strings.TrimSpace(cfg.Sources.HuggingFace.TokenEnv)
-    if hfEnv == "" { hfEnv = "HF_TOKEN" }
-    civEnv := strings.TrimSpace(cfg.Sources.CivitAI.TokenEnv)
-    if civEnv == "" { civEnv = "CIVITAI_TOKEN" }
+	h := strings.ToLower(strings.TrimSpace(host))
+	hfEnv := strings.TrimSpace(cfg.Sources.HuggingFace.TokenEnv)
+	if hfEnv == "" {
+		hfEnv = "HF_TOKEN"
+	}
+	civEnv := strings.TrimSpace(cfg.Sources.CivitAI.TokenEnv)
+	if civEnv == "" {
+		civEnv = "CIVITAI_TOKEN"
+	}
 
-    mk := func(base string) string {
-        if hostIs(h, "huggingface.co") {
-            if hadAuth {
-                return fmt.Sprintf("%s (Hugging Face: token present but not authorized; ensure you have access and have accepted the repository license)", base)
-            }
-            return fmt.Sprintf("%s (Hugging Face: token required; export %s)", base, hfEnv)
-        }
-        if hostIs(h, "civitai.com") {
-            if hadAuth {
-                return fmt.Sprintf("%s (Civitai: token present but not authorized; ensure your account has access and age-gating or permissions allow download)", base)
-            }
-            return fmt.Sprintf("%s (Civitai: token may be required; export %s)", base, civEnv)
-        }
-        return base
-    }
+	mk := func(base string) string {
+		if hostIs(h, "huggingface.co") {
+			if hadAuth {
+				return fmt.Sprintf("%s (Hugging Face: token present but not authorized; ensure you have access and have accepted the repository license)", base)
+			}
+			return fmt.Sprintf("%s (Hugging Face: token required; export %s)", base, hfEnv)
+		}
+		if hostIs(h, "civitai.com") {
+			if hadAuth {
+				return fmt.Sprintf("%s (Civitai: token present but not authorized; ensure your account has access and age-gating or permissions allow download)", base)
+			}
+			return fmt.Sprintf("%s (Civitai: token may be required; export %s)", base, civEnv)
+		}
+		return base
+	}
 
-    switch statusCode {
-    case 429:
-        // Keep neutral guidance for rate limits; do not imply tokens are required
-        return "429 Too Many Requests: rate limited"
-    case 401:
-        if hadAuth {
-            return mk("401 Unauthorized: token present but not authorized")
-        }
-        return mk("401 Unauthorized: token required")
-    case 403:
-        if hadAuth {
-            return mk("403 Forbidden: token lacks permission")
-        }
-        return mk("403 Forbidden: access denied (may require token)")
-    case 404:
-        if hadAuth {
-            return mk("404 Not Found (or private): with token; check path/revision or permissions")
-        }
-        return mk("404 Not Found: check path/revision; if private, provide token")
-    default:
-        // Preserve original status text verbatim
-        return status
-    }
+	switch statusCode {
+	case 429:
+		// Keep neutral guidance for rate limits; do not imply tokens are required
+		return "429 Too Many Requests: rate limited"
+	case 401:
+		if hadAuth {
+			return mk("401 Unauthorized: token present but not authorized")
+		}
+		return mk("401 Unauthorized: token required")
+	case 403:
+		if hadAuth {
+			return mk("403 Forbidden: token lacks permission")
+		}
+		return mk("403 Forbidden: access denied (may require token)")
+	case 404:
+		if hadAuth {
+			return mk("404 Not Found (or private): with token; check path/revision or permissions")
+		}
+		return mk("404 Not Found: check path/revision; if private, provide token")
+	default:
+		// Preserve original status text verbatim
+		return status
+	}
 }
 
 // hostIs returns true if h equals root or is a subdomain of root.
 func hostIs(h, root string) bool {
-    h = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(h)), ".")
-    root = strings.ToLower(strings.TrimSpace(root))
-    return h == root || strings.HasSuffix(h, "."+root)
+	h = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(h)), ".")
+	root = strings.ToLower(strings.TrimSpace(root))
+	return h == root || strings.HasSuffix(h, "."+root)
 }
 
 // hostFromURL extracts hostname from a URL string.
 func hostFromURL(raw string) string {
-    if u, err := neturl.Parse(raw); err == nil && u != nil { return u.Hostname() }
-    return ""
+	if u, err := neturl.Parse(raw); err == nil && u != nil {
+		return u.Hostname()
+	}
+	return ""
 }
-

--- a/internal/downloader/errors_test.go
+++ b/internal/downloader/errors_test.go
@@ -1,31 +1,30 @@
 package downloader
 
 import (
-    "strings"
-    "testing"
+	"strings"
+	"testing"
 
-    "modfetch/internal/config"
+	"modfetch/internal/config"
 )
 
 func TestFriendlyStatus_429_RateLimited(t *testing.T) {
-    cfg := &config.Config{}
-    cases := []struct{
-        name string
-        host string
-        hadAuth bool
-    }{
-        {"HF anon", "huggingface.co", false},
-        {"Civitai authed", "civitai.com", true},
-        {"Generic host", "example.com", false},
-    }
-    for _, tc := range cases {
-        t.Run(tc.name, func(t *testing.T) {
-            out := friendlyHTTPStatusMessage(cfg, tc.host, 429, "429 Too Many Requests", tc.hadAuth)
-            lo := strings.ToLower(out)
-            if !strings.Contains(lo, "429") || !strings.Contains(lo, "rate limited") {
-                t.Fatalf("expected 429 rate limited message for %s, got: %q", tc.host, out)
-            }
-        })
-    }
+	cfg := &config.Config{}
+	cases := []struct {
+		name    string
+		host    string
+		hadAuth bool
+	}{
+		{"HF anon", "huggingface.co", false},
+		{"Civitai authed", "civitai.com", true},
+		{"Generic host", "example.com", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := friendlyHTTPStatusMessage(cfg, tc.host, 429, "429 Too Many Requests", tc.hadAuth)
+			lo := strings.ToLower(out)
+			if !strings.Contains(lo, "429") || !strings.Contains(lo, "rate limited") {
+				t.Fatalf("expected 429 rate limited message for %s, got: %q", tc.host, out)
+			}
+		})
+	}
 }
-

--- a/internal/downloader/fsutil.go
+++ b/internal/downloader/fsutil.go
@@ -7,16 +7,21 @@ import (
 // writeAndSync writes content to path and fsyncs the file.
 func writeAndSync(path string, b []byte) error {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	defer func() { _ = f.Close() }()
-	if _, err := f.Write(b); err != nil { return err }
+	if _, err := f.Write(b); err != nil {
+		return err
+	}
 	return f.Sync()
 }
 
 func fsyncDir(dir string) error {
 	df, err := os.Open(dir)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	defer func() { _ = df.Close() }()
 	return df.Sync()
 }
-

--- a/internal/downloader/hf_resolve_download_test.go
+++ b/internal/downloader/hf_resolve_download_test.go
@@ -13,32 +13,47 @@ import (
 )
 
 func TestHFResolveAndDownload(t *testing.T) {
-	if testing.Short() { t.Skip("-short set") }
+	if testing.Short() {
+		t.Skip("-short set")
+	}
 	tmp := t.TempDir()
 	cfgPath := filepath.Join(tmp, "cfg.yml")
-	cfgYaml := []byte("version: 1\n"+
-		"general:\n"+
-		"  data_root: \""+tmp+"/data\"\n"+
-		"  download_root: \""+tmp+"/dl\"\n"+
-		"sources:\n"+
-		"  huggingface:\n"+
-		"    enabled: true\n"+
+	cfgYaml := []byte("version: 1\n" +
+		"general:\n" +
+		"  data_root: \"" + tmp + "/data\"\n" +
+		"  download_root: \"" + tmp + "/dl\"\n" +
+		"sources:\n" +
+		"  huggingface:\n" +
+		"    enabled: true\n" +
 		"    token_env: \"HF_TOKEN\"\n")
-	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	cfg, err := config.Load(cfgPath)
-	if err != nil { t.Fatalf("config: %v", err) }
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
 	log := logging.New("info", false)
 	st, err := state.Open(cfg)
-	if err != nil { t.Fatalf("state: %v", err) }
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
 	defer func() { _ = st.SQL.Close() }()
 
 	uri := "hf://gpt2/README.md?rev=main"
 	res, err := resolver.Resolve(context.Background(), uri, cfg)
-	if err != nil { t.Fatalf("resolve: %v", err) }
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
 	dl := NewChunked(cfg, log, st, nil)
 	dest, sha, err := dl.Download(context.Background(), res.URL, "", "", res.Headers, false)
-	if err != nil { t.Fatalf("download: %v", err) }
-	if _, err := os.Stat(dest); err != nil { t.Fatalf("dest stat: %v", err) }
-	if len(sha) != 64 { t.Fatalf("sha length: %d", len(sha)) }
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("dest stat: %v", err)
+	}
+	if len(sha) != 64 {
+		t.Fatalf("sha length: %d", len(sha))
+	}
 }
-

--- a/internal/downloader/httpclient.go
+++ b/internal/downloader/httpclient.go
@@ -15,7 +15,9 @@ import (
 
 func newHTTPClient(cfg *config.Config) *http.Client {
 	timeout := time.Duration(cfg.Network.TimeoutSeconds) * time.Second
-	if timeout <= 0 { timeout = 60 * time.Second }
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
 	tr := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
@@ -34,14 +36,24 @@ func newHTTPClient(cfg *config.Config) *http.Client {
 	client := &http.Client{Transport: tr, Timeout: timeout}
 	// Preserve important headers across redirects (Range, If-Range, UA). Avoid leaking Authorization across hosts.
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if len(via) == 0 { return nil }
+		if len(via) == 0 {
+			return nil
+		}
 		prev := via[len(via)-1]
-		if ua := prev.Header.Get("User-Agent"); ua != "" { req.Header.Set("User-Agent", ua) }
-		if rng := prev.Header.Get("Range"); rng != "" { req.Header.Set("Range", rng) }
-		if ir := prev.Header.Get("If-Range"); ir != "" { req.Header.Set("If-Range", ir) }
+		if ua := prev.Header.Get("User-Agent"); ua != "" {
+			req.Header.Set("User-Agent", ua)
+		}
+		if rng := prev.Header.Get("Range"); rng != "" {
+			req.Header.Set("Range", rng)
+		}
+		if ir := prev.Header.Get("If-Range"); ir != "" {
+			req.Header.Set("If-Range", ir)
+		}
 		// Only forward Authorization when host is the same
 		if prev.URL != nil && req.URL != nil && strings.EqualFold(prev.URL.Host, req.URL.Host) {
-			if auth := prev.Header.Get("Authorization"); auth != "" { req.Header.Set("Authorization", auth) }
+			if auth := prev.Header.Get("Authorization"); auth != "" {
+				req.Header.Set("Authorization", auth)
+			}
 		}
 		return nil
 	}
@@ -74,20 +86,31 @@ func resolveRedirectURL(baseClient *http.Client, rawURL string, headers map[stri
 	cl.CheckRedirect = func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }
 	req, _ := http.NewRequest(http.MethodGet, rawURL, nil)
 	req.Header.Set("User-Agent", ua)
-	for k, v := range headers { req.Header.Set(k, v) }
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 	resp, err := cl.Do(req)
-	if err != nil { return "", false }
+	if err != nil {
+		return "", false
+	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < 300 || resp.StatusCode >= 400 { return "", false }
+	if resp.StatusCode < 300 || resp.StatusCode >= 400 {
+		return "", false
+	}
 	loc := resp.Header.Get("Location")
-	if loc == "" { return "", false }
+	if loc == "" {
+		return "", false
+	}
 	u, err := neturl.Parse(loc)
-	if err != nil { return "", false }
+	if err != nil {
+		return "", false
+	}
 	if !u.IsAbs() {
 		base, err := neturl.Parse(rawURL)
-		if err != nil { return "", false }
+		if err != nil {
+			return "", false
+		}
 		u = base.ResolveReference(u)
 	}
 	return u.String(), true
 }
-

--- a/internal/downloader/paths.go
+++ b/internal/downloader/paths.go
@@ -41,7 +41,9 @@ func StagePartPath(cfg *config.Config, url, dest string) string {
 func renameOrCopy(src, dst string) error {
 	if err := os.Rename(src, dst); err != nil {
 		if linkErr, ok := err.(*os.LinkError); ok && linkErr.Err == syscall.EXDEV {
-			if err2 := copyFile(src, dst); err2 != nil { return err2 }
+			if err2 := copyFile(src, dst); err2 != nil {
+				return err2
+			}
 			_ = os.Remove(src)
 			return nil
 		}
@@ -52,12 +54,20 @@ func renameOrCopy(src, dst string) error {
 
 func copyFile(src, dst string) error {
 	sf, err := os.Open(src)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	defer func() { _ = sf.Close() }()
 	df, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	defer func() { _ = df.Close() }()
-	if _, err := io.Copy(df, sf); err != nil { return err }
-	if err := df.Sync(); err != nil { return err }
+	if _, err := io.Copy(df, sf); err != nil {
+		return err
+	}
+	if err := df.Sync(); err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/downloader/probe.go
+++ b/internal/downloader/probe.go
@@ -30,25 +30,39 @@ func ProbeURL(ctx context.Context, cfg *config.Config, rawURL string, headers ma
 	// First try HEAD (follows redirects)
 	req, _ := http.NewRequestWithContext(ctx, http.MethodHead, rawURL, nil)
 	req.Header.Set("User-Agent", ua)
-	for k, v := range headers { req.Header.Set(k, v) }
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 	resp, err := cl.Do(req)
 	var meta ProbeMeta
 	if err == nil {
 		defer func() { _ = resp.Body.Close() }()
-		if resp.Request != nil && resp.Request.URL != nil { meta.FinalURL = resp.Request.URL.String() }
+		if resp.Request != nil && resp.Request.URL != nil {
+			meta.FinalURL = resp.Request.URL.String()
+		}
 		meta.ETag = resp.Header.Get("ETag")
 		meta.LastModified = resp.Header.Get("Last-Modified")
-		if cd := resp.Header.Get("Content-Disposition"); cd != "" { if fn := parseDispositionFilename(cd); fn != "" { meta.Filename = fn } }
-		if clh := resp.Header.Get("Content-Length"); clh != "" { _, _ = fmt.Sscan(clh, &meta.Size) }
+		if cd := resp.Header.Get("Content-Disposition"); cd != "" {
+			if fn := parseDispositionFilename(cd); fn != "" {
+				meta.Filename = fn
+			}
+		}
+		if clh := resp.Header.Get("Content-Length"); clh != "" {
+			_, _ = fmt.Sscan(clh, &meta.Size)
+		}
 		meta.AcceptRange = false
-		if ar := resp.Header.Get("Accept-Ranges"); ar != "" { meta.AcceptRange = true }
+		if ar := resp.Header.Get("Accept-Ranges"); ar != "" {
+			meta.AcceptRange = true
+		}
 	}
 	// If we still lack size or accept-range, try Range GET probe
 	if meta.Size <= 0 || !meta.AcceptRange {
 		// Request 0-0
 		req2, _ := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 		req2.Header.Set("User-Agent", ua)
-		for k, v := range headers { req2.Header.Set(k, v) }
+		for k, v := range headers {
+			req2.Header.Set(k, v)
+		}
 		req2.Header.Set("Range", "bytes=0-0")
 		resp2, err2 := cl.Do(req2)
 		if err2 == nil {
@@ -59,10 +73,14 @@ func ProbeURL(ctx context.Context, cfg *config.Config, rawURL string, headers ma
 					meta.Size = total
 					meta.AcceptRange = true
 				}
-				if meta.FinalURL == "" && resp2.Request != nil && resp2.Request.URL != nil { meta.FinalURL = resp2.Request.URL.String() }
+				if meta.FinalURL == "" && resp2.Request != nil && resp2.Request.URL != nil {
+					meta.FinalURL = resp2.Request.URL.String()
+				}
 				if meta.Filename == "" {
 					if cd := resp2.Header.Get("Content-Disposition"); cd != "" {
-						if fn := parseDispositionFilename(cd); fn != "" { meta.Filename = fn }
+						if fn := parseDispositionFilename(cd); fn != "" {
+							meta.Filename = fn
+						}
 					}
 				}
 			}
@@ -75,17 +93,25 @@ func ProbeURL(ctx context.Context, cfg *config.Config, rawURL string, headers ma
 			// try a HEAD on resolved
 			req3, _ := http.NewRequestWithContext(ctx, http.MethodHead, ru, nil)
 			req3.Header.Set("User-Agent", ua)
-			for k, v := range headers { req3.Header.Set(k, v) }
+			for k, v := range headers {
+				req3.Header.Set(k, v)
+			}
 			if resp3, err3 := cl.Do(req3); err3 == nil {
 				defer func() { _ = resp3.Body.Close() }()
-				if clh := resp3.Header.Get("Content-Length"); clh != "" && meta.Size <= 0 { _, _ = fmt.Sscan(clh, &meta.Size) }
+				if clh := resp3.Header.Get("Content-Length"); clh != "" && meta.Size <= 0 {
+					_, _ = fmt.Sscan(clh, &meta.Size)
+				}
 				if cd := resp3.Header.Get("Content-Disposition"); cd != "" && meta.Filename == "" {
-					if fn := parseDispositionFilename(cd); fn != "" { meta.Filename = fn }
+					if fn := parseDispositionFilename(cd); fn != "" {
+						meta.Filename = fn
+					}
 				}
 			}
 		}
 	}
-	if meta.FinalURL == "" { meta.FinalURL = rawURL }
+	if meta.FinalURL == "" {
+		meta.FinalURL = rawURL
+	}
 	return meta, nil
 }
 
@@ -96,13 +122,21 @@ func ComputeRemoteSHA256(ctx context.Context, cfg *config.Config, rawURL string,
 	ua := userAgent(cfg)
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	req.Header.Set("User-Agent", ua)
-	for k, v := range headers { req.Header.Set(k, v) }
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 	resp, err := cl.Do(req)
-	if err != nil { return "", err }
+	if err != nil {
+		return "", err
+	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode/100 != 2 { return "", fmt.Errorf("GET status: %s", resp.Status) }
+	if resp.StatusCode/100 != 2 {
+		return "", fmt.Errorf("GET status: %s", resp.Status)
+	}
 	h := sha256.New()
-	if _, err := io.Copy(h, resp.Body); err != nil { return "", err }
+	if _, err := io.Copy(h, resp.Body); err != nil {
+		return "", err
+	}
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
@@ -120,10 +154,13 @@ func CheckReachable(ctx context.Context, cfg *config.Config, rawURL string, head
 	}
 	req, _ := http.NewRequestWithContext(ctx, http.MethodHead, rawURL, nil)
 	req.Header.Set("User-Agent", ua)
-	for k, v := range headers { req.Header.Set(k, v) }
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 	resp, err := cl.Do(req)
-	if err != nil { return false, err.Error() }
+	if err != nil {
+		return false, err.Error()
+	}
 	defer func() { _ = resp.Body.Close() }()
 	return true, resp.Status
 }
-

--- a/internal/downloader/probe.go
+++ b/internal/downloader/probe.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"modfetch/internal/config"
@@ -48,10 +50,12 @@ func ProbeURL(ctx context.Context, cfg *config.Config, rawURL string, headers ma
 			}
 		}
 		if clh := resp.Header.Get("Content-Length"); clh != "" {
-			_, _ = fmt.Sscan(clh, &meta.Size)
+			if n, err := strconv.ParseInt(strings.TrimSpace(clh), 10, 64); err == nil && n >= 0 {
+				meta.Size = n
+			}
 		}
 		meta.AcceptRange = false
-		if ar := resp.Header.Get("Accept-Ranges"); ar != "" {
+		if ar := resp.Header.Get("Accept-Ranges"); strings.EqualFold(strings.TrimSpace(ar), "bytes") {
 			meta.AcceptRange = true
 		}
 	}

--- a/internal/downloader/probe.go
+++ b/internal/downloader/probe.go
@@ -103,7 +103,9 @@ func ProbeURL(ctx context.Context, cfg *config.Config, rawURL string, headers ma
 			if resp3, err3 := cl.Do(req3); err3 == nil {
 				defer func() { _ = resp3.Body.Close() }()
 				if clh := resp3.Header.Get("Content-Length"); clh != "" && meta.Size <= 0 {
-					_, _ = fmt.Sscan(clh, &meta.Size)
+					if n, err := strconv.ParseInt(strings.TrimSpace(clh), 10, 64); err == nil && n >= 0 {
+						meta.Size = n
+					}
 				}
 				if cd := resp3.Header.Get("Content-Disposition"); cd != "" && meta.Filename == "" {
 					if fn := parseDispositionFilename(cd); fn != "" {

--- a/internal/downloader/probe_test.go
+++ b/internal/downloader/probe_test.go
@@ -50,4 +50,3 @@ func TestCheckReachable_NetworkError(t *testing.T) {
 		t.Fatalf("expected error string, got empty")
 	}
 }
-

--- a/internal/downloader/safetensors_fix.go
+++ b/internal/downloader/safetensors_fix.go
@@ -38,11 +38,11 @@ func adjustSafetensors(path string, log *logging.Logger) (bool, error) {
 	if err := binary.Read(f, binary.LittleEndian, &hdrLen); err != nil {
 		return false, err
 	}
-	if hdrLen == 0 || hdrLen > uint64(fi.Size()) {
+	if hdrLen == 0 || hdrLen > uint64(fi.Size()-8) || hdrLen > 64*1024*1024 {
 		return false, fmt.Errorf("safetensors: invalid header len %d", hdrLen)
 	}
 	hdr := make([]byte, hdrLen)
-	if _, err := f.Read(hdr); err != nil {
+	if _, err := io.ReadFull(f, hdr); err != nil {
 		return false, err
 	}
 	var meta map[string]any

--- a/internal/downloader/safetensors_fix.go
+++ b/internal/downloader/safetensors_fix.go
@@ -41,7 +41,7 @@ func adjustSafetensors(path string, log *logging.Logger) (bool, error) {
 	if hdrLen == 0 || hdrLen > uint64(fi.Size()-8) || hdrLen > 64*1024*1024 {
 		return false, fmt.Errorf("safetensors: invalid header len %d", hdrLen)
 	}
-	hdr := make([]byte, hdrLen)
+	hdr := make([]byte, int(hdrLen))
 	if _, err := io.ReadFull(f, hdr); err != nil {
 		return false, err
 	}
@@ -125,7 +125,7 @@ func deepVerifySafetensors(path string) (bool, int64, error) {
 	if hdrLen == 0 || hdrLen > uint64(fi.Size()-8) || hdrLen > 64*1024*1024 {
 		return false, 0, fmt.Errorf("invalid safetensors header length: %d", hdrLen)
 	}
-	hdr := make([]byte, hdrLen)
+	hdr := make([]byte, int(hdrLen))
 	if _, err := io.ReadFull(f, hdr); err != nil {
 		return false, 0, err
 	}

--- a/internal/downloader/safetensors_fix.go
+++ b/internal/downloader/safetensors_fix.go
@@ -19,42 +19,74 @@ func adjustSafetensors(path string, log *logging.Logger) (bool, error) {
 		return false, nil
 	}
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
-	if err != nil { return false, err }
+	if err != nil {
+		return false, err
+	}
 	defer func() { _ = f.Close() }()
 	fi, err := f.Stat()
-	if err != nil { return false, err }
-	if fi.Size() < 8 { return false, fmt.Errorf("safetensors: file too small: %d", fi.Size()) }
+	if err != nil {
+		return false, err
+	}
+	if fi.Size() < 8 {
+		return false, fmt.Errorf("safetensors: file too small: %d", fi.Size())
+	}
 	// Read header length
 	var hdrLen uint64
-	if _, err := f.Seek(0, 0); err != nil { return false, err }
-	if err := binary.Read(f, binary.LittleEndian, &hdrLen); err != nil { return false, err }
-	if hdrLen == 0 || hdrLen > uint64(fi.Size()) { return false, fmt.Errorf("safetensors: invalid header len %d", hdrLen) }
+	if _, err := f.Seek(0, 0); err != nil {
+		return false, err
+	}
+	if err := binary.Read(f, binary.LittleEndian, &hdrLen); err != nil {
+		return false, err
+	}
+	if hdrLen == 0 || hdrLen > uint64(fi.Size()) {
+		return false, fmt.Errorf("safetensors: invalid header len %d", hdrLen)
+	}
 	hdr := make([]byte, hdrLen)
-	if _, err := f.Read(hdr); err != nil { return false, err }
+	if _, err := f.Read(hdr); err != nil {
+		return false, err
+	}
 	var meta map[string]any
-	if err := json.Unmarshal(hdr, &meta); err != nil { return false, fmt.Errorf("safetensors: header json: %w", err) }
+	if err := json.Unmarshal(hdr, &meta); err != nil {
+		return false, fmt.Errorf("safetensors: header json: %w", err)
+	}
 	// Compute max data end from top-level tensor entries
 	var maxEnd int64 = 0
 	for k, v := range meta {
 		lk := strings.ToLower(k)
-		if lk == "metadata" || lk == "__metadata__" { continue }
+		if lk == "metadata" || lk == "__metadata__" {
+			continue
+		}
 		m, ok := v.(map[string]any)
-		if !ok { continue }
+		if !ok {
+			continue
+		}
 		off, ok := m["data_offsets"].([]any)
-		if !ok || len(off) != 2 { continue }
+		if !ok || len(off) != 2 {
+			continue
+		}
 		_, ok1 := toInt64(off[0])
 		end, ok2 := toInt64(off[1])
-		if !ok1 || !ok2 { continue }
-		if end > maxEnd { maxEnd = end }
+		if !ok1 || !ok2 {
+			continue
+		}
+		if end > maxEnd {
+			maxEnd = end
+		}
 	}
 	req := int64(8) + int64(hdrLen) + maxEnd
-	if req < 0 { return false, fmt.Errorf("safetensors: computed size invalid") }
+	if req < 0 {
+		return false, fmt.Errorf("safetensors: computed size invalid")
+	}
 	if fi.Size() < req {
 		return false, fmt.Errorf("safetensors: file incomplete: have=%d need=%d", fi.Size(), req)
 	}
 	if fi.Size() > req {
-		if err := f.Truncate(req); err != nil { return false, err }
-		if log != nil { log.Warnf("safetensors: truncated trailing %d bytes", fi.Size()-req) }
+		if err := f.Truncate(req); err != nil {
+			return false, err
+		}
+		if log != nil {
+			log.Warnf("safetensors: truncated trailing %d bytes", fi.Size()-req)
+		}
 		return true, nil
 	}
 	return false, nil
@@ -67,64 +99,117 @@ func deepVerifySafetensors(path string) (bool, int64, error) {
 		return true, 0, nil
 	}
 	f, err := os.Open(path)
-	if err != nil { return false, 0, err }
+	if err != nil {
+		return false, 0, err
+	}
 	defer func() { _ = f.Close() }()
-	fi, err := f.Stat(); if err != nil { return false, 0, err }
-	if fi.Size() < 8 { return false, 0, fmt.Errorf("file too small: %d", fi.Size()) }
+	fi, err := f.Stat()
+	if err != nil {
+		return false, 0, err
+	}
+	if fi.Size() < 8 {
+		return false, 0, fmt.Errorf("file too small: %d", fi.Size())
+	}
 	var hdrLen uint64
-	if err := binary.Read(f, binary.LittleEndian, &hdrLen); err != nil { return false, 0, err }
-	if hdrLen == 0 || hdrLen > uint64(fi.Size()-8) || hdrLen > 64*1024*1024 { return false, 0, fmt.Errorf("invalid safetensors header length: %d", hdrLen) }
+	if err := binary.Read(f, binary.LittleEndian, &hdrLen); err != nil {
+		return false, 0, err
+	}
+	if hdrLen == 0 || hdrLen > uint64(fi.Size()-8) || hdrLen > 64*1024*1024 {
+		return false, 0, fmt.Errorf("invalid safetensors header length: %d", hdrLen)
+	}
 	hdr := make([]byte, hdrLen)
-	if _, err := io.ReadFull(f, hdr); err != nil { return false, 0, err }
+	if _, err := io.ReadFull(f, hdr); err != nil {
+		return false, 0, err
+	}
 	var meta map[string]any
-	if err := json.Unmarshal(hdr, &meta); err != nil { return false, 0, fmt.Errorf("header json: %w", err) }
+	if err := json.Unmarshal(hdr, &meta); err != nil {
+		return false, 0, fmt.Errorf("header json: %w", err)
+	}
 	dataLen := fi.Size() - 8 - int64(hdrLen)
-	if dataLen < 0 { return false, 0, fmt.Errorf("negative data length") }
+	if dataLen < 0 {
+		return false, 0, fmt.Errorf("negative data length")
+	}
 	var maxEnd int64
 	for k, v := range meta {
 		lk := strings.ToLower(k)
-		if lk == "metadata" || lk == "__metadata__" { continue }
+		if lk == "metadata" || lk == "__metadata__" {
+			continue
+		}
 		m, ok := v.(map[string]any)
-		if !ok { continue }
+		if !ok {
+			continue
+		}
 		off, ok := m["data_offsets"].([]any)
-		if !ok || len(off) != 2 { continue }
+		if !ok || len(off) != 2 {
+			continue
+		}
 		start, ok1 := toInt64(off[0])
 		end, ok2 := toInt64(off[1])
-		if !ok1 || !ok2 { return false, 0, fmt.Errorf("tensor %q: invalid data_offsets", k) }
-		if start < 0 || end < 0 || end < start { return false, 0, fmt.Errorf("tensor %q: invalid range %d-%d", k, start, end) }
-		if end > dataLen { return false, 0, fmt.Errorf("tensor %q: data end %d beyond data length %d", k, end, dataLen) }
+		if !ok1 || !ok2 {
+			return false, 0, fmt.Errorf("tensor %q: invalid data_offsets", k)
+		}
+		if start < 0 || end < 0 || end < start {
+			return false, 0, fmt.Errorf("tensor %q: invalid range %d-%d", k, start, end)
+		}
+		if end > dataLen {
+			return false, 0, fmt.Errorf("tensor %q: data end %d beyond data length %d", k, end, dataLen)
+		}
 		if dtRaw, ok := m["dtype"].(string); ok {
 			if shp, ok := m["shape"].([]any); ok {
 				exp := dtypeBytes(dtRaw)
 				if exp > 0 {
 					var cnt int64 = 1
-					for _, dim := range shp { d, ok := toInt64(dim); if !ok || d <= 0 { cnt = 0; break }; cnt *= d }
+					for _, dim := range shp {
+						d, ok := toInt64(dim)
+						if !ok || d <= 0 {
+							cnt = 0
+							break
+						}
+						cnt *= d
+					}
 					if cnt > 0 {
 						sz := end - start
-						if sz != cnt*exp { return false, 0, fmt.Errorf("tensor %q: size %d != %d*%d", k, sz, cnt, exp) }
+						if sz != cnt*exp {
+							return false, 0, fmt.Errorf("tensor %q: size %d != %d*%d", k, sz, cnt, exp)
+						}
 					}
 				}
 			}
 		}
-		if end > maxEnd { maxEnd = end }
+		if end > maxEnd {
+			maxEnd = end
+		}
 	}
 	declared := int64(8) + int64(hdrLen) + maxEnd
-	if fi.Size() < declared { return false, declared, fmt.Errorf("incomplete: have=%d need=%d", fi.Size(), declared) }
-	if fi.Size() > declared { return false, declared, fmt.Errorf("extra bytes: have=%d need=%d", fi.Size(), declared) }
+	if fi.Size() < declared {
+		return false, declared, fmt.Errorf("incomplete: have=%d need=%d", fi.Size(), declared)
+	}
+	if fi.Size() > declared {
+		return false, declared, fmt.Errorf("extra bytes: have=%d need=%d", fi.Size(), declared)
+	}
 	return true, declared, nil
 }
 
 func dtypeBytes(dt string) int64 {
 	switch strings.ToUpper(strings.TrimSpace(dt)) {
-	case "F64": return 8
-	case "F32": return 4
-	case "F16", "BF16": return 2
-	case "F8", "F8_E4M3FN", "F8_E5M2": return 1
-	case "I64": return 8
-	case "I32": return 4
-	case "I16": return 2
-	case "I8", "U8", "BOOL": return 1
-	default: return 0
+	case "F64":
+		return 8
+	case "F32":
+		return 4
+	case "F16", "BF16":
+		return 2
+	case "F8", "F8_E4M3FN", "F8_E5M2":
+		return 1
+	case "I64":
+		return 8
+	case "I32":
+		return 4
+	case "I16":
+		return 2
+	case "I8", "U8", "BOOL":
+		return 1
+	default:
+		return 0
 	}
 }
 

--- a/internal/downloader/single_429_test.go
+++ b/internal/downloader/single_429_test.go
@@ -39,12 +39,18 @@ func TestSingle_429RateLimited_HoldWithRetryAfter(t *testing.T) {
 		"  data_root: \"" + tmp + "/data\"",
 		"  download_root: \"" + tmp + "/dl\"",
 	}, "\n"))
-	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	cfg, err := config.Load(cfgPath)
-	if err != nil { t.Fatalf("config: %v", err) }
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
 	log := logging.New("info", false)
 	st, err := state.Open(cfg)
-	if err != nil { t.Fatalf("state: %v", err) }
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
 	defer func() { _ = st.SQL.Close() }()
 
 	dl := NewSingle(cfg, log, st, nil)
@@ -53,7 +59,9 @@ func TestSingle_429RateLimited_HoldWithRetryAfter(t *testing.T) {
 		t.Fatalf("expected error on 429 rate limited")
 	}
 	rows, err := st.ListDownloads()
-	if err != nil { t.Fatalf("list: %v", err) }
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
 	found := false
 	for _, r := range rows {
 		if r.URL == url {
@@ -75,4 +83,3 @@ func TestSingle_429RateLimited_HoldWithRetryAfter(t *testing.T) {
 		t.Fatalf("expected a downloads row for %s", url)
 	}
 }
-

--- a/internal/downloader/single_test.go
+++ b/internal/downloader/single_test.go
@@ -12,30 +12,43 @@ import (
 
 // Integration test that downloads a tiny public text file from Hugging Face.
 func TestSingleDownloadHF(t *testing.T) {
-	if testing.Short() { t.Skip("-short set") }
+	if testing.Short() {
+		t.Skip("-short set")
+	}
 	tmp := t.TempDir()
-	cfgYaml := []byte(""+
-		"version: 1\n"+
-		"general:\n"+
-		"  data_root: \""+tmp+"/data\"\n"+
-		"  download_root: \""+tmp+"/dl\"\n"+
-		"  placement_mode: \"symlink\"\n"+
-		"  quarantine: false\n"+
+	cfgYaml := []byte("" +
+		"version: 1\n" +
+		"general:\n" +
+		"  data_root: \"" + tmp + "/data\"\n" +
+		"  download_root: \"" + tmp + "/dl\"\n" +
+		"  placement_mode: \"symlink\"\n" +
+		"  quarantine: false\n" +
 		"  allow_overwrite: true\n")
-	cfgPath := tmp+"/config.yml"
-	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	cfgPath := tmp + "/config.yml"
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	cfg, err := config.Load(cfgPath)
-	if err != nil { t.Fatalf("config load: %v", err) }
+	if err != nil {
+		t.Fatalf("config load: %v", err)
+	}
 
 	log := logging.New("info", false)
 	st, err := state.Open(cfg)
-	if err != nil { t.Fatalf("state open: %v", err) }
+	if err != nil {
+		t.Fatalf("state open: %v", err)
+	}
 	defer func() { _ = st.SQL.Close() }()
 
 	dl := NewSingle(cfg, log, st, nil)
 	final, sum, err := dl.Download(context.Background(), "https://raw.githubusercontent.com/github/gitignore/main/Go.gitignore", "", "", nil, false)
-	if err != nil { t.Fatalf("download: %v", err) }
-	if _, err := os.Stat(final); err != nil { t.Fatalf("final file missing: %v", err) }
-	if len(sum) != 64 { t.Fatalf("unexpected sha256 length: %d", len(sum)) }
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if _, err := os.Stat(final); err != nil {
+		t.Fatalf("final file missing: %v", err)
+	}
+	if len(sum) != 64 {
+		t.Fatalf("unexpected sha256 length: %d", len(sum))
+	}
 }
-

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -44,7 +44,9 @@ type Logger struct {
 
 func New(level string, jsonOut bool) *Logger {
 	out := io.Writer(os.Stderr)
-	if jsonOut { out = os.Stdout }
+	if jsonOut {
+		out = os.Stdout
+	}
 	return &Logger{min: ParseLevel(level), json: jsonOut, out: out}
 }
 
@@ -56,13 +58,15 @@ func (l *Logger) Warnf(format string, a ...any)  { l.log(Warn, fmt.Sprintf(forma
 func (l *Logger) Errorf(format string, a ...any) { l.log(Error, fmt.Sprintf(format, a...)) }
 
 func (l *Logger) log(level Level, msg string) {
-	if !l.Enabled(level) { return }
+	if !l.Enabled(level) {
+		return
+	}
 	lvl := levelString(level)
 	if l.json {
 		payload := map[string]any{
-			"ts": time.Now().Format(time.RFC3339Nano),
+			"ts":    time.Now().Format(time.RFC3339Nano),
 			"level": lvl,
-			"msg": msg,
+			"msg":   msg,
 		}
 		_ = json.NewEncoder(l.out).Encode(payload)
 		return
@@ -92,10 +96,16 @@ type throttleEntry struct {
 // WarnfThrottled logs a warning at most once per window for a given key.
 // Repeated calls within the window are suppressed and summarized on the next log.
 func (l *Logger) WarnfThrottled(key string, window time.Duration, format string, a ...any) {
-	if l == nil { return }
-	if window <= 0 { window = time.Second }
+	if l == nil {
+		return
+	}
+	if window <= 0 {
+		window = time.Second
+	}
 	l.mu.Lock()
-	if l.throttle == nil { l.throttle = make(map[string]throttleEntry) }
+	if l.throttle == nil {
+		l.throttle = make(map[string]throttleEntry)
+	}
 	e := l.throttle[key]
 	now := time.Now()
 	if now.Before(e.until) {
@@ -115,4 +125,3 @@ func (l *Logger) WarnfThrottled(key string, window time.Duration, format string,
 	}
 	l.log(Warn, msg)
 }
-

--- a/internal/logging/sanitize.go
+++ b/internal/logging/sanitize.go
@@ -9,9 +9,13 @@ import (
 // Returns the URL without userinfo and query, preserving scheme, host, and path.
 func SanitizeURL(raw string) string {
 	s := strings.TrimSpace(raw)
-	if s == "" { return s }
+	if s == "" {
+		return s
+	}
 	u, err := url.Parse(s)
-	if err != nil { return s }
+	if err != nil {
+		return s
+	}
 	// If no scheme and no authority, keep as-is to avoid percent-encoding spaces
 	if u.Scheme == "" && !strings.Contains(s, "://") {
 		return s
@@ -21,4 +25,3 @@ func SanitizeURL(raw string) string {
 	u.Fragment = ""
 	return u.String()
 }
-

--- a/internal/logging/sanitize_test.go
+++ b/internal/logging/sanitize_test.go
@@ -3,8 +3,8 @@ package logging
 import "testing"
 
 func TestSanitizeURL(t *testing.T) {
-	cases := []struct{
-		in string
+	cases := []struct {
+		in   string
 		want string
 	}{
 		{"https://user:pass@example.com/path?token=secret&x=1#frag", "https://example.com/path"},
@@ -18,4 +18,3 @@ func TestSanitizeURL(t *testing.T) {
 		}
 	}
 }
-

--- a/internal/placer/placer.go
+++ b/internal/placer/placer.go
@@ -1,17 +1,15 @@
 package placer
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"modfetch/internal/classifier"
 	"modfetch/internal/config"
+	"modfetch/internal/util"
 )
 
 // ComputeTargets returns absolute destination directories for an artifact type
@@ -116,16 +114,7 @@ func exists(p string) bool {
 }
 
 func sha256File(p string) (string, error) {
-	f, err := os.Open(p)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = f.Close() }()
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(h.Sum(nil)), nil
+	return util.HashFileSHA256(p)
 }
 
 func sameSHA256(p string, want string) (bool, error) {

--- a/internal/placer/placer.go
+++ b/internal/placer/placer.go
@@ -3,6 +3,7 @@ package placer
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"

--- a/internal/placer/placer_test.go
+++ b/internal/placer/placer_test.go
@@ -13,42 +13,55 @@ func TestPlaceSymlinkCheckpoint(t *testing.T) {
 	// Build config mapping sd.checkpoint -> comfyui.checkpoints
 	cfgPath := filepath.Join(tmp, "cfg.yml")
 	checkpointDir := filepath.Join(tmp, "ComfyUI", "models", "checkpoints")
-	cfgYaml := []byte("version: 1\n"+
-		"general:\n"+
-		"  data_root: \""+tmp+"/data\"\n"+
-		"  download_root: \""+tmp+"/dl\"\n"+
-		"  placement_mode: symlink\n"+
-		"  allow_overwrite: true\n"+
-		"placement:\n"+
-		"  apps:\n"+
-		"    comfyui:\n"+
-		"      base: \""+filepath.Join(tmp, "ComfyUI")+"\"\n"+
-		"      paths:\n"+
-		"        checkpoints: models/checkpoints\n"+
-		"  mapping:\n"+
-		"    - match: sd.checkpoint\n"+
-		"      targets:\n"+
-		"        - app: comfyui\n"+
+	cfgYaml := []byte("version: 1\n" +
+		"general:\n" +
+		"  data_root: \"" + tmp + "/data\"\n" +
+		"  download_root: \"" + tmp + "/dl\"\n" +
+		"  placement_mode: symlink\n" +
+		"  allow_overwrite: true\n" +
+		"placement:\n" +
+		"  apps:\n" +
+		"    comfyui:\n" +
+		"      base: \"" + filepath.Join(tmp, "ComfyUI") + "\"\n" +
+		"      paths:\n" +
+		"        checkpoints: models/checkpoints\n" +
+		"  mapping:\n" +
+		"    - match: sd.checkpoint\n" +
+		"      targets:\n" +
+		"        - app: comfyui\n" +
 		"          path_key: checkpoints\n")
-	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	cfg, err := config.Load(cfgPath)
-	if err != nil { t.Fatalf("config load: %v", err) }
+	if err != nil {
+		t.Fatalf("config load: %v", err)
+	}
 
 	// Create a dummy safetensors file to classify as sd.checkpoint
 	src := filepath.Join(tmp, "model.safetensors")
-	if err := os.WriteFile(src, []byte("dummy-weights"), 0o644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(src, []byte("dummy-weights"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	paths, err := Place(cfg, src, "", "")
-	if err != nil { t.Fatalf("place: %v", err) }
-	if len(paths) != 1 { t.Fatalf("expected 1 path, got %d", len(paths)) }
+	if err != nil {
+		t.Fatalf("place: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 path, got %d", len(paths))
+	}
 	dst := paths[0]
 	// Expect symlink exists and points somewhere
 	fi, err := os.Lstat(dst)
-	if err != nil { t.Fatalf("dst lstat: %v", err) }
-	if fi.Mode()&os.ModeSymlink == 0 { t.Fatalf("expected symlink at %s", dst) }
+	if err != nil {
+		t.Fatalf("dst lstat: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected symlink at %s", dst)
+	}
 	// And parent directory is the configured checkpoints dir
 	if filepath.Dir(dst) != checkpointDir {
 		t.Fatalf("expected parent %s, got %s", checkpointDir, filepath.Dir(dst))
 	}
 }
-

--- a/internal/resolver/civitai_test.go
+++ b/internal/resolver/civitai_test.go
@@ -45,22 +45,28 @@ func TestCivitAIResolve_ModelLatestAndHeaders(t *testing.T) {
 	// Override base URL for resolver
 	oldBase := civitaiBaseURL
 	civitaiBaseURL = tsURL
-	defer func(){ civitaiBaseURL = oldBase }()
+	defer func() { civitaiBaseURL = oldBase }()
 
 	// Config enabling CivitAI with token env
 	tmp := t.TempDir()
 	cfgPath := filepath.Join(tmp, "cfg.yml")
-	cfgYaml := []byte("version: 1\n"+
-		"general:\n  data_root: \""+tmp+"/data\"\n  download_root: \""+tmp+"/dl\"\n"+
+	cfgYaml := []byte("version: 1\n" +
+		"general:\n  data_root: \"" + tmp + "/data\"\n  download_root: \"" + tmp + "/dl\"\n" +
 		"sources:\n  civitai:\n    enabled: true\n    token_env: \"CIVITAI_TOKEN\"\n")
-	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	_ = os.Setenv("CIVITAI_TOKEN", "XYZ")
 	cfg, err := config.Load(cfgPath)
-	if err != nil { t.Fatalf("config: %v", err) }
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
 
 	// Latest primary
 	res, err := (&CivitAI{}).Resolve(context.Background(), "civitai://model/123", cfg)
-	if err != nil { t.Fatalf("resolve: %v", err) }
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
 	if !strings.HasSuffix(res.URL, "/dl/primary.bin") {
 		t.Fatalf("unexpected url: %s", res.URL)
 	}
@@ -74,7 +80,9 @@ func TestCivitAIResolve_ModelLatestAndHeaders(t *testing.T) {
 
 	// Filter by file name substring
 	res2, err := (&CivitAI{}).Resolve(context.Background(), "civitai://model/123?file=vae", cfg)
-	if err != nil { t.Fatalf("resolve2: %v", err) }
+	if err != nil {
+		t.Fatalf("resolve2: %v", err)
+	}
 	if !strings.HasSuffix(res2.URL, "/dl/vae.bin") {
 		t.Fatalf("unexpected url2: %s", res2.URL)
 	}
@@ -84,7 +92,9 @@ func TestCivitAIResolve_ModelLatestAndHeaders(t *testing.T) {
 
 	// Specific version
 	res3, err := (&CivitAI{}).Resolve(context.Background(), "civitai://model/123?version=12", cfg)
-	if err != nil { t.Fatalf("resolve3: %v", err) }
+	if err != nil {
+		t.Fatalf("resolve3: %v", err)
+	}
 	if !strings.HasSuffix(res3.URL, "/dl/mv.bin") {
 		t.Fatalf("unexpected url3: %s", res3.URL)
 	}
@@ -113,4 +123,3 @@ type respRewriter struct {
 func (rw *respRewriter) Write(b []byte) (int, error) {
 	return rw.ResponseWriter.Write([]byte(strings.ReplaceAll(string(b), tsURLPlaceholder, rw.replace)))
 }
-

--- a/internal/resolver/huggingface.go
+++ b/internal/resolver/huggingface.go
@@ -15,12 +15,16 @@ import (
 type HuggingFace struct{}
 
 // Accepts URIs of the form:
-//   hf://{owner}/{repo}/{path}?rev=main
+//
+//	hf://{owner}/{repo}/{path}?rev=main
+//
 // If rev is omitted, defaults to "main".
 func (h *HuggingFace) CanHandle(u string) bool { return strings.HasPrefix(u, "hf://") }
 
 func (h *HuggingFace) Resolve(ctx context.Context, uri string, cfg *config.Config) (*Resolved, error) {
-	if !h.CanHandle(uri) { return nil, errors.New("unsupported scheme") }
+	if !h.CanHandle(uri) {
+		return nil, errors.New("unsupported scheme")
+	}
 	s := strings.TrimPrefix(uri, "hf://")
 	// Split off query
 	var rawPath, rawQuery string
@@ -48,11 +52,15 @@ func (h *HuggingFace) Resolve(ctx context.Context, uri string, cfg *config.Confi
 	rev := "main"
 	if rawQuery != "" {
 		q, _ := url.ParseQuery(rawQuery)
-		if v := q.Get("rev"); v != "" { rev = v }
+		if v := q.Get("rev"); v != "" {
+			rev = v
+		}
 	}
 	// Construct resolve URL
 	repoID := repo
-	if strings.TrimSpace(owner) != "" { repoID = owner + "/" + repo }
+	if strings.TrimSpace(owner) != "" {
+		repoID = owner + "/" + repo
+	}
 	base := "https://huggingface.co/" + repoID
 	resURL := base + "/resolve/" + url.PathEscape(rev) + "/" + strings.ReplaceAll(filePath, "+", "%2B")
 
@@ -78,7 +86,9 @@ func (h *HuggingFace) Resolve(ctx context.Context, uri string, cfg *config.Confi
 			"file_name": fileName,
 		}
 		suggested = util.SafeFileName(util.ExpandPattern(pat, tokens))
-		if strings.TrimSpace(suggested) == "" { suggested = "" }
+		if strings.TrimSpace(suggested) == "" {
+			suggested = ""
+		}
 	}
 	if suggested == "" {
 		suggested = util.SafeFileName(fileName)
@@ -88,4 +98,3 @@ func (h *HuggingFace) Resolve(ctx context.Context, uri string, cfg *config.Confi
 
 // getenv split to enable testing
 var getenv = os.Getenv
-

--- a/internal/resolver/huggingface_test.go
+++ b/internal/resolver/huggingface_test.go
@@ -12,13 +12,22 @@ import (
 func TestHFResolveBasic(t *testing.T) {
 	tmp := t.TempDir()
 	cfgPath := filepath.Join(tmp, "cfg.yml")
-	cfgYaml := []byte("version: 1\ngeneral:\n  data_root: \""+tmp+"\"\n  download_root: \""+tmp+"\"\n")
-	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil { t.Fatal(err) }
+	cfgYaml := []byte("version: 1\ngeneral:\n  data_root: \"" + tmp + "\"\n  download_root: \"" + tmp + "\"\n")
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	cfg, err := config.Load(cfgPath)
-	if err != nil { t.Fatalf("config: %v", err) }
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
 	res, err := (&HuggingFace{}).Resolve(context.Background(), "hf://gpt2/README.md?rev=main", cfg)
-	if err != nil { t.Fatalf("resolve: %v", err) }
-	if res.URL == "" { t.Fatalf("empty url") }
-	if res.Headers == nil { t.Fatalf("nil headers") }
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if res.URL == "" {
+		t.Fatalf("empty url")
+	}
+	if res.Headers == nil {
+		t.Fatalf("nil headers")
+	}
 }
-

--- a/internal/state/chunks.go
+++ b/internal/state/chunks.go
@@ -40,7 +40,7 @@ func (db *DB) InitChunksTable() error {
 
 func (db *DB) UpsertChunk(c ChunkRow) error {
 	_, err := db.SQL.Exec(`INSERT INTO chunks(url,dest,idx,start,end,size,sha256,status,updated_at) VALUES(?,?,?,?,?,?,?,?,strftime('%s','now'))
-ON CONFLICT(url,dest,idx) DO UPDATE SET start=excluded.start,end=excluded.end,size=excluded.size,sha256=excluded.sha256,status=excluded.status,updated_at=strftime('%s','now')`,
+ON CONFLICT(url,dest,idx) DO UPDATE SET start=excluded.start,end=excluded.end,size=excluded.size,sha256=COALESCE(NULLIF(excluded.sha256, ''), chunks.sha256),status=excluded.status,updated_at=strftime('%s','now')`,
 		c.URL, c.Dest, c.Index, c.Start, c.End, c.Size, c.SHA256, c.Status)
 	return err
 }
@@ -48,7 +48,7 @@ ON CONFLICT(url,dest,idx) DO UPDATE SET start=excluded.start,end=excluded.end,si
 // Tx variants for grouping operations atomically
 func (db *DB) UpsertChunkTx(tx *sql.Tx, c ChunkRow) error {
 	_, err := tx.Exec(`INSERT INTO chunks(url,dest,idx,start,end,size,sha256,status,updated_at) VALUES(?,?,?,?,?,?,?,?,strftime('%s','now'))
-ON CONFLICT(url,dest,idx) DO UPDATE SET start=excluded.start,end=excluded.end,size=excluded.size,sha256=excluded.sha256,status=excluded.status,updated_at=strftime('%s','now')`,
+ON CONFLICT(url,dest,idx) DO UPDATE SET start=excluded.start,end=excluded.end,size=excluded.size,sha256=COALESCE(NULLIF(excluded.sha256, ''), chunks.sha256),status=excluded.status,updated_at=strftime('%s','now')`,
 		c.URL, c.Dest, c.Index, c.Start, c.End, c.Size, c.SHA256, c.Status)
 	return err
 }

--- a/internal/state/chunks.go
+++ b/internal/state/chunks.go
@@ -1,24 +1,27 @@
 package state
 
 import (
+	"database/sql"
 	"errors"
 )
 
 type ChunkRow struct {
-	URL      string
-	Dest     string
-	Index    int
-	Start    int64
-	End      int64
-	Size     int64
-	SHA256   string
-	Status   string // pending | running | complete | dirty
+	URL    string
+	Dest   string
+	Index  int
+	Start  int64
+	End    int64
+	Size   int64
+	SHA256 string
+	Status string // pending | running | complete | dirty
 }
 
 func init() {}
 
 func (db *DB) InitChunksTable() error {
-	if db == nil || db.SQL == nil { return errors.New("nil db") }
+	if db == nil || db.SQL == nil {
+		return errors.New("nil db")
+	}
 	_, err := db.SQL.Exec(`CREATE TABLE IF NOT EXISTS chunks (
 		url TEXT NOT NULL,
 		dest TEXT NOT NULL,
@@ -37,19 +40,46 @@ func (db *DB) InitChunksTable() error {
 
 func (db *DB) UpsertChunk(c ChunkRow) error {
 	_, err := db.SQL.Exec(`INSERT INTO chunks(url,dest,idx,start,end,size,sha256,status,updated_at) VALUES(?,?,?,?,?,?,?,?,strftime('%s','now'))
-	ON CONFLICT(url,dest,idx) DO UPDATE SET start=excluded.start,end=excluded.end,size=excluded.size,sha256=excluded.sha256,status=excluded.status,updated_at=strftime('%s','now')`,
+ON CONFLICT(url,dest,idx) DO UPDATE SET start=excluded.start,end=excluded.end,size=excluded.size,sha256=excluded.sha256,status=excluded.status,updated_at=strftime('%s','now')`,
 		c.URL, c.Dest, c.Index, c.Start, c.End, c.Size, c.SHA256, c.Status)
+	return err
+}
+
+// Tx variants for grouping operations atomically
+func (db *DB) UpsertChunkTx(tx *sql.Tx, c ChunkRow) error {
+	_, err := tx.Exec(`INSERT INTO chunks(url,dest,idx,start,end,size,sha256,status,updated_at) VALUES(?,?,?,?,?,?,?,?,strftime('%s','now'))
+ON CONFLICT(url,dest,idx) DO UPDATE SET start=excluded.start,end=excluded.end,size=excluded.size,sha256=excluded.sha256,status=excluded.status,updated_at=strftime('%s','now')`,
+		c.URL, c.Dest, c.Index, c.Start, c.End, c.Size, c.SHA256, c.Status)
+	return err
+}
+
+func (db *DB) UpdateChunkStatusTx(tx *sql.Tx, url, dest string, idx int, status string) error {
+	_, err := tx.Exec(`UPDATE chunks SET status=?, updated_at=strftime('%s','now') WHERE url=? AND dest=? AND idx=?`, status, url, dest, idx)
+	return err
+}
+
+func (db *DB) UpdateChunkSHATx(tx *sql.Tx, url, dest string, idx int, sha string) error {
+	_, err := tx.Exec(`UPDATE chunks SET sha256=?, updated_at=strftime('%s','now') WHERE url=? AND dest=? AND idx=?`, sha, url, dest, idx)
+	return err
+}
+
+func (db *DB) DeleteChunksTx(tx *sql.Tx, url, dest string) error {
+	_, err := tx.Exec(`DELETE FROM chunks WHERE url=? AND dest=?`, url, dest)
 	return err
 }
 
 func (db *DB) ListChunks(url, dest string) ([]ChunkRow, error) {
 	rows, err := db.SQL.Query(`SELECT url,dest,idx,start,end,size,sha256,status FROM chunks WHERE url=? AND dest=? ORDER BY idx`, url, dest)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	defer func() { _ = rows.Close() }()
 	var out []ChunkRow
 	for rows.Next() {
 		var c ChunkRow
-		if err := rows.Scan(&c.URL, &c.Dest, &c.Index, &c.Start, &c.End, &c.Size, &c.SHA256, &c.Status); err != nil { return nil, err }
+		if err := rows.Scan(&c.URL, &c.Dest, &c.Index, &c.Start, &c.End, &c.Size, &c.SHA256, &c.Status); err != nil {
+			return nil, err
+		}
 		out = append(out, c)
 	}
 	return out, rows.Err()
@@ -70,4 +100,3 @@ func (db *DB) DeleteChunks(url, dest string) error {
 	_, err := db.SQL.Exec(`DELETE FROM chunks WHERE url=? AND dest=?`, url, dest)
 	return err
 }
-

--- a/internal/state/hostcaps.go
+++ b/internal/state/hostcaps.go
@@ -6,13 +6,15 @@ import (
 )
 
 type HostCaps struct {
-	Host          string
-	HeadOK        bool
-	AcceptRanges  bool
+	Host         string
+	HeadOK       bool
+	AcceptRanges bool
 }
 
 func (db *DB) InitHostCapsTable() error {
-	if db == nil || db.SQL == nil { return errors.New("nil db") }
+	if db == nil || db.SQL == nil {
+		return errors.New("nil db")
+	}
 	_, err := db.SQL.Exec(`CREATE TABLE IF NOT EXISTS host_caps (
 		host TEXT PRIMARY KEY,
 		head_ok INTEGER NOT NULL,
@@ -23,7 +25,9 @@ func (db *DB) InitHostCapsTable() error {
 }
 
 func (db *DB) UpsertHostCaps(host string, headOK, acceptRanges bool) error {
-	if db == nil || db.SQL == nil { return errors.New("nil db") }
+	if db == nil || db.SQL == nil {
+		return errors.New("nil db")
+	}
 	_, err := db.SQL.Exec(`INSERT INTO host_caps(host, head_ok, accept_ranges, updated_at) VALUES(?,?,?,strftime('%s','now'))
 	ON CONFLICT(host) DO UPDATE SET head_ok=excluded.head_ok, accept_ranges=excluded.accept_ranges, updated_at=strftime('%s','now')`,
 		host, boolToInt(headOK), boolToInt(acceptRanges))
@@ -31,7 +35,9 @@ func (db *DB) UpsertHostCaps(host string, headOK, acceptRanges bool) error {
 }
 
 func (db *DB) GetHostCaps(host string) (HostCaps, bool, error) {
-	if db == nil || db.SQL == nil { return HostCaps{}, false, errors.New("nil db") }
+	if db == nil || db.SQL == nil {
+		return HostCaps{}, false, errors.New("nil db")
+	}
 	var hc HostCaps
 	var headOK, acc int
 	row := db.SQL.QueryRow(`SELECT head_ok, accept_ranges FROM host_caps WHERE host=?`, host)
@@ -48,15 +54,21 @@ func (db *DB) GetHostCaps(host string) (HostCaps, bool, error) {
 
 // ListHostCaps returns all cached host capabilities.
 func (db *DB) ListHostCaps() ([]HostCaps, error) {
-	if db == nil || db.SQL == nil { return nil, errors.New("nil db") }
+	if db == nil || db.SQL == nil {
+		return nil, errors.New("nil db")
+	}
 	rows, err := db.SQL.Query(`SELECT host, head_ok, accept_ranges FROM host_caps ORDER BY host`)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	defer func() { _ = rows.Close() }()
 	var out []HostCaps
 	for rows.Next() {
 		var host string
 		var head, acc int
-		if err := rows.Scan(&host, &head, &acc); err != nil { return nil, err }
+		if err := rows.Scan(&host, &head, &acc); err != nil {
+			return nil, err
+		}
 		out = append(out, HostCaps{Host: host, HeadOK: head != 0, AcceptRanges: acc != 0})
 	}
 	return out, rows.Err()
@@ -64,17 +76,25 @@ func (db *DB) ListHostCaps() ([]HostCaps, error) {
 
 // DeleteHostCaps deletes a single host from the cache.
 func (db *DB) DeleteHostCaps(host string) error {
-	if db == nil || db.SQL == nil { return errors.New("nil db") }
+	if db == nil || db.SQL == nil {
+		return errors.New("nil db")
+	}
 	_, err := db.SQL.Exec(`DELETE FROM host_caps WHERE host=?`, host)
 	return err
 }
 
 // ClearHostCaps deletes all host capabilities from the cache.
 func (db *DB) ClearHostCaps() error {
-	if db == nil || db.SQL == nil { return errors.New("nil db") }
+	if db == nil || db.SQL == nil {
+		return errors.New("nil db")
+	}
 	_, err := db.SQL.Exec(`DELETE FROM host_caps`)
 	return err
 }
 
-func boolToInt(b bool) int { if b { return 1 }; return 0 }
-
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/state/hostcaps_test.go
+++ b/internal/state/hostcaps_test.go
@@ -1,20 +1,30 @@
 package state
 
 import (
-	"testing"
 	"modfetch/internal/config"
+	"testing"
 )
 
 func TestHostCapsUpsertGet(t *testing.T) {
-	cfg := &config.Config{Version:1, General: config.General{DataRoot: t.TempDir(), DownloadRoot: t.TempDir()}}
+	cfg := &config.Config{Version: 1, General: config.General{DataRoot: t.TempDir(), DownloadRoot: t.TempDir()}}
 	dbptr, err := Open(cfg)
-	if err != nil { t.Fatalf("open: %v", err) }
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
 	defer func() { _ = dbptr.SQL.Close() }()
 
 	host := "example.com"
-	if err := dbptr.UpsertHostCaps(host, true, false); err != nil { t.Fatalf("upsert: %v", err) }
+	if err := dbptr.UpsertHostCaps(host, true, false); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
 	got, ok, err := dbptr.GetHostCaps(host)
-	if err != nil { t.Fatalf("get: %v", err) }
-	if !ok { t.Fatalf("expected row") }
-	if !got.HeadOK || got.AcceptRanges { t.Fatalf("unexpected caps: %+v", got) }
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected row")
+	}
+	if !got.HeadOK || got.AcceptRanges {
+		t.Fatalf("unexpected caps: %+v", got)
+	}
 }

--- a/internal/tui/configwizard/wizard.go
+++ b/internal/tui/configwizard/wizard.go
@@ -34,9 +34,15 @@ func New(defaults *config.Config) *Wizard {
 	dd := "~/modfetch/downloads"
 	pm := "symlink"
 	if defaults != nil {
-		if defaults.General.DataRoot != "" { dr = defaults.General.DataRoot }
-		if defaults.General.DownloadRoot != "" { dd = defaults.General.DownloadRoot }
-		if defaults.General.PlacementMode != "" { pm = defaults.General.PlacementMode }
+		if defaults.General.DataRoot != "" {
+			dr = defaults.General.DataRoot
+		}
+		if defaults.General.DownloadRoot != "" {
+			dd = defaults.General.DownloadRoot
+		}
+		if defaults.General.PlacementMode != "" {
+			pm = defaults.General.PlacementMode
+		}
 	}
 	fields = append(fields, mk("general.data_root", dr))
 	fields = append(fields, mk("general.download_root", dd))
@@ -48,10 +54,22 @@ func New(defaults *config.Config) *Wizard {
 	cvEn := "true"
 	cvTok := "CIVITAI_TOKEN"
 	if defaults != nil {
-		if defaults.Sources.HuggingFace.Enabled { hfEn = "true" } else { hfEn = "false" }
-		if defaults.Sources.HuggingFace.TokenEnv != "" { hfTok = defaults.Sources.HuggingFace.TokenEnv }
-		if defaults.Sources.CivitAI.Enabled { cvEn = "true" } else { cvEn = "false" }
-		if defaults.Sources.CivitAI.TokenEnv != "" { cvTok = defaults.Sources.CivitAI.TokenEnv }
+		if defaults.Sources.HuggingFace.Enabled {
+			hfEn = "true"
+		} else {
+			hfEn = "false"
+		}
+		if defaults.Sources.HuggingFace.TokenEnv != "" {
+			hfTok = defaults.Sources.HuggingFace.TokenEnv
+		}
+		if defaults.Sources.CivitAI.Enabled {
+			cvEn = "true"
+		} else {
+			cvEn = "false"
+		}
+		if defaults.Sources.CivitAI.TokenEnv != "" {
+			cvTok = defaults.Sources.CivitAI.TokenEnv
+		}
 	}
 	fields = append(fields, mk("sources.huggingface.enabled (true|false)", hfEn))
 	fields = append(fields, mk("sources.huggingface.token_env", hfTok))
@@ -61,8 +79,12 @@ func New(defaults *config.Config) *Wizard {
 	csm := 8
 	pfc := 4
 	if defaults != nil {
-		if defaults.Concurrency.ChunkSizeMB > 0 { csm = defaults.Concurrency.ChunkSizeMB }
-		if defaults.Concurrency.PerFileChunks > 0 { pfc = defaults.Concurrency.PerFileChunks }
+		if defaults.Concurrency.ChunkSizeMB > 0 {
+			csm = defaults.Concurrency.ChunkSizeMB
+		}
+		if defaults.Concurrency.PerFileChunks > 0 {
+			pfc = defaults.Concurrency.PerFileChunks
+		}
 	}
 	fields = append(fields, mk("concurrency.chunk_size_mb", fmt.Sprint(csm)))
 	fields = append(fields, mk("concurrency.per_file_chunks", fmt.Sprint(pfc)))
@@ -92,16 +114,30 @@ func (w *Wizard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			if m.String() == "up" || m.String() == "shift+tab" {
-				w.focus--; if w.focus < 0 { w.focus = 0 }
+				w.focus--
+				if w.focus < 0 {
+					w.focus = 0
+				}
 			} else {
-				w.focus++; if w.focus >= len(w.inputs) { w.focus = len(w.inputs)-1 }
+				w.focus++
+				if w.focus >= len(w.inputs) {
+					w.focus = len(w.inputs) - 1
+				}
 			}
-			for j := range w.inputs { if j == w.focus { w.inputs[j].Focus() } else { w.inputs[j].Blur() } }
+			for j := range w.inputs {
+				if j == w.focus {
+					w.inputs[j].Focus()
+				} else {
+					w.inputs[j].Blur()
+				}
+			}
 		}
 	}
 	// Update all inputs
 	cmds := make([]tea.Cmd, len(w.inputs))
-	for i := range w.inputs { w.inputs[i], cmds[i] = w.inputs[i].Update(msg) }
+	for i := range w.inputs {
+		w.inputs[i], cmds[i] = w.inputs[i].Update(msg)
+	}
 	return w, tea.Batch(cmds...)
 }
 
@@ -122,7 +158,9 @@ func (w *Wizard) View() string {
 	}
 	for i, input := range w.inputs {
 		marker := " "
-		if i == w.focus { marker = ">" }
+		if i == w.focus {
+			marker = ">"
+		}
 		b.WriteString(fmt.Sprintf("%s %-32s %s\n", marker, labels[i]+":", input.View()))
 	}
 	if w.done {
@@ -133,13 +171,22 @@ func (w *Wizard) View() string {
 
 func (w *Wizard) buildConfig() *config.Config {
 	get := func(i int) string { return strings.TrimSpace(w.inputs[i].Value()) }
-	parseBool := func(s string) bool { return strings.EqualFold(s, "true") || s == "1" || strings.EqualFold(s, "y") || strings.EqualFold(s, "yes") }
-	parseInt := func(s string, def int) int { if n, err := strconv.Atoi(strings.TrimSpace(s)); err == nil && n >= 0 { return n }; return def }
+	parseBool := func(s string) bool {
+		return strings.EqualFold(s, "true") || s == "1" || strings.EqualFold(s, "y") || strings.EqualFold(s, "yes")
+	}
+	parseInt := func(s string, def int) int {
+		if n, err := strconv.Atoi(strings.TrimSpace(s)); err == nil && n >= 0 {
+			return n
+		}
+		return def
+	}
 	o := &config.Config{Version: 1}
 	o.General.DataRoot = get(0)
 	o.General.DownloadRoot = get(1)
 	pm := strings.ToLower(get(2))
-	if pm != "symlink" && pm != "hardlink" && pm != "copy" { pm = "symlink" }
+	if pm != "symlink" && pm != "hardlink" && pm != "copy" {
+		pm = "symlink"
+	}
 	o.General.PlacementMode = pm
 	o.Sources.HuggingFace.Enabled = parseBool(get(3))
 	o.Sources.HuggingFace.TokenEnv = get(4)
@@ -151,4 +198,3 @@ func (w *Wizard) buildConfig() *config.Config {
 }
 
 func (w *Wizard) Config() *config.Config { return w.out }
-

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3,13 +3,13 @@ package tui
 import (
 	"context"
 	"fmt"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
-	neturl "net/url"
 	"strings"
 	"time"
 
@@ -19,27 +19,27 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/dustin/go-humanize"
 	"modfetch/internal/config"
-	"modfetch/internal/state"
-	"modfetch/internal/logging"
 	"modfetch/internal/downloader"
+	"modfetch/internal/logging"
 	"modfetch/internal/resolver"
+	"modfetch/internal/state"
 )
 
 type model struct {
-	cfg      *config.Config
-	st       *state.DB
-	rows     []state.DownloadRow
-	selected int
-	showInfo bool
-	showHelp bool
-	menuOn   bool
-	menuIndex int
-	menuItems []string
-	filterOn bool
-	filter   textinput.Model
-	sortMode string // ""|"speed"|"eta"
+	cfg          *config.Config
+	st           *state.DB
+	rows         []state.DownloadRow
+	selected     int
+	showInfo     bool
+	showHelp     bool
+	menuOn       bool
+	menuIndex    int
+	menuItems    []string
+	filterOn     bool
+	filter       textinput.Model
+	sortMode     string // ""|"speed"|"eta"
 	filterPreset string // all|active|errors
-	groupOn  bool
+	groupOn      bool
 	showURLFirst bool
 	// new download modal
 	newDL    bool
@@ -48,13 +48,13 @@ type model struct {
 	newFocus int
 	newMsg   string
 	// onboarding tips
-	tipsOn   bool
+	tipsOn bool
 	// running downloads control (only those started via TUI)
 	running map[string]context.CancelFunc
 	// ephemeral starters (resolving/preflight), keyed by URL|Dest
 	ephems  map[string]ephemeral
-	spin   int
-	err      error
+	spin    int
+	err     error
 	width   int
 	height  int
 	refresh time.Duration
@@ -72,9 +72,17 @@ type ephemeral struct {
 	When time.Time
 }
 
-type dlDoneMsg struct { url string; dest string; path string; err error }
+type dlDoneMsg struct {
+	url  string
+	dest string
+	path string
+	err  error
+}
 
-type obs struct{ bytes int64; t time.Time }
+type obs struct {
+	bytes int64
+	t     time.Time
+}
 
 type uiStyles struct {
 	header lipgloss.Style
@@ -97,35 +105,75 @@ func New(cfg *config.Config, st *state.DB) tea.Model {
 	}
 	ti := textinput.New()
 	ti.Placeholder = "filter (url or dest contains)"
-m := &model{cfg: cfg, st: st, refresh: time.Second, prog: p, styles: styles, filter: ti, prev: map[string]obs{}, filterPreset: "all", tipsOn: true, running: map[string]context.CancelFunc{}, ephems: map[string]ephemeral{}, menuItems: []string{"New download","Filter preset","Group by status","Toggle columns","Sort by speed","Sort by ETA","Clear sort","Help","Refresh","Quit"}}
+	m := &model{cfg: cfg, st: st, refresh: time.Second, prog: p, styles: styles, filter: ti, prev: map[string]obs{}, filterPreset: "all", tipsOn: true, running: map[string]context.CancelFunc{}, ephems: map[string]ephemeral{}, menuItems: []string{"New download", "Filter preset", "Group by status", "Toggle columns", "Sort by speed", "Sort by ETA", "Clear sort", "Help", "Refresh", "Quit"}}
 	// new download inputs
-	m.newURL = textinput.New(); m.newURL.Placeholder = "URL (https://..., hf://..., civitai://...)"; m.newURL.CharLimit = 4096
-	m.newDest = textinput.New(); m.newDest.Placeholder = "Destination path (optional)"; m.newDest.CharLimit = 4096
+	m.newURL = textinput.New()
+	m.newURL.Placeholder = "URL (https://..., hf://..., civitai://...)"
+	m.newURL.CharLimit = 4096
+	m.newDest = textinput.New()
+	m.newDest.Placeholder = "Destination path (optional)"
+	m.newDest.CharLimit = 4096
 	return m
 }
 
+type recoverRowsMsg struct{ rows []state.DownloadRow }
+
 func (m *model) Init() tea.Cmd {
+	if m.cfg != nil && m.cfg.General.AutoRecoverOnStart {
+		return tea.Batch(refreshCmd(), tickCmd(m.refresh), m.recoverCmd())
+	}
 	return tea.Batch(refreshCmd(), tickCmd(m.refresh))
 }
 
 func refreshCmd() tea.Cmd { return func() tea.Msg { return refreshMsg{} } }
 
-func tickCmd(d time.Duration) tea.Cmd { return tea.Tick(d, func(t time.Time) tea.Msg { return tickMsg(t) }) }
+func (m *model) recoverCmd() tea.Cmd {
+	return func() tea.Msg {
+		rows, err := m.st.ListDownloads()
+		if err != nil {
+			return recoverRowsMsg{rows: nil}
+		}
+		var todo []state.DownloadRow
+		for _, r := range rows {
+			st := strings.ToLower(strings.TrimSpace(r.Status))
+			if st == "running" || st == "hold" {
+				todo = append(todo, r)
+			}
+		}
+		return recoverRowsMsg{rows: todo}
+	}
+}
+
+func tickCmd(d time.Duration) tea.Cmd {
+	return tea.Tick(d, func(t time.Time) tea.Msg { return tickMsg(t) })
+}
 
 func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 		return m, nil
-case tea.KeyMsg:
+	case tea.KeyMsg:
 		// Handle menu navigation
 		if m.menuOn && !m.newDL {
 			sw := msg.String()
 			switch sw {
-			case "up": if m.menuIndex>0 { m.menuIndex-- }; return m, nil
-			case "down": if m.menuIndex < len(m.menuItems)-1 { m.menuIndex++ }; return m, nil
-			case "enter": m.menuOn=false; return m, m.applyMenuChoice(m.menuIndex)
-			case "esc","m": m.menuOn=false; return m, nil
+			case "up":
+				if m.menuIndex > 0 {
+					m.menuIndex--
+				}
+				return m, nil
+			case "down":
+				if m.menuIndex < len(m.menuItems)-1 {
+					m.menuIndex++
+				}
+				return m, nil
+			case "enter":
+				m.menuOn = false
+				return m, m.applyMenuChoice(m.menuIndex)
+			case "esc", "m":
+				m.menuOn = false
+				return m, nil
 			}
 		}
 		// Handle new download modal key events first
@@ -133,19 +181,27 @@ case tea.KeyMsg:
 			sw := msg.String()
 			switch sw {
 			case "esc":
-				m.newDL = false; m.newMsg = ""; return m, nil
+				m.newDL = false
+				m.newMsg = ""
+				return m, nil
 			case "tab":
 				m.newFocus = (m.newFocus + 1) % 2
 				return m, nil
 			case "shift+tab":
 				m.newFocus = (m.newFocus + 1 + 2 - 1) % 2
 				return m, nil
-case "enter":
+			case "enter":
 				url := strings.TrimSpace(m.newURL.Value())
 				dest := strings.TrimSpace(m.newDest.Value())
-				if url == "" { m.newMsg = "URL required"; return m, nil }
+				if url == "" {
+					m.newMsg = "URL required"
+					return m, nil
+				}
 				dg := strings.TrimSpace(m.destGuess(url, dest))
-				if err := m.preflightForDownload(url, dg); err != nil { m.newMsg = "preflight failed: "+err.Error(); return m, nil }
+				if err := m.preflightForDownload(url, dg); err != nil {
+					m.newMsg = "preflight failed: " + err.Error()
+					return m, nil
+				}
 				m.addEphemeral(url, dg)
 				m.newMsg = "starting download..."
 				// close the modal immediately so focus returns to the table
@@ -153,8 +209,16 @@ case "enter":
 				return m, m.startDownloadCmd(url, dg)
 			}
 			// route typing to focused input
-			if m.newFocus == 0 { var cmd tea.Cmd; m.newURL, cmd = m.newURL.Update(msg); return m, cmd }
-			{ var cmd tea.Cmd; m.newDest, cmd = m.newDest.Update(msg); return m, cmd }
+			if m.newFocus == 0 {
+				var cmd tea.Cmd
+				m.newURL, cmd = m.newURL.Update(msg)
+				return m, cmd
+			}
+			{
+				var cmd tea.Cmd
+				m.newDest, cmd = m.newDest.Update(msg)
+				return m, cmd
+			}
 		}
 		switch msg.String() {
 		case "q", "ctrl+c":
@@ -166,19 +230,39 @@ case "enter":
 			m.filter.Focus()
 			return m, nil
 		case "enter":
-			if m.filterOn { m.filterOn = false; m.filter.Blur(); return m, refreshCmd() }
+			if m.filterOn {
+				m.filterOn = false
+				m.filter.Blur()
+				return m, refreshCmd()
+			}
 			return m, nil
 		case "esc":
-			if m.filterOn { m.filterOn = false; m.filter.SetValue(""); m.filter.Blur(); return m, refreshCmd() }
+			if m.filterOn {
+				m.filterOn = false
+				m.filter.SetValue("")
+				m.filter.Blur()
+				return m, refreshCmd()
+			}
 			return m, nil
 		case "j", "down":
-			if m.selected < len(m.rows)-1 { m.selected++ }
+			if m.selected < len(m.rows)-1 {
+				m.selected++
+			}
 			return m, nil
 		case "k", "up":
-			if m.selected > 0 { m.selected-- }
+			if m.selected > 0 {
+				m.selected--
+			}
 			return m, nil
 		case "n":
-			m.newDL = true; m.newURL.SetValue(""); m.newDest.SetValue(""); m.newFocus = 0; m.newURL.Focus(); m.newDest.Blur(); m.newMsg = ""; return m, nil
+			m.newDL = true
+			m.newURL.SetValue("")
+			m.newDest.SetValue("")
+			m.newFocus = 0
+			m.newURL.Focus()
+			m.newDest.Blur()
+			m.newMsg = ""
+			return m, nil
 		case "f":
 			switch m.filterPreset {
 			case "all":
@@ -190,79 +274,118 @@ case "enter":
 			}
 			return m, refreshCmd()
 		case "g":
-			m.groupOn = !m.groupOn; return m, refreshCmd()
+			m.groupOn = !m.groupOn
+			return m, refreshCmd()
 		case "t":
-			m.showURLFirst = !m.showURLFirst; return m, nil
+			m.showURLFirst = !m.showURLFirst
+			return m, nil
 		case "d":
 			m.showInfo = !m.showInfo
 			return m, nil
 		case "?", "h":
 			m.showHelp = !m.showHelp
 			return m, nil
-case "m":
+		case "m":
 			m.menuOn = !m.menuOn
-			if m.menuOn { m.menuIndex = 0 }
-			return m, nil
-case "p":
-			// pause/cancel selected if running under TUI
-			if m.selected >=0 && m.selected < len(m.rows) {
-				key := m.rows[m.selected].URL+"|"+m.rows[m.selected].Dest
-				if cancel, ok := m.running[key]; ok { cancel(); delete(m.running, key); m.newMsg = "cancelled: "+m.rows[m.selected].Dest }
+			if m.menuOn {
+				m.menuIndex = 0
 			}
 			return m, nil
-case "y":
+		case "p":
+			// pause/cancel selected if running under TUI
+			if m.selected >= 0 && m.selected < len(m.rows) {
+				key := m.rows[m.selected].URL + "|" + m.rows[m.selected].Dest
+				if cancel, ok := m.running[key]; ok {
+					cancel()
+					delete(m.running, key)
+					m.newMsg = "cancelled: " + m.rows[m.selected].Dest
+				}
+			}
+			return m, nil
+		case "y":
 			// retry selected
-			if m.selected >=0 && m.selected < len(m.rows) {
-				u := m.rows[m.selected].URL; d := m.rows[m.selected].Dest
+			if m.selected >= 0 && m.selected < len(m.rows) {
+				u := m.rows[m.selected].URL
+				d := m.rows[m.selected].Dest
 				ctx, cancel := context.WithCancel(context.Background())
 				m.running[u+"|"+d] = cancel
 				m.newMsg = "retrying..."
 				return m, m.startDownloadCmdCtx(ctx, u, d)
 			}
 			return m, nil
-case "C":
+		case "C":
 			// copy dest path
-			if m.selected >=0 && m.selected < len(m.rows) {
-				if err := copyToClipboard(m.rows[m.selected].Dest); err != nil { m.newMsg = "copy failed: "+err.Error() } else { m.newMsg = "copied path to clipboard" }
-			}
-			return m, nil
-case "U":
-			// copy URL
-			if m.selected >=0 && m.selected < len(m.rows) {
-				if err := copyToClipboard(m.rows[m.selected].URL); err != nil { m.newMsg = "copy failed: "+err.Error() } else { m.newMsg = "copied URL to clipboard" }
-			}
-			return m, nil
-case "O":
-			// open folder (or reveal on macOS)
-			if m.selected >=0 && m.selected < len(m.rows) {
-				p := m.rows[m.selected].Dest
-				if p != "" {
-					if err := openInFileManager(p, true); err != nil { m.newMsg = "open failed: "+err.Error() } else { m.newMsg = "opened in file manager" }
+			if m.selected >= 0 && m.selected < len(m.rows) {
+				if err := copyToClipboard(m.rows[m.selected].Dest); err != nil {
+					m.newMsg = "copy failed: " + err.Error()
+				} else {
+					m.newMsg = "copied path to clipboard"
 				}
 			}
 			return m, nil
-case "D":
+		case "U":
+			// copy URL
+			if m.selected >= 0 && m.selected < len(m.rows) {
+				if err := copyToClipboard(m.rows[m.selected].URL); err != nil {
+					m.newMsg = "copy failed: " + err.Error()
+				} else {
+					m.newMsg = "copied URL to clipboard"
+				}
+			}
+			return m, nil
+		case "O":
+			// open folder (or reveal on macOS)
+			if m.selected >= 0 && m.selected < len(m.rows) {
+				p := m.rows[m.selected].Dest
+				if p != "" {
+					if err := openInFileManager(p, true); err != nil {
+						m.newMsg = "open failed: " + err.Error()
+					} else {
+						m.newMsg = "opened in file manager"
+					}
+				}
+			}
+			return m, nil
+		case "D":
 			// delete staged data (.part) and clear chunk state
-			if m.selected >=0 && m.selected < len(m.rows) {
+			if m.selected >= 0 && m.selected < len(m.rows) {
 				r := m.rows[m.selected]
 				deleted := []string{}
 				// hashed staged path
 				p1 := downloader.StagePartPath(m.cfg, r.URL, r.Dest)
-				if fi, err := os.Stat(p1); err == nil && !fi.IsDir() { if err := os.Remove(p1); err == nil { deleted = append(deleted, p1) } }
+				if fi, err := os.Stat(p1); err == nil && !fi.IsDir() {
+					if err := os.Remove(p1); err == nil {
+						deleted = append(deleted, p1)
+					}
+				}
 				// next-to-dest .part
 				p2 := r.Dest + ".part"
-				if p2 != p1 { if fi, err := os.Stat(p2); err == nil && !fi.IsDir() { if err := os.Remove(p2); err == nil { deleted = append(deleted, p2) } } }
+				if p2 != p1 {
+					if fi, err := os.Stat(p2); err == nil && !fi.IsDir() {
+						if err := os.Remove(p2); err == nil {
+							deleted = append(deleted, p2)
+						}
+					}
+				}
 				_ = m.st.DeleteChunks(r.URL, r.Dest)
-				if len(deleted) > 0 { m.newMsg = "deleted staged data: " + strings.Join(deleted, ", ") } else { m.newMsg = "no staged data found" }
+				if len(deleted) > 0 {
+					m.newMsg = "deleted staged data: " + strings.Join(deleted, ", ")
+				} else {
+					m.newMsg = "no staged data found"
+				}
 				return m, refreshCmd()
 			}
 			return m, nil
-case "X":
+		case "X":
 			// clear download row from DB (useful for stuck planning rows)
-			if m.selected >=0 && m.selected < len(m.rows) {
+			if m.selected >= 0 && m.selected < len(m.rows) {
 				r := m.rows[m.selected]
 				_ = m.st.DeleteChunks(r.URL, r.Dest)
-				if err := m.st.DeleteDownload(r.URL, r.Dest); err != nil { m.newMsg = "clear failed: "+err.Error() } else { m.newMsg = "cleared row" }
+				if err := m.st.DeleteDownload(r.URL, r.Dest); err != nil {
+					m.newMsg = "clear failed: " + err.Error()
+				} else {
+					m.newMsg = "cleared row"
+				}
 				return m, refreshCmd()
 			}
 			return m, nil
@@ -278,34 +401,62 @@ case "X":
 		}
 	case tickMsg:
 		return m, refreshCmd()
-case refreshMsg:
+	case recoverRowsMsg:
+		// Start downloads for rows that appear to have been running previously
+		if len(msg.rows) == 0 {
+			return m, nil
+		}
+		cmds := make([]tea.Cmd, 0, len(msg.rows))
+		for _, r := range msg.rows {
+			cmds = append(cmds, m.startDownloadCmd(r.URL, r.Dest))
+		}
+		return m, tea.Batch(cmds...)
+	case refreshMsg:
 		rows, err := m.st.ListDownloads()
-		if err != nil { return m, func() tea.Msg { return errMsg{err} } }
+		if err != nil {
+			return m, func() tea.Msg { return errMsg{err} }
+		}
 		m.rows = rows
 		// Clear ephemerals when a matching DB row appears by URL or Dest.
 		if len(m.ephems) > 0 {
 			for k, e := range m.ephems {
 				cleared := false
 				for _, r := range rows {
-					if r.URL == e.URL { cleared = true; break }
-					if e.Dest != "" && r.Dest != "" && filepath.Clean(r.Dest) == filepath.Clean(e.Dest) { cleared = true; break }
+					if r.URL == e.URL {
+						cleared = true
+						break
+					}
+					if e.Dest != "" && r.Dest != "" && filepath.Clean(r.Dest) == filepath.Clean(e.Dest) {
+						cleared = true
+						break
+					}
 				}
-				if cleared { delete(m.ephems, k) }
+				if cleared {
+					delete(m.ephems, k)
+				}
 			}
 		}
-		if m.selected >= len(m.rows) { m.selected = len(m.rows) - 1 }
-		if m.selected < 0 { m.selected = 0 }
+		if m.selected >= len(m.rows) {
+			m.selected = len(m.rows) - 1
+		}
+		if m.selected < 0 {
+			m.selected = 0
+		}
 		// Auto-hide tips once we have any rows
-		if len(m.rows) > 0 { m.tipsOn = false }
+		if len(m.rows) > 0 {
+			m.tipsOn = false
+		}
 		// advance spinner
 		m.spin++
 		return m, tickCmd(m.refresh)
 	case errMsg:
 		m.err = msg.err
 		return m, tickCmd(m.refresh)
-case dlDoneMsg:
+	case dlDoneMsg:
 		// clear ephemeral if still present
-		if strings.TrimSpace(msg.url) != "" { delete(m.ephems, ephemeralKey(msg.url, msg.dest)) }
+		if strings.TrimSpace(msg.url) != "" {
+			delete(m.ephems, ephemeralKey(msg.url, msg.dest))
+		}
 		if msg.err != nil {
 			m.newMsg = fmt.Sprintf("download failed: %v", msg.err)
 		} else {
@@ -328,56 +479,70 @@ func (m *model) View() string {
 	// Header with totals and throughput
 	var total int64
 	var gRate float64
-	counts := map[string]int{"complete":0, "running":0, "pending":0, "planning":0, "error":0}
+	counts := map[string]int{"complete": 0, "running": 0, "pending": 0, "planning": 0, "error": 0}
 	for _, r := range m.filteredRows() {
-		if r.Status == "complete" { total += r.Size }
+		if r.Status == "complete" {
+			total += r.Size
+		}
 		_, _, rate, _ := m.progressFor(r)
 		gRate += rate
 		ls := strings.ToLower(r.Status)
-		if _, ok := counts[ls]; ok { counts[ls]++ }
+		if _, ok := counts[ls]; ok {
+			counts[ls]++
+		}
 	}
 	help := m.styles.label.Render("(q quit, r refresh, j/k select, n new, f filter preset, g group, t toggle cols, d details, / filter, m menu)")
 	fmt.Fprintf(&b, "%s %s %s\n", m.styles.header.Render("modfetch: downloads"), help, m.styles.label.Render("total="+humanize.Bytes(uint64(total))+" rate="+humanize.Bytes(uint64(gRate))+"/s"))
 	// Status counts & preset
-	fmt.Fprintf(&b, "%s\n", m.styles.label.Render(fmt.Sprintf("completed:%d running:%d pending:%d planning:%d errors:%d • view:%s", counts["complete"], counts["running"], counts["pending"], counts["planning"], counts["error"], m.filterPreset)) )
+	fmt.Fprintf(&b, "%s\n", m.styles.label.Render(fmt.Sprintf("completed:%d running:%d pending:%d planning:%d errors:%d • view:%s", counts["complete"], counts["running"], counts["pending"], counts["planning"], counts["error"], m.filterPreset)))
 	// Token env warnings
 	if m.cfg.Sources.HuggingFace.Enabled {
 		env := strings.TrimSpace(m.cfg.Sources.HuggingFace.TokenEnv)
-		if env == "" { env = "HF_TOKEN" }
+		if env == "" {
+			env = "HF_TOKEN"
+		}
 		if strings.TrimSpace(os.Getenv(env)) == "" {
-			b.WriteString(m.styles.label.Render("Warning: Hugging Face token env "+env+" not set; gated repos may 401")+"\n")
+			b.WriteString(m.styles.label.Render("Warning: Hugging Face token env "+env+" not set; gated repos may 401") + "\n")
 		}
 	}
 	if m.cfg.Sources.CivitAI.Enabled {
 		env := strings.TrimSpace(m.cfg.Sources.CivitAI.TokenEnv)
-		if env == "" { env = "CIVITAI_TOKEN" }
+		if env == "" {
+			env = "CIVITAI_TOKEN"
+		}
 		if strings.TrimSpace(os.Getenv(env)) == "" {
-			b.WriteString(m.styles.label.Render("Warning: CivitAI token env "+env+" not set; gated content may 401")+"\n")
+			b.WriteString(m.styles.label.Render("Warning: CivitAI token env "+env+" not set; gated content may 401") + "\n")
 		}
 	}
 	if m.filterOn {
-		b.WriteString("Filter: "+ m.filter.View()+"\n")
+		b.WriteString("Filter: " + m.filter.View() + "\n")
 	}
 	if m.menuOn {
 		b.WriteString(m.menuView())
 		b.WriteString("\n")
 	}
 	if m.tipsOn && len(m.rows) == 0 {
-		b.WriteString(lipgloss.NewStyle().Bold(true).Render("Welcome to modfetch")+"\n")
+		b.WriteString(lipgloss.NewStyle().Bold(true).Render("Welcome to modfetch") + "\n")
 		b.WriteString("- Press n to add your first download (URL and optional dest)\n")
 		b.WriteString("- Press m for Menu, h for Help, / to Filter\n")
 		b.WriteString("- Config: ~/.config/modfetch/config.yml (auto-created on first run)\n\n")
 	}
 	if m.newMsg != "" {
-		b.WriteString(m.styles.label.Render(m.newMsg)+"\n")
+		b.WriteString(m.styles.label.Render(m.newMsg) + "\n")
 	}
 	// New download modal overlay
 	if m.newDL {
-		b.WriteString(lipgloss.NewStyle().Bold(true).Render("New Download")+"\n")
-		if m.newFocus == 0 { m.newURL.Focus(); m.newDest.Blur() } else { m.newDest.Focus(); m.newURL.Blur() }
-		b.WriteString("  URL:  "+m.newURL.View()+"\n")
-		b.WriteString("  Dest: "+m.newDest.View()+"\n")
-		b.WriteString(m.styles.label.Render("Enter to start • Tab to switch • Esc to cancel")+"\n\n")
+		b.WriteString(lipgloss.NewStyle().Bold(true).Render("New Download") + "\n")
+		if m.newFocus == 0 {
+			m.newURL.Focus()
+			m.newDest.Blur()
+		} else {
+			m.newDest.Focus()
+			m.newURL.Blur()
+		}
+		b.WriteString("  URL:  " + m.newURL.View() + "\n")
+		b.WriteString("  Dest: " + m.newDest.View() + "\n")
+		b.WriteString(m.styles.label.Render("Enter to start • Tab to switch • Esc to cancel") + "\n\n")
 	}
 	if m.err != nil {
 		fmt.Fprintf(&b, "error: %v\n\n", m.err)
@@ -388,48 +553,73 @@ func (m *model) View() string {
 	}
 	// Columns header with dynamic widths
 	avail := m.width
-	if avail <= 0 { avail = 120 }
+	if avail <= 0 {
+		avail = 120
+	}
 	fixed := 8 + 2 + 10 + 2 + 10 + 2 + 8 + 2 + 2 // status, spaces, progress label, speed, eta, spaces
 	rest := avail - fixed
-	if rest < 20 { rest = 20 }
-	destW := rest/2
-	urlW := rest - destW
-	if m.showURLFirst { destW, urlW = urlW, destW }
-	// Build header labels
-	labelLeft := "DEST"; labelRight := "URL"; if m.showURLFirst { labelLeft, labelRight = "URL", "DEST" }
-	fmt.Fprintf(&b, "%s\n", m.styles.label.Render(fmt.Sprintf("%-8s  %-10s  %-10s  %-8s  %-*s  %-*s", "STATUS", "PROGRESS", "SPEED", "ETA", destW, labelLeft, urlW, labelRight)))
-rows := m.filteredRows()
-// Prepend ephemeral starters so UI never looks idle
-if len(m.ephems) > 0 {
-	keys := make([]string, 0, len(m.ephems))
-	for k := range m.ephems { keys = append(keys, k) }
-	sort.Strings(keys)
-	for _, k := range keys {
-		e := m.ephems[k]
-		rows = append([]state.DownloadRow{{URL: e.URL, Dest: e.Dest, Status: "pending", Size: 0}}, rows...)
+	if rest < 20 {
+		rest = 20
 	}
-}
-// apply preset filters
-switch m.filterPreset {
-case "active":
-	rows = filterByStatuses(rows, []string{"planning","pending","running"})
-case "errors":
-	rows = filterByStatuses(rows, []string{"error","checksum_mismatch","verify_failed"})
-}
+	destW := rest / 2
+	urlW := rest - destW
+	if m.showURLFirst {
+		destW, urlW = urlW, destW
+	}
+	// Build header labels
+	labelLeft := "DEST"
+	labelRight := "URL"
+	if m.showURLFirst {
+		labelLeft, labelRight = "URL", "DEST"
+	}
+	fmt.Fprintf(&b, "%s\n", m.styles.label.Render(fmt.Sprintf("%-8s  %-10s  %-10s  %-8s  %-*s  %-*s", "STATUS", "PROGRESS", "SPEED", "ETA", destW, labelLeft, urlW, labelRight)))
+	rows := m.filteredRows()
+	// Prepend ephemeral starters so UI never looks idle
+	if len(m.ephems) > 0 {
+		keys := make([]string, 0, len(m.ephems))
+		for k := range m.ephems {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			e := m.ephems[k]
+			rows = append([]state.DownloadRow{{URL: e.URL, Dest: e.Dest, Status: "pending", Size: 0}}, rows...)
+		}
+	}
+	// apply preset filters
+	switch m.filterPreset {
+	case "active":
+		rows = filterByStatuses(rows, []string{"planning", "pending", "running"})
+	case "errors":
+		rows = filterByStatuses(rows, []string{"error", "checksum_mismatch", "verify_failed"})
+	}
 	var prevStatus string
 	for i, r := range rows {
 		if m.groupOn {
 			if i == 0 || !strings.EqualFold(prevStatus, r.Status) {
-				b.WriteString(m.styles.label.Render(fmt.Sprintf("== %s ==", strings.ToUpper(r.Status)))+"\n")
+				b.WriteString(m.styles.label.Render(fmt.Sprintf("== %s ==", strings.ToUpper(r.Status))) + "\n")
 				prevStatus = r.Status
 			}
 		}
 		prog := m.renderProgress(r)
 		_, _, rate, eta := m.progressFor(r)
-		d := r.Dest; if len(d) > destW { if destW > 1 { d = d[len(d)-destW:] } }
-		u := logging.SanitizeURL(r.URL); if len(u) > urlW { if urlW > 1 { u = u[:urlW-1] + "…" } }
-		left := d; right := u
-		if m.showURLFirst { left, right = u, d }
+		d := r.Dest
+		if len(d) > destW {
+			if destW > 1 {
+				d = d[len(d)-destW:]
+			}
+		}
+		u := logging.SanitizeURL(r.URL)
+		if len(u) > urlW {
+			if urlW > 1 {
+				u = u[:urlW-1] + "…"
+			}
+		}
+		left := d
+		right := u
+		if m.showURLFirst {
+			left, right = u, d
+		}
 		line := fmt.Sprintf("%-8s  %-10s  %-10s  %-8s  %-*s  %-*s", r.Status, prog, humanize.Bytes(uint64(rate))+"/s", eta, destW, left, urlW, right)
 		if i == m.selected {
 			line = lipgloss.NewStyle().Bold(true).Render(line)
@@ -452,10 +642,16 @@ func (m *model) renderProgress(r state.DownloadRow) string {
 		return "planning " + m.spinnerChar()
 	}
 	cur, total, _, _ := m.progressFor(r)
-	if total <= 0 { return "--" }
+	if total <= 0 {
+		return "--"
+	}
 	ratio := float64(cur) / float64(total)
-	if ratio < 0 { ratio = 0 }
-	if ratio > 1 { ratio = 1 }
+	if ratio < 0 {
+		ratio = 0
+	}
+	if ratio > 1 {
+		ratio = 1
+	}
 	bar := m.prog.ViewAs(ratio)
 	return bar
 }
@@ -463,7 +659,9 @@ func (m *model) renderProgress(r state.DownloadRow) string {
 func (m *model) renderDetails(r state.DownloadRow) string {
 	var sb strings.Builder
 	abs := r.Dest
-	if abs != "" { abs, _ = filepath.Abs(r.Dest) }
+	if abs != "" {
+		abs, _ = filepath.Abs(r.Dest)
+	}
 	cur, total, rate, eta := m.progressFor(r)
 	fmt.Fprintf(&sb, "    %s %s\n", m.styles.label.Render("dest:"), abs)
 	// Guidance if stuck in planning for more than ~5s without chunks
@@ -490,7 +688,9 @@ func (m *model) progressFor(r state.DownloadRow) (cur int64, total int64, rate f
 	chunks, _ := m.st.ListChunks(r.URL, r.Dest)
 	if len(chunks) > 0 {
 		for _, c := range chunks {
-			if strings.EqualFold(c.Status, "complete") { cur += c.Size }
+			if strings.EqualFold(c.Status, "complete") {
+				cur += c.Size
+			}
 			total += 0 // already in r.Size
 		}
 	} else {
@@ -507,17 +707,23 @@ func (m *model) progressFor(r state.DownloadRow) (cur int64, total int64, rate f
 	key := r.URL + "|" + r.Dest
 	prev := m.prev[key]
 	dt := time.Since(prev.t).Seconds()
-	if dt > 0 { rate = float64(cur-prev.bytes) / dt }
+	if dt > 0 {
+		rate = float64(cur-prev.bytes) / dt
+	}
 	m.prev[key] = obs{bytes: cur, t: time.Now()}
 	if rate > 0 && total > 0 && cur < total {
 		rem := float64(total-cur) / rate
 		eta = fmt.Sprintf("%ds", int(rem+0.5))
-	} else { eta = "-" }
+	} else {
+		eta = "-"
+	}
 	return
 }
 
 func (m *model) filteredRows() []state.DownloadRow {
-	if !m.filterOn && strings.TrimSpace(m.filter.Value()) == "" && m.sortMode == "" { return m.rows }
+	if !m.filterOn && strings.TrimSpace(m.filter.Value()) == "" && m.sortMode == "" {
+		return m.rows
+	}
 	q := strings.ToLower(strings.TrimSpace(m.filter.Value()))
 	var out []state.DownloadRow
 	for _, r := range m.rows {
@@ -536,9 +742,15 @@ func (m *model) filteredRows() []state.DownloadRow {
 			case "speed":
 				return ri > rj
 			case "eta":
-				if etaI == 0 && etaJ == 0 { return ri > rj }
-				if etaI == 0 { return false }
-				if etaJ == 0 { return true }
+				if etaI == 0 && etaJ == 0 {
+					return ri > rj
+				}
+				if etaI == 0 {
+					return false
+				}
+				if etaJ == 0 {
+					return true
+				}
 				return etaI < etaJ
 			default:
 				return false
@@ -549,16 +761,22 @@ func (m *model) filteredRows() []state.DownloadRow {
 }
 
 func etaSeconds(cur, total int64, rate float64) float64 {
-	if rate <= 0 || total <= 0 || cur >= total { return 0 }
+	if rate <= 0 || total <= 0 || cur >= total {
+		return 0
+	}
 	return float64(total-cur) / rate
 }
 
 func filterByStatuses(in []state.DownloadRow, want []string) []state.DownloadRow {
 	set := map[string]struct{}{}
-	for _, s := range want { set[strings.ToLower(s)] = struct{}{} }
+	for _, s := range want {
+		set[strings.ToLower(s)] = struct{}{}
+	}
 	var out []state.DownloadRow
 	for _, r := range in {
-		if _, ok := set[strings.ToLower(r.Status)]; ok { out = append(out, r) }
+		if _, ok := set[strings.ToLower(r.Status)]; ok {
+			out = append(out, r)
+		}
 	}
 	return out
 }
@@ -570,19 +788,31 @@ func (m *model) helpView() string {
 func (m *model) menuView() string {
 	var b strings.Builder
 	b.WriteString(lipgloss.NewStyle().Bold(true).Render("Menu") + "\n")
-		for i, it := range m.menuItems {
-			var line string
-			if i == m.menuIndex { line = "> "+it } else { line = "  "+it }
-			b.WriteString(line+"\n")
+	for i, it := range m.menuItems {
+		var line string
+		if i == m.menuIndex {
+			line = "> " + it
+		} else {
+			line = "  " + it
 		}
-	b.WriteString(m.styles.label.Render("Use ↑/↓ to select, Enter to apply, m or Esc to close")+"\n")
+		b.WriteString(line + "\n")
+	}
+	b.WriteString(m.styles.label.Render("Use ↑/↓ to select, Enter to apply, m or Esc to close") + "\n")
 	return b.String()
 }
 
 func (m *model) applyMenuChoice(i int) tea.Cmd {
-	if i < 0 || i >= len(m.menuItems) { return nil }
+	if i < 0 || i >= len(m.menuItems) {
+		return nil
+	}
 	switch m.menuItems[i] {
-	case "New download": m.newDL = true; m.newURL.SetValue(""); m.newDest.SetValue(""); m.newFocus=0; m.newURL.Focus(); m.newMsg=""
+	case "New download":
+		m.newDL = true
+		m.newURL.SetValue("")
+		m.newDest.SetValue("")
+		m.newFocus = 0
+		m.newURL.Focus()
+		m.newMsg = ""
 	case "Filter preset":
 		switch m.filterPreset {
 		case "all":
@@ -592,27 +822,35 @@ func (m *model) applyMenuChoice(i int) tea.Cmd {
 		default:
 			m.filterPreset = "all"
 		}
-	case "Group by status": m.groupOn = !m.groupOn
-	case "Toggle columns": m.showURLFirst = !m.showURLFirst
-	case "Sort by speed": m.sortMode = "speed"
-	case "Sort by ETA": m.sortMode = "eta"
-	case "Clear sort": m.sortMode = ""
-	case "Help": m.showHelp = !m.showHelp
-	case "Refresh": return refreshCmd()
-	case "Quit": return tea.Quit
+	case "Group by status":
+		m.groupOn = !m.groupOn
+	case "Toggle columns":
+		m.showURLFirst = !m.showURLFirst
+	case "Sort by speed":
+		m.sortMode = "speed"
+	case "Sort by ETA":
+		m.sortMode = "eta"
+	case "Clear sort":
+		m.sortMode = ""
+	case "Help":
+		m.showHelp = !m.showHelp
+	case "Refresh":
+		return refreshCmd()
+	case "Quit":
+		return tea.Quit
 	}
 	return nil
 }
 
 func (m *model) startDownloadCmd(urlStr, dest string) tea.Cmd {
 	ctx, cancel := context.WithCancel(context.Background())
-	key := urlStr+"|"+dest
+	key := urlStr + "|" + dest
 	m.running[key] = cancel
 	return m.startDownloadCmdCtx(ctx, urlStr, dest)
 }
 
 func (m *model) startDownloadCmdCtx(ctx context.Context, urlStr, dest string) tea.Cmd {
-return func() tea.Msg {
+	return func() tea.Msg {
 		resolved := urlStr
 		headers := map[string]string{}
 		// Translate civitai model page URLs into civitai:// URIs for proper resolution
@@ -624,28 +862,49 @@ return func() tea.Msg {
 					if len(parts) >= 2 {
 						modelID := parts[1]
 						q := u.Query()
-						ver := q.Get("modelVersionId"); if ver == "" { ver = q.Get("version") }
-						civ := "civitai://model/" + modelID; if strings.TrimSpace(ver) != "" { civ += "?version=" + ver }
-						if res, err := resolver.Resolve(ctx, civ, m.cfg); err == nil { resolved = res.URL; headers = res.Headers }
+						ver := q.Get("modelVersionId")
+						if ver == "" {
+							ver = q.Get("version")
+						}
+						civ := "civitai://model/" + modelID
+						if strings.TrimSpace(ver) != "" {
+							civ += "?version=" + ver
+						}
+						if res, err := resolver.Resolve(ctx, civ, m.cfg); err == nil {
+							resolved = res.URL
+							headers = res.Headers
+						}
 					}
 				}
 			}
 		}
-if strings.HasPrefix(resolved, "hf://") || strings.HasPrefix(resolved, "civitai://") {
+		if strings.HasPrefix(resolved, "hf://") || strings.HasPrefix(resolved, "civitai://") {
 			res, err := resolver.Resolve(ctx, resolved, m.cfg)
-			if err != nil { return dlDoneMsg{url: urlStr, dest: dest, path: "", err: err} }
+			if err != nil {
+				return dlDoneMsg{url: urlStr, dest: dest, path: "", err: err}
+			}
 			resolved = res.URL
 			headers = res.Headers
 		} else {
 			if u, err := neturl.Parse(resolved); err == nil {
 				h := strings.ToLower(u.Hostname())
 				if strings.HasSuffix(h, "huggingface.co") && m.cfg.Sources.HuggingFace.Enabled {
-					env := strings.TrimSpace(m.cfg.Sources.HuggingFace.TokenEnv); if env == "" { env = "HF_TOKEN" }
-					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" { headers["Authorization"] = "Bearer "+tok }
+					env := strings.TrimSpace(m.cfg.Sources.HuggingFace.TokenEnv)
+					if env == "" {
+						env = "HF_TOKEN"
+					}
+					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
+						headers["Authorization"] = "Bearer " + tok
+					}
 				}
 				if strings.HasSuffix(h, "civitai.com") && m.cfg.Sources.CivitAI.Enabled {
-					env := strings.TrimSpace(m.cfg.Sources.CivitAI.TokenEnv); if env == "" { env = "CIVITAI_TOKEN" }
-					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" { headers["Authorization"] = "Bearer "+tok }
+					env := strings.TrimSpace(m.cfg.Sources.CivitAI.TokenEnv)
+					if env == "" {
+						env = "CIVITAI_TOKEN"
+					}
+					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
+						headers["Authorization"] = "Bearer " + tok
+					}
 				}
 			}
 		}
@@ -672,12 +931,16 @@ func (m *model) addEphemeral(url, dest string) {
 
 func (m *model) destGuess(urlStr, dest string) string {
 	d := strings.TrimSpace(dest)
-	if d != "" { return d }
+	if d != "" {
+		return d
+	}
 	root := strings.TrimSpace(m.cfg.General.DownloadRoot)
 	if strings.HasPrefix(urlStr, "http://") || strings.HasPrefix(urlStr, "https://") {
 		if u, err := neturl.Parse(urlStr); err == nil {
 			b := path.Base(u.Path)
-			if b == "/" || b == "." || b == "" || b == ".." { b = "download" }
+			if b == "/" || b == "." || b == "" || b == ".." {
+				b = "download"
+			}
 			candidate := filepath.Join(root, b)
 			if rel, err := filepath.Rel(root, candidate); err == nil && !strings.HasPrefix(rel, "..") {
 				return candidate
@@ -691,20 +954,34 @@ func (m *model) destGuess(urlStr, dest string) string {
 
 func (m *model) preflightForDownload(urlStr, dest string) error {
 	// Ensure download_root exists and is writable
-	if err := os.MkdirAll(m.cfg.General.DownloadRoot, 0o755); err != nil { return err }
-	if err := tryWrite(m.cfg.General.DownloadRoot); err != nil { return fmt.Errorf("download_root not writable: %w", err) }
+	if err := os.MkdirAll(m.cfg.General.DownloadRoot, 0o755); err != nil {
+		return err
+	}
+	if err := tryWrite(m.cfg.General.DownloadRoot); err != nil {
+		return fmt.Errorf("download_root not writable: %w", err)
+	}
 	// Ensure staging area exists and is writable depending on stage_partials
 	if m.cfg.General.StagePartials {
 		parts := m.cfg.General.PartialsRoot
-		if strings.TrimSpace(parts) == "" { parts = filepath.Join(m.cfg.General.DownloadRoot, ".parts") }
-		if err := os.MkdirAll(parts, 0o755); err != nil { return fmt.Errorf("create parts dir: %w", err) }
-		if err := tryWrite(parts); err != nil { return fmt.Errorf("parts dir not writable: %w", err) }
+		if strings.TrimSpace(parts) == "" {
+			parts = filepath.Join(m.cfg.General.DownloadRoot, ".parts")
+		}
+		if err := os.MkdirAll(parts, 0o755); err != nil {
+			return fmt.Errorf("create parts dir: %w", err)
+		}
+		if err := tryWrite(parts); err != nil {
+			return fmt.Errorf("parts dir not writable: %w", err)
+		}
 	} else {
 		// part lives next to dest; ensure its parent if dest provided
 		d := strings.TrimSpace(dest)
 		if d != "" {
-			if err := os.MkdirAll(filepath.Dir(d), 0o755); err != nil { return fmt.Errorf("create dest dir: %w", err) }
-			if err := tryWrite(filepath.Dir(d)); err != nil { return fmt.Errorf("dest dir not writable: %w", err) }
+			if err := os.MkdirAll(filepath.Dir(d), 0o755); err != nil {
+				return fmt.Errorf("create dest dir: %w", err)
+			}
+			if err := tryWrite(filepath.Dir(d)); err != nil {
+				return fmt.Errorf("dest dir not writable: %w", err)
+			}
 		}
 	}
 	return nil
@@ -712,8 +989,12 @@ func (m *model) preflightForDownload(urlStr, dest string) error {
 
 func tryWrite(dir string) error {
 	f, err := os.CreateTemp(dir, ".mf-wr-*")
-	if err != nil { return err }
-	name := f.Name(); _ = f.Close(); _ = os.Remove(name)
+	if err != nil {
+		return err
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
 	return nil
 }
 
@@ -721,28 +1002,48 @@ func tryWrite(dir string) error {
 
 func copyToClipboard(s string) error {
 	s = strings.TrimSpace(s)
-	if s == "" { return fmt.Errorf("empty") }
+	if s == "" {
+		return fmt.Errorf("empty")
+	}
 	switch runtime.GOOS {
 	case "darwin":
 		cmd := exec.Command("pbcopy")
-		in, err := cmd.StdinPipe(); if err != nil { return err }
-		if err := cmd.Start(); err != nil { return err }
-		_, _ = in.Write([]byte(s)); _ = in.Close()
+		in, err := cmd.StdinPipe()
+		if err != nil {
+			return err
+		}
+		if err := cmd.Start(); err != nil {
+			return err
+		}
+		_, _ = in.Write([]byte(s))
+		_ = in.Close()
 		return cmd.Wait()
 	case "linux":
 		// try wl-copy then xclip
 		if _, err := exec.LookPath("wl-copy"); err == nil {
 			cmd := exec.Command("wl-copy")
-			in, err := cmd.StdinPipe(); if err != nil { return err }
-			if err := cmd.Start(); err != nil { return err }
-			_, _ = in.Write([]byte(s)); _ = in.Close()
+			in, err := cmd.StdinPipe()
+			if err != nil {
+				return err
+			}
+			if err := cmd.Start(); err != nil {
+				return err
+			}
+			_, _ = in.Write([]byte(s))
+			_ = in.Close()
 			return cmd.Wait()
 		}
 		if _, err := exec.LookPath("xclip"); err == nil {
 			cmd := exec.Command("xclip", "-selection", "clipboard")
-			in, err := cmd.StdinPipe(); if err != nil { return err }
-			if err := cmd.Start(); err != nil { return err }
-			_, _ = in.Write([]byte(s)); _ = in.Close()
+			in, err := cmd.StdinPipe()
+			if err != nil {
+				return err
+			}
+			if err := cmd.Start(); err != nil {
+				return err
+			}
+			_, _ = in.Write([]byte(s))
+			_ = in.Close()
 			return cmd.Wait()
 		}
 	}
@@ -751,11 +1052,17 @@ func copyToClipboard(s string) error {
 
 func openInFileManager(p string, reveal bool) error {
 	p = strings.TrimSpace(p)
-	if p == "" { return fmt.Errorf("empty path") }
+	if p == "" {
+		return fmt.Errorf("empty path")
+	}
 	// Determine directory to open even if file doesn't exist yet
 	var dir string
 	if fi, err := os.Stat(p); err == nil {
-		if fi.IsDir() { dir = p } else { dir = filepath.Dir(p) }
+		if fi.IsDir() {
+			dir = p
+		} else {
+			dir = filepath.Dir(p)
+		}
 	} else {
 		dir = filepath.Dir(p)
 	}
@@ -763,7 +1070,9 @@ func openInFileManager(p string, reveal bool) error {
 	case "darwin":
 		if reveal {
 			// Reveal if possible; if that fails, fallback to opening dir
-			if err := exec.Command("open", "-R", p).Run(); err == nil { return nil }
+			if err := exec.Command("open", "-R", p).Run(); err == nil {
+				return nil
+			}
 		}
 		return exec.Command("open", dir).Run()
 	case "linux":
@@ -773,4 +1082,3 @@ func openInFileManager(p string, reveal bool) error {
 	}
 	return fmt.Errorf("cannot open file manager on %s", runtime.GOOS)
 }
-

--- a/internal/util/hasher.go
+++ b/internal/util/hasher.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+)
+
+// HashFileSHA256 computes the SHA256 of a file in a streaming fashion
+// using a 1 MiB buffer to reduce syscall overhead without large memory use.
+func HashFileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	return HashReaderSHA256(f)
+}
+
+// HashReaderSHA256 computes SHA256 from an io.Reader using a 1 MiB buffer.
+func HashReaderSHA256(r io.Reader) (string, error) {
+	h := sha256.New()
+	buf := make([]byte, 1<<20) // 1 MiB
+	if _, err := io.CopyBuffer(h, r, buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/util/naming_test.go
+++ b/internal/util/naming_test.go
@@ -24,4 +24,3 @@ func TestExpandPattern(t *testing.T) {
 		t.Fatalf("expected empty for empty pattern")
 	}
 }
-

--- a/internal/util/paths.go
+++ b/internal/util/paths.go
@@ -15,7 +15,9 @@ import (
 // separators. Falls back to "download" when empty after cleaning.
 func SafeFileName(name string) string {
 	name = strings.TrimSpace(name)
-	if name == "" { return "download" }
+	if name == "" {
+		return "download"
+	}
 	// Preserve extension while cleaning base
 	ext := filepath.Ext(name)
 	base := strings.TrimSuffix(name, ext)
@@ -35,7 +37,9 @@ func SafeFileName(name string) string {
 	}
 	clean := b.String()
 	clean = strings.Trim(clean, "-.")
-	if clean == "" { clean = "download" }
+	if clean == "" {
+		clean = "download"
+	}
 	return clean + ext
 }
 
@@ -43,11 +47,15 @@ func SafeFileName(name string) string {
 // If parsing fails or the path is empty, it falls back to a reasonable default ("download").
 func URLPathBase(u string) string {
 	s := strings.TrimSpace(u)
-	if s == "" { return "download" }
+	if s == "" {
+		return "download"
+	}
 	if pu, err := url.Parse(s); err == nil && pu != nil {
 		p := pu.Path
 		b := pathpkg.Base(p)
-		if b != "" && b != "/" && b != "." { return b }
+		if b != "" && b != "/" && b != "." {
+			return b
+		}
 		// URL parsed but had no usable path segment
 		return "download"
 	}
@@ -56,7 +64,9 @@ func URLPathBase(u string) string {
 		s = s[:i]
 	}
 	b := filepath.Base(s)
-	if b == "" || b == "/" || b == "." { return "download" }
+	if b == "" || b == "/" || b == "." {
+		return "download"
+	}
 	return b
 }
 
@@ -70,15 +80,21 @@ func UniquePath(dir, base, versionHint string) (string, error) {
 	name := strings.TrimSuffix(base, ext)
 	path := filepath.Join(dir, base)
 	if _, err := os.Stat(path); err != nil {
-		if os.IsNotExist(err) { return path, nil }
+		if os.IsNotExist(err) {
+			return path, nil
+		}
 		return "", err
 	}
 	if strings.TrimSpace(versionHint) != "" {
 		cand := filepath.Join(dir, fmt.Sprintf("%s (v%s)%s", name, versionHint, ext))
-		if _, err := os.Stat(cand); os.IsNotExist(err) { return cand, nil }
+		if _, err := os.Stat(cand); os.IsNotExist(err) {
+			return cand, nil
+		}
 	}
 	for i := 2; ; i++ {
 		cand := filepath.Join(dir, fmt.Sprintf("%s (%d)%s", name, i, ext))
-		if _, err := os.Stat(cand); os.IsNotExist(err) { return cand, nil }
+		if _, err := os.Stat(cand); os.IsNotExist(err) {
+			return cand, nil
+		}
 	}
 }

--- a/internal/util/paths.go
+++ b/internal/util/paths.go
@@ -76,6 +76,10 @@ func URLPathBase(u string) string {
 // " (2)", " (3)", etc., before the extension.
 func UniquePath(dir, base, versionHint string) (string, error) {
 	base = SafeFileName(base)
+	vh := strings.TrimSpace(versionHint)
+	if vh != "" {
+		versionHint = SafeFileName(vh)
+	}
 	ext := filepath.Ext(base)
 	name := strings.TrimSuffix(base, ext)
 	path := filepath.Join(dir, base)

--- a/internal/util/paths_test.go
+++ b/internal/util/paths_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -19,6 +20,26 @@ func TestSafeFileName(t *testing.T) {
 		if got != want {
 			t.Fatalf("SafeFileName(%q)=%q want %q", in, got, want)
 		}
+	}
+}
+
+func TestUniquePath_VersionHintSanitized(t *testing.T) {
+	d := t.TempDir()
+	base := "file.bin"
+	// occupy base so hint path is tried
+	p1, _ := UniquePath(d, base, "")
+	_ = os.WriteFile(p1, []byte("x"), 0o644)
+
+	p2, err := UniquePath(d, base, "../v12/../../evil")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := filepath.Base(p2)
+	if strings.Contains(b, "/") || strings.Contains(b, "\\") {
+		t.Fatalf("versionHint not sanitized in filename: %q", b)
+	}
+	if !strings.Contains(b, "v12") && !strings.Contains(b, "evil") {
+		t.Fatalf("expected sanitized hint to be present in name: %q", b)
 	}
 }
 

--- a/internal/util/paths_test.go
+++ b/internal/util/paths_test.go
@@ -10,7 +10,7 @@ func TestSafeFileName(t *testing.T) {
 	cases := map[string]string{
 		"foo/bar":                           "foo-bar",
 		"foo\\bar":                          "foo-bar",
-		"  spaced name  ":                  "spaced-name",
+		"  spaced name  ":                   "spaced-name",
 		"2058285?type=Archive&format=Other": "2058285-type-Archive-format-Other",
 		"":                                  "download",
 	}
@@ -26,23 +26,34 @@ func TestUniquePath(t *testing.T) {
 	d := t.TempDir()
 	base := "ModelX - file.bin"
 	p1, err := UniquePath(d, base, "")
-	if err != nil { t.Fatal(err) }
-if filepath.Base(p1) != "ModelX---file.bin" { t.Fatalf("got %s want %s", filepath.Base(p1), "ModelX---file.bin") }
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(p1) != "ModelX---file.bin" {
+		t.Fatalf("got %s want %s", filepath.Base(p1), "ModelX---file.bin")
+	}
 	// create p1
-	if err := os.WriteFile(p1, []byte("x"), 0o644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(p1, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	// Next should try version hint
 	p2, err := UniquePath(d, base, "12")
-	if err != nil { t.Fatal(err) }
-if filepath.Base(p2) != "ModelX---file (v12).bin" {
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(p2) != "ModelX---file (v12).bin" {
 		t.Fatalf("unexpected p2: %s", filepath.Base(p2))
 	}
 	// create p2
-	if err := os.WriteFile(p2, []byte("x"), 0o644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(p2, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	// Next should try numeric suffix
 	p3, err := UniquePath(d, base, "12")
-	if err != nil { t.Fatal(err) }
-if filepath.Base(p3) != "ModelX---file (2).bin" {
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(p3) != "ModelX---file (2).bin" {
 		t.Fatalf("unexpected p3: %s", filepath.Base(p3))
 	}
 }
-

--- a/internal/util/urlutil_test.go
+++ b/internal/util/urlutil_test.go
@@ -5,8 +5,8 @@ import "testing"
 func TestURLPathBase(t *testing.T) {
 	cases := map[string]string{
 		"https://civitai.com/api/download/models/2058285?type=Archive&format=Other": "2058285",
-		"https://example.com/path/to/file.bin?foo=bar": "file.bin",
-		"https://example.com/": "download",
+		"https://example.com/path/to/file.bin?foo=bar":                              "file.bin",
+		"https://example.com/":  "download",
 		"/just/a/path/name.txt": "name.txt",
 	}
 	for in, want := range cases {


### PR DESCRIPTION
This PR delivers two Priority 1 reliability items and a shared hashing helper:\n\nHighlights\n- TUI (legacy + v2):\n  - Auto-recover on startup when general.auto_recover_on_start: true.\n  - Scans state for rows in status running/hold and resumes them.\n- Downloader (chunked):\n  - Group initial chunk planning in a single DB transaction for consistency.\n- Util:\n  - New streaming SHA256 helpers (HashFileSHA256/HashReaderSHA256) and refactors to use them for final post-adjustment hashes and placer checksums.\n- Docs:\n  - Add general.auto_recover_on_start to docs/CONFIG.md.\n  - README now links to consolidated docs/ROADMAP.md.\n- Repo hygiene:\n  - Add WARP.md and docs/ROADMAP.md for contributor guidance.\n\nNotes\n- Auto-recovery is opt-in via config; default remains unchanged.\n- Tests previously passed; local CI may require environment fix if macOS temp dir permissions block go build/test.\n\nFollow-ups (suggested)\n- Add unit tests for internal/util/hasher.go.\n- Consider transaction grouping for multi-row state updates beyond chunk planning.\n- Implement selection persistence and planning-phase progress accuracy in the TUI (Priority 3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added --force option to skip SHA256 verification.
  - Auto-resume in-progress downloads on startup via auto_recover_on_start.
  - TUI v2: restores persisted UI state and surfaces config-derived types in New Job modal.

- Bug Fixes
  - More accurate progress during planning.
  - Improved final-URL and size detection when probing.
  - More robust sha256-file parsing and verification handling.
  - Smarter CivitAI file-selection fallback and clearer auth guidance on 401/403.
  - Stricter safetensors validation and automatic truncation/repair of oversized files.

- Documentation
  - Added consolidated ROADMAP and developer WARP docs; README links to ROADMAP.
  - Documented auto_recover_on_start in CONFIG.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->