### PR TITLE
fix: correct TUI version selection logic and navigation issues

### DIFF
--- a/cmd/modfetch/tui_cmd.go
+++ b/cmd/modfetch/tui_cmd.go
@@ -23,9 +23,9 @@ func handleTUI(ctx context.Context, args []string) error {
 	cfgPath := fs.String("config", "", "Path to YAML config file")
 	logLevel := fs.String("log-level", "info", "log level")
 	jsonOut := fs.Bool("json", false, "json logs (not used in TUI)")
-	// --v2 kept for compatibility but unused since v2 is default
+	// --v2 kept for compatibility, v2 is now default
 	_ = fs.Bool("v2", false, "Use TUI v2 (default)")
-	useV1 := fs.Bool("v1", false, "Use legacy TUI v1 (fallback)")
+	useV1 := fs.Bool("v1", false, "Use refactored TUI v1 (experimental)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -87,11 +87,11 @@ func handleTUI(ctx context.Context, args []string) error {
 	}
 	defer func() { _ = st.SQL.Close() }()
 	var m tea.Model
-	// Default to refactored TUI unless legacy v1 explicitly requested
+	// Default to TUI v2 (which works) unless legacy v1 explicitly requested
 	if *useV1 {
-		m = uiv2.New(c, st, version)
+		m = ui.New(c, st)  // Use refactored TUI v1
 	} else {
-		m = ui.New(c, st)
+		m = uiv2.New(c, st, version)  // Use working TUI v2 as default
 	}
 	p := tea.NewProgram(m, tea.WithMouseCellMotion())
 	_, err = p.Run()


### PR DESCRIPTION
# fix: correct TUI version selection logic and navigation issues

## Summary
Fixes TUI navigation issues where arrow keys don't work and help instructions aren't accessible. The root cause was backwards version selection logic in `tui_cmd.go` - users were getting the refactored TUI v1 (which has MVC orchestration issues) by default instead of the working TUI v2.

**Changes:**
- Swapped TUI version selection logic so v2 is default, v1 requires `--v1` flag  
- Updated help text to clarify v2 is default, v1 is experimental
- No functional changes to either TUI implementation

**Before:** `modfetch tui` → refactored TUI v1 (broken navigation)  
**After:** `modfetch tui` → TUI v2 (working navigation)

## Review & Testing Checklist for Human
This is a **medium-risk** change that requires manual verification:

- [ ] **Manual TUI testing**: Launch `./bin/modfetch tui` and verify arrow keys, j/k navigation, help system (?), new download (n), menu (m) all work properly
- [ ] **Version flag testing**: Confirm `modfetch tui --v1` launches refactored version and `modfetch tui --v2` works as expected  
- [ ] **No regressions**: Test that TUI functionality (downloads, filtering, etc.) works the same as before
- [ ] **Terminal compatibility**: Verify no escape sequences or garbled output in different terminal environments

### Test Plan
1. Build and run `make test && make build`
2. Test default TUI: `./bin/modfetch tui` - should show clean interface with full navigation
3. Test refactored TUI: `./bin/modfetch tui --v1` - may show escape sequences but should still function
4. In both versions, test: arrow key navigation, ? for help, n for new download, basic TUI operations

### Notes
- This fixes the immediate user-facing issue but doesn't resolve the underlying MVC orchestration problems in the refactored TUI v1
- The refactored TUI still has escape sequence issues and minimal interface - it's just no longer the default
- Session requested by @jxwalker (james@dxc.com)
- Link to Devin run: https://app.devin.ai/sessions/d999ba2dcb9d40b3b8c564c9a9cfd16c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Default terminal UI now uses the newer v2 interface for a modernized experience.
- Refactor
  - Streamlined UI selection logic: v2 is the default; legacy v1 can be enabled via the provided flag.
  - Improved clarity around UI behavior and defaults through updated inline guidance.
- Chores
  - Updated internal comments to reflect the new default and the experimental status of v1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->