### PR TITLE
chore: update Homebrew formula with v0.5.0 SHA256 checksums

### DIFF
--- a/packaging/homebrew/modfetch.rb
+++ b/packaging/homebrew/modfetch.rb
@@ -5,21 +5,21 @@ class Modfetch < Formula
   on_macos do
     on_arm do
       url "https://github.com/jxwalker/modfetch/releases/download/v#{version}/modfetch_darwin_arm64"
-      sha256 "REPLACE_WITH_SHA256_AFTER_RELEASE"
+      sha256 "ff756723babcba03ad7a737224d7528d62a8a92fa9857fbd0141f48181789327"
     end
     on_intel do
       url "https://github.com/jxwalker/modfetch/releases/download/v#{version}/modfetch_darwin_amd64"
-      sha256 "REPLACE_WITH_SHA256_AFTER_RELEASE"
+      sha256 "eca58c75467e08bc0a901383317011456b5e0f703cfb2fcd8306c512badfa964"
     end
   end
   on_linux do
     on_arm do
       url "https://github.com/jxwalker/modfetch/releases/download/v#{version}/modfetch_linux_arm64"
-      sha256 "REPLACE_WITH_SHA256_AFTER_RELEASE"
+      sha256 "4076365128562cb1e6a0b9a7270490087e3d83a78c6d1f1d430ecb64aba0d785"
     end
     on_intel do
       url "https://github.com/jxwalker/modfetch/releases/download/v#{version}/modfetch_linux_amd64"
-      sha256 "REPLACE_WITH_SHA256_AFTER_RELEASE"
+      sha256 "0894365fea64a3dabec178009b96a2818a43a6a27fa8642c83a3fe2bdbf7f972"
     end
   end
 


### PR DESCRIPTION
# chore: update Homebrew formula with v0.5.0 SHA256 checksums

## Summary

Updates the Homebrew formula with actual SHA256 checksums from the v0.5.0 GitHub release artifacts. Replaces the `"REPLACE_WITH_SHA256_AFTER_RELEASE"` placeholders with verified checksums for all 4 platform/architecture combinations (macOS arm64/amd64, Linux arm64/amd64).

This completes the v0.5.0 release process and makes the Homebrew formula functional for package installation.

## Review & Testing Checklist for Human

**3 critical items to verify:**

- [ ] **Verify checksums match v0.5.0 release artifacts**: Download the SHA256 files from https://github.com/jxwalker/modfetch/releases/tag/v0.5.0 and confirm each checksum in the formula matches the corresponding platform binary
- [ ] **Test Homebrew installation**: Try installing via Homebrew on at least one platform to ensure the formula works end-to-end
- [ ] **Double-check platform mapping**: Verify that arm64/amd64 checksums are assigned to the correct platform blocks (easy to swap accidentally)

### Notes

- The checksums were automatically extracted from the GitHub release artifacts after the v0.5.0 release workflow completed successfully
- If any checksum is incorrect, Homebrew installation will fail with a verification error
- This PR should be merged quickly after verification since it unblocks Homebrew installation for users

**Link to Devin run**: https://app.devin.ai/sessions/d999ba2dcb9d40b3b8c564c9a9cfd16c  
**Requested by**: @jxwalker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated integrity checksums for modfetch binaries across macOS (Apple Silicon and Intel) and Linux (arm64 and amd64). Ensures Homebrew installations verify downloads correctly. No changes to URLs, installation behavior, or functionality; this is a checksum refresh to maintain distribution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->