### PR TITLE
hotfix: initialize SKIP_CONFIG_WIZARD variable to prevent unbound variable error

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,7 @@ INSTALL_DIR=${INSTALL_DIR:-/usr/local/bin}
 CONFIG_DIR=${CONFIG_DIR:-"${XDG_CONFIG_HOME:-$HOME/.config}/modfetch"}
 DATA_DIR=${DATA_DIR:-"$HOME/modfetch-data"}
 DOWNLOAD_DIR=${DOWNLOAD_DIR:-"$HOME/Downloads/modfetch"}
+SKIP_CONFIG_WIZARD=${SKIP_CONFIG_WIZARD:-false}
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
# hotfix: initialize SKIP_CONFIG_WIZARD variable to prevent unbound variable error

## Summary
Adds missing default initialization for `SKIP_CONFIG_WIZARD` variable in the installation script. This fixes a bash "unbound variable" error that occurs when users run the installer without the `--skip-config-wizard` flag.

**Root cause**: The script uses `set -euo pipefail` which makes unbound variables fatal. `SKIP_CONFIG_WIZARD` was only set when the `--skip-config-wizard` flag was passed, causing crashes when the flag wasn't used.

**Fix**: Initialize `SKIP_CONFIG_WIZARD=${SKIP_CONFIG_WIZARD:-false}` at the top of the script alongside other variable declarations.

## Review & Testing Checklist for Human
- [ ] **Test installer without any flags**: Verify it completes successfully and runs the config wizard by default
- [ ] **Test installer with --skip-config-wizard**: Verify it completes successfully and skips the config wizard

### Notes
- This resolves the installation failure reported by the user on macOS ARM64
- Default value `false` preserves existing behavior (config wizard runs by default)
- Minimal risk change - just adding variable initialization

**Session**: https://app.devin.ai/sessions/d999ba2dcb9d40b3b8c564c9a9cfd16c  
**Requested by**: @jxwalker