### PR TITLE
ci: portable fmt-check + gofmt cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,19 @@ test:
 	go test ./...
 
 fmt:
-	go fmt ./...
+	# Format only module packages (ignore caches like .tmp)
+	gofmt -s -w $(shell go list -f '{{.Dir}}' ./...)
 
 # Fails if files need formatting
 fmt-check:
 	@echo "Checking gofmt..."
-	@diff -u <(echo -n) <(gofmt -s -l .) || (echo "Run 'make fmt' to format the above files" && exit 1)
+	@files="$$(gofmt -s -l $$(go list -f '{{.Dir}}' ./...))"; \
+	if [ -n "$$files" ]; then \
+	  echo "$$files" | sed 's/^/ - /'; \
+	  echo "Run 'make fmt' to format the above files"; \
+	  exit 1; \
+	fi; \
+	echo "gofmt OK"
 
 vet:
 	go vet ./...

--- a/cmd/modfetch/config_wizard.go
+++ b/cmd/modfetch/config_wizard.go
@@ -8,9 +8,9 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"gopkg.in/yaml.v3"
 	"github.com/jxwalker/modfetch/internal/config"
 	cw "github.com/jxwalker/modfetch/internal/tui/configwizard"
+	"gopkg.in/yaml.v3"
 )
 
 func handleConfigWizard(ctx context.Context, args []string) error {

--- a/cmd/modfetch/tui_cmd.go
+++ b/cmd/modfetch/tui_cmd.go
@@ -9,13 +9,13 @@ import (
 	"path/filepath"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"gopkg.in/yaml.v3"
 	"github.com/jxwalker/modfetch/internal/config"
 	"github.com/jxwalker/modfetch/internal/logging"
 	"github.com/jxwalker/modfetch/internal/state"
 	ui "github.com/jxwalker/modfetch/internal/tui"
 	cw "github.com/jxwalker/modfetch/internal/tui/configwizard"
 	uiv2 "github.com/jxwalker/modfetch/internal/tui/v2"
+	"gopkg.in/yaml.v3"
 )
 
 func handleTUI(ctx context.Context, args []string) error {


### PR DESCRIPTION
This PR improves local/CI formatting checks and applies gofmt -s to two files.\n\nChanges\n- Makefile: fmt now targets only module packages via 'go list -f {{.Dir}} ./...', fmt-check avoids process substitution and prints a clear file list.\n- gofmt -s: cmd/modfetch/config_wizard.go, cmd/modfetch/tui_cmd.go\n\nWhy\n- 'make ci' previously failed on shells without process substitution and scanned .tmp/go-mod-cache. This makes checks portable and scoped.\n\nValidation\n- make ci passes locally (vet, fmt-check, and go test ./... all OK).