### PR TITLE
fix: converge terminal state after finalization

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,63 @@
+# modfetch
+
+## What This Is
+
+`modfetch` is a brownfield Go CLI/TUI for downloading and organizing AI model artifacts from Hugging Face, CivitAI, and direct URLs. The next stage is to turn it from a strong downloader into a model-centric acquisition tool that serves both experienced operators who want tight control and beginners who just want the right model to work.
+
+## Core Value
+
+A user can fetch the right model artifact for their machine and runtime with high confidence in integrity, low disk waste, and clear operational control.
+
+## Requirements
+
+### Validated
+
+- ✓ Reliable chunked and single-stream downloads with resume/retry already exist in the codebase.
+- ✓ SHA256 verification and deep safetensors validation already exist for file-level workflows.
+- ✓ Resolver support for `hf://` and `civitai://` already exists.
+- ✓ Placement, TUI monitoring, SQLite-backed state, and library scanning already exist.
+
+### Active
+
+- [ ] Make download finalization and SQLite job state converge reliably so completed artifacts never remain stuck as `running`.
+- [ ] Make Hugging Face repos first-class snapshot artifacts instead of file-centric downloads.
+- [ ] Add repo-aware integrity verification and targeted shard repair.
+- [ ] Minimize duplicate copies across staging, cache, placement, and runtime consumption.
+- [ ] Add runtime-aware planning and prepare flows for common local runtimes.
+- [ ] Make beginner workflows practical through machine checks, recommendations, aliases, and launch guidance.
+- [ ] Preserve and strengthen CivitAI as a core differentiated workflow.
+
+### Out of Scope
+
+- Automatic training, fine-tuning, or serving infrastructure management — not core to acquisition and placement.
+- Becoming a generic package manager for arbitrary binaries — the focus remains model and companion-asset workflows.
+- Full automatic format conversion in the first milestone — conversion awareness matters now; conversion execution can follow later.
+
+## Context
+
+The repo already has strong download primitives: chunk planning, retries, verification, placement rules, metadata fetchers, a TUI, and local state. The major gap is product shape. Today the tool is still primarily file-oriented, especially for Hugging Face, while large-model users need repo snapshots, runtime-aware file selection, disk-efficient placement, repo-level verification, and recovery. Beginner usability is also limited because the current CLI assumes the user already knows model IDs, formats, runtimes, and storage tradeoffs.
+
+The roadmap provided by the user is grounded in a real operator workflow: large NAS-backed model storage, constrained boot disks, sharded safetensors repos, mixed runtimes, and flaky CivitAI conditions. The product needs to be meaningfully better than `hf` plus `aria2` by owning the planning, integrity, placement, and recovery story end to end.
+
+There is also an immediate correctness bug from a recent real run: the downloaded model file was correct and usable, but `modfetch` left the process and SQLite row in `running` state after final placement completed. That makes terminal-state bookkeeping a prerequisite for trusting later planner and verification layers.
+
+## Constraints
+
+- **Tech stack**: Go codebase with existing CLI/TUI/state architecture — planning should extend current package seams instead of forcing a rewrite.
+- **Brownfield**: Existing download and verification behavior must remain stable for current users.
+- **Integrity**: “Download complete” must imply trustworthy artifact state, not just bytes written.
+- **Efficiency**: Large-model workflows must avoid unnecessary duplicate copies and make overhead visible before execution.
+- **UX split**: The same product must satisfy advanced operators and low-context beginners without bifurcating the codebase.
+
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| Keep `modfetch` as a brownfield extension of the existing CLI/TUI architecture | The repo already has solid primitives worth preserving | ✓ Good |
+| Treat model acquisition as a manifest-driven workflow | Planning, verification, placement, and repair all need a shared source of truth | ✓ Good |
+| Fix terminal-state bookkeeping before expanding planner/state responsibilities | Snapshot and verification work depends on trustworthy lifecycle state | ✓ Good |
+| Prioritize Hugging Face snapshots before broader beginner/catalog work | The biggest capability gap is repo-centric large-model workflows | ✓ Good |
+| Bias the first milestone toward trust and efficiency before convenience layers | Beginner UX is only credible if downloads are correct and storage-aware | ✓ Good |
+
+---
+*Last updated: 2026-04-23 after initial GSD planning for the modfetch roadmap*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,126 @@
+# Requirements: modfetch
+
+**Defined:** 2026-04-23
+**Core Value:** A user can fetch the right model artifact for their machine and runtime with high confidence in integrity, low disk waste, and clear operational control.
+
+## v1 Requirements
+
+### State and Finalization Correctness
+
+- [ ] **STATE-01**: A download that has finalized a correct file is persisted as a terminal success state instead of remaining `running`.
+- [ ] **STATE-02**: Finalization updates state, progress views, and process cleanup atomically enough that successful jobs do not get stranded in intermediate bookkeeping states.
+
+### Snapshot Planning
+
+- [ ] **SNAP-01**: User can plan a full Hugging Face repo snapshot as one logical artifact.
+- [ ] **SNAP-02**: Planning output reports total bytes, file count, shard count, largest file, and estimated staging overhead before download.
+- [ ] **SNAP-03**: The tool distinguishes repo snapshots, variants, and shard files in both human and JSON output.
+- [ ] **SNAP-04**: User can execute a repo snapshot with one command instead of building a batch manually.
+
+### Integrity and Repair
+
+- [ ] **INTEG-01**: A completed snapshot is verified against an expected manifest of required files.
+- [ ] **INTEG-02**: Truncated, undersized, zero-byte, or structurally invalid safetensors shards are not marked complete.
+- [ ] **INTEG-03**: User can run repo-level verification after download using a dedicated command.
+- [ ] **INTEG-04**: User can repair only failed shards without refetching a healthy repo.
+- [ ] **INTEG-05**: Verification results are visible in CLI output and JSON output.
+
+### Storage and Placement
+
+- [ ] **PLAC-01**: Same-filesystem workflows can finalize without an unnecessary second full copy.
+- [ ] **PLAC-02**: Finalization reports whether files were renamed, hardlinked, reflinked, symlinked, or copied.
+- [ ] **PLAC-03**: Planning output shows expected disk overhead for the chosen placement strategy.
+- [ ] **PLAC-04**: Shared cache and runtime placement workflows remain compatible with existing placement rules.
+
+### Runtime Guidance
+
+- [ ] **RUN-01**: User can plan or fetch using runtime-aware presets starting with `vllm`.
+- [ ] **RUN-02**: Runtime-aware planning explains why each file is included or excluded.
+- [ ] **RUN-03**: `llama.cpp` and `transformers` are supported after `vllm` with runtime-appropriate file selection.
+- [ ] **RUN-04**: Prepared output can be handed directly to the selected runtime without manual repo surgery.
+
+### Beginner Workflow
+
+- [ ] **GUIDE-01**: User can check whether a model fits their machine before downloading.
+- [ ] **GUIDE-02**: User can run a guided `prepare` flow that chooses or confirms a sane setup path.
+- [ ] **GUIDE-03**: Machine inspection reports OS, architecture, memory, relevant accelerator info, and free disk by mount where available.
+- [ ] **GUIDE-04**: Beginner-facing output recommends likely-fit model/runtime combinations and explains caveats.
+
+### Catalog and Discovery
+
+- [ ] **CAT-01**: User can search by goal or friendly alias instead of only raw repo IDs.
+- [ ] **CAT-02**: The tool can generate next-step launch templates for supported runtimes.
+
+### CivitAI Reliability
+
+- [ ] **CIV-01**: CivitAI downloads survive interrupted sessions without silent corruption.
+- [ ] **CIV-02**: Diagnostics distinguish auth issues, provider-side interruptions, network instability, and anti-bot failures.
+- [ ] **CIV-03**: Reliability mode remains a first-class workflow, not a side feature.
+
+### Device Profiles and Workflow Packs
+
+- [ ] **PROF-01**: User can target named device profiles that encode runtime and storage defaults.
+- [ ] **PROF-02**: The same model request can produce different correct plans for different targets.
+- [ ] **PACK-01**: Workflow packs can resolve multiple related artifacts for common workflows.
+- [ ] **PACK-02**: Image-model ecosystems can place assets into app-aware destinations in later phases without rewriting core planning.
+
+## v2 Requirements
+
+### Conversion and Advanced Ecosystem Support
+
+- **V2-01**: The tool can execute safe format conversions where a target-native artifact is unavailable.
+- **V2-02**: The tool can support broader app-aware image workflow orchestration beyond the initial pack system.
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| Generic binary mirroring for non-model workloads | Dilutes the product away from model acquisition and runtime preparation |
+| Automatic serving lifecycle management | Deployment/orchestration is downstream of acquisition |
+| Automatic conversion in the first milestone | Too much risk before manifest, integrity, and placement foundations are solid |
+
+## Traceability
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| STATE-01 | Phase 1 | Pending |
+| STATE-02 | Phase 1 | Pending |
+| SNAP-01 | Phase 1 | Pending |
+| SNAP-02 | Phase 1 | Pending |
+| SNAP-03 | Phase 1 | Pending |
+| SNAP-04 | Phase 1 | Pending |
+| INTEG-01 | Phase 2 | Pending |
+| INTEG-02 | Phase 2 | Pending |
+| INTEG-03 | Phase 2 | Pending |
+| INTEG-04 | Phase 2 | Pending |
+| INTEG-05 | Phase 2 | Pending |
+| PLAC-01 | Phase 3 | Pending |
+| PLAC-02 | Phase 3 | Pending |
+| PLAC-03 | Phase 3 | Pending |
+| PLAC-04 | Phase 3 | Pending |
+| RUN-01 | Phase 4 | Pending |
+| RUN-02 | Phase 4 | Pending |
+| RUN-03 | Phase 4 | Pending |
+| RUN-04 | Phase 4 | Pending |
+| GUIDE-01 | Phase 5 | Pending |
+| GUIDE-02 | Phase 5 | Pending |
+| GUIDE-03 | Phase 5 | Pending |
+| GUIDE-04 | Phase 5 | Pending |
+| CAT-01 | Phase 6 | Pending |
+| CAT-02 | Phase 6 | Pending |
+| CIV-01 | Phase 7 | Pending |
+| CIV-02 | Phase 7 | Pending |
+| CIV-03 | Phase 7 | Pending |
+| PROF-01 | Phase 8 | Pending |
+| PROF-02 | Phase 8 | Pending |
+| PACK-01 | Phase 8 | Pending |
+| PACK-02 | Phase 8 | Pending |
+
+**Coverage:**
+- v1 requirements: 33 total
+- Mapped to phases: 33
+- Unmapped: 0
+
+---
+*Requirements defined: 2026-04-23*
+*Last updated: 2026-04-23 after initial roadmap synthesis from the user roadmap and live codebase review*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,156 @@
+# Roadmap: modfetch
+
+## Overview
+
+`modfetch` already has strong download primitives. The roadmap now shifts the product from a capable downloader into a model-centric acquisition system that beats `hf downloader` and `aria2` by planning full model snapshots, guaranteeing integrity, minimizing disk waste, and guiding both expert operators and beginners toward working local setups.
+
+## Phases
+
+- [ ] **Phase 1: First-Class HF Snapshots and Manifest Planner** - Build manifest-driven Hugging Face snapshot planning and execution.
+- [ ] **Phase 2: Repo-Level Verification and Shard Repair** - Make integrity a first-class repo workflow instead of a file-level afterthought.
+- [ ] **Phase 3: Efficient Finalization and Deduplicated Placement** - Remove avoidable duplicate copies and make storage strategy explicit.
+- [ ] **Phase 4: Runtime-Aware Fetching and Presets** - Add runtime-aware planning starting with `vllm`, then expand to `llama.cpp` and `transformers`.
+- [ ] **Phase 5: Machine Detection and Guided Prepare Flows** - Add `check` and `prepare` so beginners can get a compatible setup without deep model knowledge.
+- [ ] **Phase 6: Catalog, Aliases, and Launch Templates** - Make model discovery and next-step launch guidance friendlier and more approachable.
+- [ ] **Phase 7: Hardened CivitAI Reliability Mode** - Strengthen CivitAI resume, recovery, diagnostics, and corruption handling under hostile conditions.
+- [ ] **Phase 8: Device Profiles, Workflow Packs, and Image Ecosystem Support** - Add target-aware profiles and multi-artifact workflow packs for mixed fleets and image workflows.
+
+## Phase Details
+
+### Phase 1: First-Class HF Snapshots and Manifest Planner
+**Goal**: Fix terminal-state bookkeeping first, then convert Hugging Face handling from file-centric resolution to repo-centric snapshot manifests with usable planning output.
+**Depends on**: Nothing (first phase)
+**Requirements**: [STATE-01, STATE-02, SNAP-01, SNAP-02, SNAP-03, SNAP-04]
+**Success Criteria** (what must be TRUE):
+  1. A successfully finalized download cannot remain stuck in `running` state in SQLite or user-facing status views.
+  2. User can run `modfetch plan hf://owner/repo` and see real snapshot-level planning data.
+  3. User can run `modfetch snapshot hf://owner/repo` and fetch an entire repo as one logical job.
+  4. Output clearly separates repo, variant, and shard concepts instead of conflating them.
+  5. The planner becomes the source of truth for later verification and placement work.
+**Plans**: 4 plans
+
+Plans:
+- [x] 01-01: Reproduce and fix the finalization/state-cleanup bug so successful jobs transition atomically to a terminal success state.
+- [ ] 01-02: Add manifest domain types and Hugging Face repo-tree expansion.
+- [ ] 01-03: Add `plan` and `snapshot` CLI surfaces with JSON and human output.
+- [ ] 01-04: Redesign quant/variant reporting to use manifest semantics instead of selected-file heuristics.
+
+### Phase 2: Repo-Level Verification and Shard Repair
+**Goal**: Guarantee that snapshot completion means the repo is structurally sound and repairable at shard granularity.
+**Depends on**: Phase 1
+**Requirements**: [INTEG-01, INTEG-02, INTEG-03, INTEG-04, INTEG-05]
+**Success Criteria** (what must be TRUE):
+  1. A repo with a bad shard fails verification clearly and names the exact problem file.
+  2. Repo verification checks required files, sizes, and shard/index consistency in addition to existing file checks.
+  3. Corrupt or incomplete shards are quarantined or marked suspect instead of accepted as complete.
+  4. User can repair only failed shards from manifest diff data.
+**Plans**: 3 plans
+
+Plans:
+- [ ] 02-01: Persist manifest and verification receipt data in local state.
+- [ ] 02-02: Add repo-level `verify` flow for snapshot directories and manifest-backed jobs.
+- [ ] 02-03: Add targeted shard repair and suspect-file handling.
+
+### Phase 3: Efficient Finalization and Deduplicated Placement
+**Goal**: Make large-model downloads storage-aware so they do not duplicate terabytes unnecessarily.
+**Depends on**: Phase 2
+**Requirements**: [PLAC-01, PLAC-02, PLAC-03, PLAC-04]
+**Success Criteria** (what must be TRUE):
+  1. Same-filesystem workflows can finalize without an unnecessary second copy.
+  2. Planning output tells the user what overhead to expect before downloading.
+  3. Finalization status reports the exact strategy used per artifact.
+  4. Existing placement workflows keep working while gaining more efficient options.
+**Plans**: 3 plans
+
+Plans:
+- [ ] 03-01: Add explicit finalization strategy modeling including rename, hardlink, reflink, symlink, and copy.
+- [ ] 03-02: Teach planner and downloader to choose and report the lowest-overhead safe strategy.
+- [ ] 03-03: Integrate deduplicated placement with existing placer rules and state reporting.
+
+### Phase 4: Runtime-Aware Fetching and Presets
+**Goal**: Teach `modfetch` to choose the right files and layout for supported local runtimes.
+**Depends on**: Phase 3
+**Requirements**: [RUN-01, RUN-02, RUN-03, RUN-04]
+**Success Criteria** (what must be TRUE):
+  1. `--runtime vllm` fetches the minimal required set for local serving from supported HF repos.
+  2. Planner output explains why each file is included.
+  3. `llama.cpp` and `transformers` presets follow after `vllm` without regressing snapshot semantics.
+  4. Runtime-ready output can be pointed at the target runtime without manual repo surgery.
+**Plans**: 3 plans
+
+Plans:
+- [ ] 04-01: Add runtime profile model and `vllm` file-selection rules.
+- [ ] 04-02: Add runtime-aware layout presets and explanation output.
+- [ ] 04-03: Extend runtime support to `llama.cpp` and `transformers`.
+
+### Phase 5: Machine Detection and Guided Prepare Flows
+**Goal**: Make it practical for a beginner to answer “can I run this?” and get a working setup path.
+**Depends on**: Phase 4
+**Requirements**: [GUIDE-01, GUIDE-02, GUIDE-03, GUIDE-04]
+**Success Criteria** (what must be TRUE):
+  1. User can run a machine check before downloading.
+  2. Beginner output clearly warns about disk, memory, and runtime caveats.
+  3. `prepare` can carry a beginner through check → plan → fetch → verify → next-step launch guidance.
+  4. Advanced users can still override profile, runtime, and placement decisions explicitly.
+**Plans**: 3 plans
+
+Plans:
+- [ ] 05-01: Add machine inspection for OS, architecture, memory, storage, and available accelerator signals.
+- [ ] 05-02: Add `check` and first-pass recommendation logic.
+- [ ] 05-03: Add `prepare` happy path built on planner, verifier, and runtime presets.
+
+### Phase 6: Catalog, Aliases, and Launch Templates
+**Goal**: Improve discovery and reduce the amount of model-specific knowledge required to get started.
+**Depends on**: Phase 5
+**Requirements**: [CAT-01, CAT-02]
+**Success Criteria** (what must be TRUE):
+  1. User can search by goal or friendly alias instead of only by raw model repo.
+  2. The tool can explain what it chose and why.
+  3. Launch templates for supported runtimes are emitted automatically as next steps.
+**Plans**: 2 plans
+
+Plans:
+- [ ] 06-01: Add curated alias/catalog model and lookup commands.
+- [ ] 06-02: Add runtime launch templates and explanation output.
+
+### Phase 7: Hardened CivitAI Reliability Mode
+**Goal**: Preserve and deepen one of `modfetch`’s original differentiators under hostile network conditions.
+**Depends on**: Phase 6
+**Requirements**: [CIV-01, CIV-02, CIV-03]
+**Success Criteria** (what must be TRUE):
+  1. Interrupted CivitAI downloads resume cleanly without silent corruption.
+  2. Diagnostic output distinguishes likely cause categories instead of generic failures.
+  3. Reliability mode is clearly better than browser-based downloads under flaky conditions.
+**Plans**: 2 plans
+
+Plans:
+- [ ] 07-01: Add hardened retry/resume behavior and integrity promotion rules for CivitAI.
+- [ ] 07-02: Add `doctor civitai` diagnostics and recovery flows.
+
+### Phase 8: Device Profiles, Workflow Packs, and Image Ecosystem Support
+**Goal**: Let one request produce different correct outcomes for different machines and multi-artifact workflows.
+**Depends on**: Phase 7
+**Requirements**: [PROF-01, PROF-02, PACK-01, PACK-02]
+**Success Criteria** (what must be TRUE):
+  1. Named device profiles encode storage, runtime, and format defaults for heterogeneous fleets.
+  2. Workflow packs can resolve multiple related artifacts as one request.
+  3. Image-model workflows can evolve on top of the same planning and verification foundations rather than a separate subsystem.
+**Plans**: 3 plans
+
+Plans:
+- [ ] 08-01: Add target profile model and profile-aware planning.
+- [ ] 08-02: Add workflow pack manifests for multi-artifact requests.
+- [ ] 08-03: Add first image-model ecosystem adapters on the shared planning core.
+
+## Progress
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 1. First-Class HF Snapshots and Manifest Planner | 1/4 | In progress | - |
+| 2. Repo-Level Verification and Shard Repair | 0/3 | Not started | - |
+| 3. Efficient Finalization and Deduplicated Placement | 0/3 | Not started | - |
+| 4. Runtime-Aware Fetching and Presets | 0/3 | Not started | - |
+| 5. Machine Detection and Guided Prepare Flows | 0/3 | Not started | - |
+| 6. Catalog, Aliases, and Launch Templates | 0/2 | Not started | - |
+| 7. Hardened CivitAI Reliability Mode | 0/2 | Not started | - |
+| 8. Device Profiles, Workflow Packs, and Image Ecosystem Support | 0/3 | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,63 @@
+# Project State
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-04-23)
+
+**Core value:** A user can fetch the right model artifact for their machine and runtime with high confidence in integrity, low disk waste, and clear operational control.
+**Current focus:** Phase 1 — First-Class HF Snapshots and Manifest Planner
+
+## Current Position
+
+Phase: 1 of 8 (First-Class HF Snapshots and Manifest Planner)
+Plan: 1 of 4 in current phase
+Status: In progress
+Last activity: 2026-04-23 — Completed 01-01 finalization/state-cleanup fix with regression coverage
+
+Progress: [█░░░░░░░░░] 12%
+
+## Performance Metrics
+
+**Velocity:**
+- Total plans completed: 1
+- Average duration: 39 min
+- Total execution time: 0.7 hours
+
+**By Phase:**
+
+| Phase | Plans | Total | Avg/Plan |
+|-------|-------|-------|----------|
+| 1 | 1 | 39 min | 39 min |
+
+**Recent Trend:**
+- Last 5 plans: 39 min
+- Trend: Stable
+
+## Accumulated Context
+
+### Decisions
+
+Decisions are logged in PROJECT.md Key Decisions table.
+Recent decisions affecting current work:
+
+- Phase 0: Use a local `.planning/` workspace rooted in the actual modfetch clone, not the unrelated parent project.
+- Phase 0: Use the user’s eight-item sequencing as the roadmap backbone.
+- Phase 0: Prioritize snapshot planning, integrity, and efficiency before convenience layers.
+- Phase 0: Fix terminal-state bookkeeping before relying on richer planner/state features.
+- Phase 1: Treat sidecar/fsync failures after a valid final artifact as warnings, not reasons to strand a row in `running`.
+- Phase 1: Reconcile stale startup state against the filesystem before auto-resuming downloads.
+
+### Pending Todos
+
+None yet.
+
+### Blockers/Concerns
+
+- The repo has existing downloader and verification behavior that must not regress while snapshot semantics are introduced.
+- Hugging Face resolution is currently file-centric, so the planner and manifest model must become the shared foundation before later phases.
+
+## Session Continuity
+
+Last session: 2026-04-23 20:00 UTC
+Stopped at: Completed 01-01 and ready to move into manifest domain modeling for 01-02
+Resume file: None

--- a/.planning/config.json
+++ b/.planning/config.json
@@ -1,0 +1,41 @@
+{
+  "model_profile": "inherit",
+  "commit_docs": true,
+  "parallelization": true,
+  "search_gitignored": false,
+  "brave_search": false,
+  "firecrawl": false,
+  "exa_search": false,
+  "git": {
+    "branching_strategy": "none",
+    "phase_branch_template": "gsd/phase-{phase}-{slug}",
+    "milestone_branch_template": "gsd/{milestone}-{slug}",
+    "quick_branch_template": null
+  },
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true,
+    "nyquist_validation": true,
+    "auto_advance": false,
+    "node_repair": true,
+    "node_repair_budget": 2,
+    "ui_phase": true,
+    "ui_safety_gate": true,
+    "text_mode": false,
+    "research_before_questions": false,
+    "discuss_mode": "discuss",
+    "skip_discuss": false,
+    "code_review": true,
+    "code_review_depth": "standard"
+  },
+  "hooks": {
+    "context_warnings": true
+  },
+  "project_code": null,
+  "phase_naming": "sequential",
+  "agent_skills": {},
+  "resolve_model_ids": "omit",
+  "mode": "yolo",
+  "granularity": "coarse"
+}

--- a/.planning/phases/01-first-class-hf-snapshots-and-manifest-planner/01-01-PLAN.md
+++ b/.planning/phases/01-first-class-hf-snapshots-and-manifest-planner/01-01-PLAN.md
@@ -1,0 +1,117 @@
+---
+phase: 1
+plan: 1
+type: brownfield
+wave: 1
+requirements: [STATE-01, STATE-02]
+objective: Fix the finalization/state-cleanup bug so a successfully finalized download cannot remain stuck in running state in SQLite or the TUI process tracker.
+---
+
+# Plan: Phase 1 Plan 1: Finalization and State Cleanup Correctness
+
+## Context
+
+Recent real-world behavior exposed a trust-breaking lifecycle bug:
+
+- the model file finished correctly
+- NAS placement was correct
+- the runtime could use the file successfully
+- `modfetch` bookkeeping remained stuck in `running`
+
+The live code review points to two concrete risk areas:
+
+1. The downloaders only persist terminal `complete` status after sidecar write and directory fsync complete successfully. If the main file is already finalized but sidecar/fsync fails, the row can remain `running`.
+2. The TUI keeps an in-memory `running` map but does not clear it in `dlDoneMsg` handling on either success or failure, which can leave the UI thinking a job is still active even after the downloader returns.
+
+These need to be fixed before snapshot manifests, repo verification, or richer planner/state semantics are layered on top.
+
+## Scope
+
+This plan covers terminal lifecycle correctness for the existing download paths:
+
+- chunked downloader finalization
+- single-stream downloader finalization
+- SQLite terminal-state persistence
+- TUI download completion/error cleanup
+- startup recovery behavior for stale `running` rows
+
+This plan does not yet introduce snapshot semantics or new CLI commands.
+
+## Tasks
+
+### Task 1: Reproduce and characterize the stuck-running bug
+- **Type**: auto
+- **Description**: Add or adapt tests that model the observed failure class: file finalized successfully while bookkeeping stays `running`. Cover both downloader state persistence and TUI cleanup semantics.
+- **Implementation notes**:
+  - Target downloader tests around post-finalization failure windows.
+  - Add focused unit coverage for `dlDoneMsg` handling and auto-recovery filtering.
+  - If the current code is hard to test, extract small helpers instead of writing brittle integration-only tests.
+- **Success Criteria**:
+  - There is at least one failing test that captures a valid finalized file paired with incorrect nonterminal bookkeeping.
+  - The failure clearly distinguishes file correctness from lifecycle correctness.
+
+### Task 2: Make downloader finalization commit a trustworthy terminal state
+- **Type**: auto
+- **Description**: Refactor chunked and single download finalization so terminal state cannot be stranded in `running` after the final artifact is already usable.
+- **Implementation notes**:
+  - Review the ordering around `renameOrCopy`, `adjustSafetensors`, sidecar write, directory fsync, and `UpsertDownload(... Status: "complete")`.
+  - Decide and encode the product rule for sidecar/fsync failures after the main artifact is valid:
+    - either treat them as nonfatal bookkeeping warnings and still mark the artifact complete with warning metadata
+    - or mark a distinct terminal degraded state, but never leave `running`
+  - Ensure error paths after final placement persist a terminal state and last error detail.
+  - Prefer one helper for “persist terminal success/failure after finalization” so chunked and single do not drift.
+- **Success Criteria**:
+  - A finalized usable file always results in a terminal download row, never `running`.
+  - Chunked and single paths share consistent terminal-state behavior.
+  - Any post-finalization bookkeeping problem is visible via status/error fields.
+
+### Task 3: Clear TUI in-memory running state on completion and failure
+- **Type**: auto
+- **Description**: Fix the TUI lifecycle so background download bookkeeping does not remain active after `dlDoneMsg` is received.
+- **Implementation notes**:
+  - Update `internal/tui/model.go` `dlDoneMsg` handling to remove the correct key from `m.running` on both success and failure.
+  - Handle normalized/resolved URL keys correctly so original URL and resolved URL cleanup do not diverge.
+  - Ensure retry and auto-place metadata maps are also cleaned consistently.
+- **Success Criteria**:
+  - Successful downloads are removed from the TUI running set.
+  - Failed downloads are removed from the TUI running set unless explicitly retried.
+  - URL normalization does not leave orphaned running-map entries.
+
+### Task 4: Harden stale recovery semantics
+- **Type**: auto
+- **Description**: Prevent auto-recovery from blindly restarting rows that only look `running` due to stale or degraded bookkeeping.
+- **Implementation notes**:
+  - Review `recoverCmd()` selection rules.
+  - Add a lightweight reconciliation step on startup or refresh that can detect “final file present and verified enough to stop recovery.”
+  - Keep this minimal: enough to avoid reanimating obviously finished jobs, not a full repo verifier.
+- **Success Criteria**:
+  - TUI startup does not automatically restart a job whose final artifact is already present and valid enough to classify as terminal.
+  - Recovery remains functional for genuinely interrupted downloads.
+
+## Files Likely To Change
+
+- `internal/downloader/chunked.go`
+- `internal/downloader/single.go`
+- `internal/downloader/fsutil.go` or a new shared finalization helper
+- `internal/tui/model.go`
+- `internal/tui/actions.go`
+- `internal/state/state.go` if terminal-state helper semantics need to be tightened
+- `internal/downloader/*_test.go`
+- `internal/tui/*_test.go` if added
+
+## Verification
+
+- Run targeted tests for downloader terminal-state transitions and TUI completion cleanup.
+- Reproduce the original class of scenario:
+  - download final file successfully
+  - confirm on-disk file exists and size is correct
+  - confirm SQLite row ends in a terminal state, not `running`
+  - confirm TUI/process bookkeeping no longer treats the job as active
+- Run a broader Go test slice for downloader, state, and TUI packages to check for regressions.
+
+## Done When
+
+1. A successful finalized artifact cannot remain `running` in SQLite.
+2. TUI completion/error handling always clears the active in-memory running state.
+3. Startup recovery does not resurrect obviously complete downloads.
+4. The bug is covered by regression tests so later snapshot/planner work builds on trustworthy lifecycle state.

--- a/.planning/phases/01-first-class-hf-snapshots-and-manifest-planner/01-01-SUMMARY.md
+++ b/.planning/phases/01-first-class-hf-snapshots-and-manifest-planner/01-01-SUMMARY.md
@@ -1,0 +1,81 @@
+---
+phase: 01-first-class-hf-snapshots-and-manifest-planner
+plan: 01
+subsystem: infra
+tags: [downloader, sqlite, tui, lifecycle, finalization, recovery]
+requires: []
+provides:
+  - Terminal download state now converges to `complete` even if post-finalization sidecar or directory fsync bookkeeping fails.
+  - TUI active-job tracking is cleared on both success and failure.
+  - Auto-recovery reconciles obviously finalized `running` rows instead of restarting them.
+affects: [snapshot-planner, verification, recovery, tui]
+tech-stack:
+  added: []
+  patterns: [terminal-state persistence helper, startup reconciliation of stale running rows]
+key-files:
+  created: [.planning/phases/01-first-class-hf-snapshots-and-manifest-planner/01-01-SUMMARY.md, internal/downloader/finalization_state_test.go, internal/tui/recovery_state_test.go]
+  modified: [internal/downloader/chunked.go, internal/downloader/fsutil.go, internal/downloader/single.go, internal/tui/actions.go, internal/tui/model.go]
+key-decisions:
+  - "Treat sidecar write and directory fsync failures after a valid final artifact as nonterminal warnings, not reasons to strand the row in running."
+  - "Clear TUI running-map state on every dlDoneMsg path, not just user-initiated cancellation."
+  - "Do not auto-recover hold rows; only reconcile or resume rows that were marked running."
+patterns-established:
+  - "Downloader finalization should persist a terminal state before returning from nonfatal bookkeeping errors."
+  - "Startup recovery must reconcile stale state with the filesystem before restarting work."
+requirements-completed: [STATE-01, STATE-02]
+duration: 39min
+completed: 2026-04-23
+---
+
+# Phase 1 Plan 1 Summary
+
+**Downloader terminal state now converges after finalization, with TUI cleanup and stale-running recovery hardened for real completed files**
+
+## Performance
+
+- **Duration:** 39 min
+- **Started:** 2026-04-23T20:00:00Z
+- **Completed:** 2026-04-23T20:39:00Z
+- **Tasks:** 4
+- **Files modified:** 7
+
+## Accomplishments
+- Successful finalized artifacts no longer remain stuck in `running` when post-finalization sidecar or directory fsync work fails.
+- TUI `running` bookkeeping is cleared on both success and failure, fixing the “process still running” symptom.
+- Startup recovery now reconciles stale `running` rows with finalized on-disk artifacts and avoids auto-resuming `hold` rows.
+- Regression coverage was added for downloader terminal-state persistence and TUI recovery/cleanup behavior.
+
+## Files Created/Modified
+- `internal/downloader/single.go` - marks finalized downloads complete even when noncritical sidecar/fsync bookkeeping fails
+- `internal/downloader/chunked.go` - applies the same terminal-state rule to chunked finalization
+- `internal/downloader/fsutil.go` - exposes hookable helpers for finalization-path tests
+- `internal/tui/actions.go` - reconciles stale running rows from finalized artifacts and stops auto-recovering hold rows
+- `internal/tui/model.go` - clears in-memory running/retrying state when downloads finish
+- `internal/downloader/finalization_state_test.go` - regression test for finalized file plus sidecar failure
+- `internal/tui/recovery_state_test.go` - regression tests for TUI cleanup and stale-running recovery
+
+## Decisions Made
+- Noncritical bookkeeping failures after a valid final artifact should be recorded as warnings while preserving terminal success state.
+- TUI running-state cleanup belongs in `dlDoneMsg` handling so all completion paths converge through one place.
+- Startup recovery should reconcile filesystem truth before restarting background work.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+- The likely lifecycle bug was split across downloader finalization ordering and separate TUI in-memory tracking, so both layers needed coordinated fixes.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- Terminal lifecycle state is now trustworthy enough to support richer snapshot planner/state work.
+- Phase 1 can proceed to manifest domain modeling and Hugging Face snapshot planning.
+
+---
+*Phase: 01-first-class-hf-snapshots-and-manifest-planner*
+*Completed: 2026-04-23*

--- a/internal/downloader/chunked.go
+++ b/internal/downloader/chunked.go
@@ -39,6 +39,24 @@ type Chunked struct {
 	}
 }
 
+func (e *Chunked) persistComplete(url, destPath, expectedSHA, actualSHA, etag, lastMod string, size int64, warning error) {
+	row := state.DownloadRow{
+		URL:            url,
+		Dest:           destPath,
+		ExpectedSHA256: expectedSHA,
+		ActualSHA256:   actualSHA,
+		ETag:           etag,
+		LastModified:   lastMod,
+		Size:           size,
+		Status:         "complete",
+	}
+	if warning != nil {
+		row.LastError = warning.Error()
+		e.log.Warnf("%s", row.LastError)
+	}
+	_ = e.st.UpsertDownload(row)
+}
+
 func NewChunked(cfg *config.Config, log *logging.Logger, st *state.DB, m interface {
 	AddBytes(int64)
 	IncRetries(int64)
@@ -439,11 +457,15 @@ func (e *Chunked) Download(ctx context.Context, url, destPath, expectedSHA strin
 		}
 		finalSHA = sha2
 	}
-	if err := writeAndSync(destPath+".sha256", []byte(finalSHA+"  "+filepath.Base(destPath)+"\n")); err != nil {
-		return "", "", err
+	if err := writeAndSyncFile(destPath+".sha256", []byte(finalSHA+"  "+filepath.Base(destPath)+"\n")); err != nil {
+		e.persistComplete(url, destPath, expectedSHA, finalSHA, h.etag, h.lastMod, h.size, fmt.Errorf("finalized artifact but failed to write sha256 sidecar: %w", err))
+		return destPath, finalSHA, nil
 	}
-	_ = fsyncDir(filepath.Dir(destPath))
-	_ = e.st.UpsertDownload(state.DownloadRow{URL: url, Dest: destPath, ExpectedSHA256: expectedSHA, ActualSHA256: finalSHA, ETag: h.etag, LastModified: h.lastMod, Size: h.size, Status: "complete"})
+	if err := fsyncDirectory(filepath.Dir(destPath)); err != nil {
+		e.persistComplete(url, destPath, expectedSHA, finalSHA, h.etag, h.lastMod, h.size, fmt.Errorf("finalized artifact but failed to fsync destination directory: %w", err))
+		return destPath, finalSHA, nil
+	}
+	e.persistComplete(url, destPath, expectedSHA, finalSHA, h.etag, h.lastMod, h.size, nil)
 	if e.metrics != nil {
 		e.metrics.IncDownloadsSuccess()
 		e.metrics.ObserveDownloadSeconds(time.Since(startTime).Seconds())

--- a/internal/downloader/finalization_state_test.go
+++ b/internal/downloader/finalization_state_test.go
@@ -1,0 +1,96 @@
+package downloader
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/config"
+	"github.com/jxwalker/modfetch/internal/logging"
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+func testConfig(t *testing.T, root string) *config.Config {
+	t.Helper()
+	cfgYaml := []byte(fmt.Sprintf(`version: 1
+general:
+  data_root: "%s/data"
+  download_root: "%s/dl"
+  placement_mode: "symlink"
+  quarantine: false
+  allow_overwrite: true
+  stage_partials: false
+network:
+  timeout_seconds: 10
+concurrency:
+  per_file_chunks: 2
+  chunk_size_mb: 1
+`, root, root))
+	cfgPath := filepath.Join(root, "config.yml")
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("config load: %v", err)
+	}
+	return cfg
+}
+
+func TestSingleDownload_PersistsCompleteWhenSidecarWriteFails(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := testConfig(t, tmp)
+	st, err := state.Open(cfg)
+	if err != nil {
+		t.Fatalf("state open: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", "11")
+			return
+		}
+		_, _ = w.Write([]byte("hello world"))
+	}))
+	defer srv.Close()
+
+	oldWrite := writeAndSyncFile
+	writeAndSyncFile = func(path string, b []byte) error {
+		if filepath.Ext(path) == ".sha256" {
+			return fmt.Errorf("simulated sidecar failure")
+		}
+		return oldWrite(path, b)
+	}
+	defer func() { writeAndSyncFile = oldWrite }()
+
+	dl := NewSingle(cfg, logging.New("error", false), st, nil)
+	dest, sha, err := dl.Download(context.Background(), srv.URL+"/model.bin", "", "", nil, false)
+	if err != nil {
+		t.Fatalf("download returned error: %v", err)
+	}
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("final file missing: %v", err)
+	}
+	if len(sha) != 64 {
+		t.Fatalf("unexpected sha length: %d", len(sha))
+	}
+	rows, err := st.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].Status != "complete" {
+		t.Fatalf("status = %q, want complete", rows[0].Status)
+	}
+	if rows[0].LastError == "" {
+		t.Fatal("expected warning in last_error for sidecar failure")
+	}
+}
+

--- a/internal/downloader/fsutil.go
+++ b/internal/downloader/fsutil.go
@@ -4,6 +4,9 @@ import (
 	"os"
 )
 
+var writeAndSyncFile = writeAndSync
+var fsyncDirectory = fsyncDir
+
 // writeAndSync writes content to path and fsyncs the file.
 func writeAndSync(path string, b []byte) error {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)

--- a/internal/downloader/single.go
+++ b/internal/downloader/single.go
@@ -21,6 +21,24 @@ import (
 	"github.com/jxwalker/modfetch/internal/util"
 )
 
+func (s *Single) persistComplete(url, destPath, expectedSHA, actualSHA, etag, lastMod string, size int64, warning error) {
+	row := state.DownloadRow{
+		URL:            url,
+		Dest:           destPath,
+		ExpectedSHA256: expectedSHA,
+		ActualSHA256:   actualSHA,
+		ETag:           etag,
+		LastModified:   lastMod,
+		Size:           size,
+		Status:         "complete",
+	}
+	if warning != nil {
+		row.LastError = warning.Error()
+		s.log.Warnf("%s", row.LastError)
+	}
+	_ = s.st.UpsertDownload(row)
+}
+
 // local helper to probe size and range via GET bytes=0-0
 func probeRangeGET(client *http.Client, url string, headers map[string]string, ua string) (size int64, ok bool) {
 	req, _ := http.NewRequest(http.MethodGet, url, nil)
@@ -223,11 +241,15 @@ func (s *Single) Download(ctx context.Context, url, destPath, expectedSHA string
 			if err != nil {
 				return "", "", err
 			}
-			if err := writeAndSync(destPath+".sha256", []byte(actualSHA+"  "+filepath.Base(destPath)+"\n")); err != nil {
-				return "", "", err
+			if err := writeAndSyncFile(destPath+".sha256", []byte(actualSHA+"  "+filepath.Base(destPath)+"\n")); err != nil {
+				s.persistComplete(url, destPath, expectedSHA, actualSHA, etag, lastMod, size, fmt.Errorf("finalized artifact but failed to write sha256 sidecar: %w", err))
+				return destPath, actualSHA, nil
 			}
-			_ = fsyncDir(filepath.Dir(destPath))
-			_ = s.st.UpsertDownload(state.DownloadRow{URL: url, Dest: destPath, ExpectedSHA256: expectedSHA, ActualSHA256: actualSHA, ETag: etag, LastModified: lastMod, Size: size, Status: "complete"})
+			if err := fsyncDirectory(filepath.Dir(destPath)); err != nil {
+				s.persistComplete(url, destPath, expectedSHA, actualSHA, etag, lastMod, size, fmt.Errorf("finalized artifact but failed to fsync destination directory: %w", err))
+				return destPath, actualSHA, nil
+			}
+			s.persistComplete(url, destPath, expectedSHA, actualSHA, etag, lastMod, size, nil)
 			if s.metrics != nil {
 				s.metrics.IncDownloadsSuccess()
 				s.metrics.ObserveDownloadSeconds(time.Since(startTime).Seconds())
@@ -301,12 +323,16 @@ func (s *Single) Download(ctx context.Context, url, destPath, expectedSHA string
 		actualSHA = sha2
 	}
 	// Write checksum file (durable)
-	if err := writeAndSync(destPath+".sha256", []byte(actualSHA+"  "+filepath.Base(destPath)+"\n")); err != nil {
-		return "", "", err
+	if err := writeAndSyncFile(destPath+".sha256", []byte(actualSHA+"  "+filepath.Base(destPath)+"\n")); err != nil {
+		s.persistComplete(url, destPath, expectedSHA, actualSHA, etag, lastMod, size, fmt.Errorf("finalized artifact but failed to write sha256 sidecar: %w", err))
+		return destPath, actualSHA, nil
 	}
 	// Fsync parent directory to persist rename and sidecar
-	_ = fsyncDir(filepath.Dir(destPath))
-	_ = s.st.UpsertDownload(state.DownloadRow{URL: url, Dest: destPath, ExpectedSHA256: expectedSHA, ActualSHA256: actualSHA, ETag: etag, LastModified: lastMod, Size: size, Status: "complete"})
+	if err := fsyncDirectory(filepath.Dir(destPath)); err != nil {
+		s.persistComplete(url, destPath, expectedSHA, actualSHA, etag, lastMod, size, fmt.Errorf("finalized artifact but failed to fsync destination directory: %w", err))
+		return destPath, actualSHA, nil
+	}
+	s.persistComplete(url, destPath, expectedSHA, actualSHA, etag, lastMod, size, nil)
 	if s.metrics != nil {
 		s.metrics.IncDownloadsSuccess()
 		s.metrics.ObserveDownloadSeconds(time.Since(startTime).Seconds())

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -28,13 +28,68 @@ func (m *Model) recoverCmd() tea.Cmd {
 		var todo []state.DownloadRow
 		for _, r := range rows {
 			st := strings.ToLower(strings.TrimSpace(r.Status))
-			if st == "running" || st == "hold" {
-				// Skip completed
+			if st == "running" {
+				if m.reconcileRecoveredRow(r) {
+					continue
+				}
 				todo = append(todo, r)
 			}
 		}
 		return recoverRowsMsg{rows: todo}
 	}
+}
+
+func (m *Model) reconcileRecoveredRow(r state.DownloadRow) bool {
+	fi, err := os.Stat(r.Dest)
+	if err != nil || fi.IsDir() {
+		return false
+	}
+	part := downloader.StagePartPath(m.cfg, r.URL, r.Dest)
+	if _, err := os.Stat(part); err == nil {
+		return false
+	}
+	if r.Size > 0 && fi.Size() != r.Size {
+		return false
+	}
+	actualSHA := strings.TrimSpace(r.ActualSHA256)
+	if actualSHA == "" {
+		actualSHA = readSHA256Sidecar(r.Dest + ".sha256")
+	}
+	_ = m.st.UpsertDownload(state.DownloadRow{
+		URL:            r.URL,
+		Dest:           r.Dest,
+		ExpectedSHA256: r.ExpectedSHA256,
+		ActualSHA256:   actualSHA,
+		ETag:           r.ETag,
+		LastModified:   r.LastModified,
+		Size:           maxInt64(r.Size, fi.Size()),
+		Status:         "complete",
+		LastError:      "recovered terminal state from finalized artifact on startup",
+	})
+	return true
+}
+
+func readSHA256Sidecar(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	fields := strings.Fields(string(b))
+	if len(fields) == 0 {
+		return ""
+	}
+	sum := strings.TrimSpace(fields[0])
+	if len(sum) == 64 {
+		return sum
+	}
+	return ""
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func (m *Model) selectionOrCurrent() []state.DownloadRow {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -173,6 +173,21 @@ type Model struct {
 	log                  *logging.Logger
 }
 
+func (m *Model) clearRunningState(msg dlDoneMsg) {
+	keys := []string{
+		msg.url + "|" + msg.dest,
+		msg.origKey,
+		msg.resKey,
+	}
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+		delete(m.running, key)
+		delete(m.retrying, key)
+	}
+}
+
 type uiState struct {
 	ThemeIndex int    `json:"theme_index"`
 	ShowURL    bool   `json:"show_url"`
@@ -374,6 +389,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case dlDoneMsg:
+		m.clearRunningState(msg)
 		// Apply placement metadata if needed (safe concurrent map access from Update thread)
 		if msg.needsPlaceMap && msg.origKey != msg.resKey {
 			if msg.autoPlace {

--- a/internal/tui/recovery_state_test.go
+++ b/internal/tui/recovery_state_test.go
@@ -1,0 +1,124 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"github.com/jxwalker/modfetch/internal/config"
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+func setupRecoveryModel(t *testing.T) (*Model, *state.DB, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	db, err := state.NewDB(dbPath)
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	cfg := &config.Config{
+		General: config.General{
+			DownloadRoot: tmpDir,
+		},
+	}
+	model := New(cfg, db, "test-version").(*Model)
+	return model, db, tmpDir
+}
+
+func TestDlDoneMsgClearsRunningStateOnSuccess(t *testing.T) {
+	model, db, _ := setupRecoveryModel(t)
+	defer func() { _ = db.Close() }()
+
+	key := "https://example.com/model.bin|/tmp/model.bin"
+	model.running[key] = func() {}
+	model.retrying[key] = model.lastRefresh
+
+	updated, _ := model.Update(dlDoneMsg{
+		url:  "https://example.com/model.bin",
+		dest: "/tmp/model.bin",
+		path: "/tmp/model.bin",
+	})
+	m := updated.(*Model)
+
+	if _, ok := m.running[key]; ok {
+		t.Fatal("running key still present after success")
+	}
+	if _, ok := m.retrying[key]; ok {
+		t.Fatal("retrying key still present after success")
+	}
+}
+
+func TestDlDoneMsgClearsRunningStateOnFailure(t *testing.T) {
+	model, db, _ := setupRecoveryModel(t)
+	defer func() { _ = db.Close() }()
+
+	key := "https://example.com/model.bin|/tmp/model.bin"
+	model.running[key] = func() {}
+
+	updated, _ := model.Update(dlDoneMsg{
+		url:  "https://example.com/model.bin",
+		dest: "/tmp/model.bin",
+		err:  context.Canceled,
+	})
+	m := updated.(*Model)
+
+	if _, ok := m.running[key]; ok {
+		t.Fatal("running key still present after failure")
+	}
+}
+
+func TestRecoverCmdReconcilesFinalizedRunningRow(t *testing.T) {
+	model, db, tmpDir := setupRecoveryModel(t)
+	defer func() { _ = db.Close() }()
+
+	dest := filepath.Join(tmpDir, "model.bin")
+	if err := os.WriteFile(dest, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+	if err := os.WriteFile(dest+".sha256", []byte("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824  model.bin\n"), 0o644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+	if err := db.UpsertDownload(state.DownloadRow{
+		URL:    "https://example.com/model.bin",
+		Dest:   dest,
+		Size:   5,
+		Status: "running",
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	msg := model.recoverCmd()().(recoverRowsMsg)
+	if len(msg.rows) != 0 {
+		t.Fatalf("expected no rows to recover, got %d", len(msg.rows))
+	}
+	rows, err := db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].Status != "complete" {
+		t.Fatalf("status = %q, want complete", rows[0].Status)
+	}
+}
+
+func TestRecoverCmdDoesNotResumeHoldRows(t *testing.T) {
+	model, db, tmpDir := setupRecoveryModel(t)
+	defer func() { _ = db.Close() }()
+
+	dest := filepath.Join(tmpDir, "hold.bin")
+	if err := db.UpsertDownload(state.DownloadRow{
+		URL:    "https://example.com/hold.bin",
+		Dest:   dest,
+		Status: "hold",
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	msg := model.recoverCmd()().(recoverRowsMsg)
+	if len(msg.rows) != 0 {
+		t.Fatalf("expected no hold rows to auto-recover, got %d", len(msg.rows))
+	}
+}


### PR DESCRIPTION
## Summary
- fix downloader terminal-state persistence so finalized artifacts do not remain stuck as `running`
- clear TUI in-memory active-job tracking on both success and failure
- reconcile stale `running` rows against finalized files during recovery and avoid auto-resuming `hold` rows
- add regression coverage for downloader finalization state and TUI recovery behavior
- include initial local GSD planning artifacts for the snapshot/integrity roadmap

## Testing
- `go test ./internal/downloader ./internal/tui`
- `go test ./...`
