### PR TITLE
[codex] Polish TUI table grouping and preferences

### DIFF
--- a/internal/tui/downloads_view.go
+++ b/internal/tui/downloads_view.go
@@ -148,17 +148,24 @@ func (m *Model) applyGrouping(in []state.DownloadRow) []state.DownloadRow {
 	if m.groupBy != "host" || len(in) < 2 {
 		return in
 	}
-	out := make([]state.DownloadRow, len(in))
-	copy(out, in)
-	sort.SliceStable(out, func(i, j int) bool {
-		hi := hostOf(out[i].URL)
-		hj := hostOf(out[j].URL)
+	hosts := make(map[string]string, len(in))
+	hostFor := func(url string) string {
+		if host, ok := hosts[url]; ok {
+			return host
+		}
+		host := hostOf(url)
+		hosts[url] = host
+		return host
+	}
+	sort.SliceStable(in, func(i, j int) bool {
+		hi := hostFor(in[i].URL)
+		hj := hostFor(in[j].URL)
 		if hi == hj {
 			return false
 		}
 		return hi < hj
 	})
-	return out
+	return in
 }
 
 type downloadTableLayout struct {
@@ -307,6 +314,9 @@ func percentLabel(cur, total int64, status string) string {
 
 func completedAwareSpeed(r state.DownloadRow, rate float64) string {
 	if !strings.EqualFold(strings.TrimSpace(r.Status), "complete") {
+		if rate <= 0 {
+			return "0 B/s"
+		}
 		return humanize.Bytes(uint64(rate)) + "/s"
 	}
 	if r.Size <= 0 || r.UpdatedAt <= 0 || r.CreatedAt <= 0 || r.UpdatedAt < r.CreatedAt {

--- a/internal/tui/downloads_view.go
+++ b/internal/tui/downloads_view.go
@@ -19,6 +19,7 @@ func (m *Model) visibleRows() []state.DownloadRow {
 	rows := m.filterRows(m.activeTab)
 	rows = m.applySearch(rows)
 	rows = m.applySort(rows)
+	rows = m.applyGrouping(rows)
 	return rows
 }
 
@@ -143,9 +144,32 @@ func (m *Model) applySort(in []state.DownloadRow) []state.DownloadRow {
 	return out
 }
 
-func (m *Model) renderTable() string {
-	rows := m.visibleRows()
-	var sb strings.Builder
+func (m *Model) applyGrouping(in []state.DownloadRow) []state.DownloadRow {
+	if m.groupBy != "host" || len(in) < 2 {
+		return in
+	}
+	out := make([]state.DownloadRow, len(in))
+	copy(out, in)
+	sort.SliceStable(out, func(i, j int) bool {
+		hi := hostOf(out[i].URL)
+		hj := hostOf(out[j].URL)
+		if hi == hj {
+			return false
+		}
+		return hi < hj
+	})
+	return out
+}
+
+type downloadTableLayout struct {
+	compact    bool
+	lastLabel  string
+	speedLabel string
+	etaLabel   string
+	lastWidth  int
+}
+
+func (m *Model) downloadTableLayout() downloadTableLayout {
 	lastLabel := "DEST"
 	switch m.columnMode {
 	case "url":
@@ -154,26 +178,41 @@ func (m *Model) renderTable() string {
 		lastLabel = "HOST"
 	}
 	speedLabel := "SPEED"
-	etaLabel := "ETA"
 	if m.sortMode == "speed" {
-		speedLabel = speedLabel + "*"
+		speedLabel += "*"
 	}
+	etaLabel := "ETA"
 	if m.sortMode == "eta" {
-		etaLabel = etaLabel + "*"
+		etaLabel += "*"
 	}
-	if m.isCompact() {
-		hdr := m.th.head.Render(fmt.Sprintf("%-1s %-8s %-3s  %-16s  %-4s  %-12s  %-8s  %-s", "S", "STATUS", "RT", "PROG", "PCT", "SRC", etaLabel, lastLabel))
-		if m.sortMode == "rem" {
-			hdr = hdr + "  [sort: remaining]"
-		}
-		sb.WriteString(hdr)
+	compact := m.isCompact()
+	return downloadTableLayout{
+		compact:    compact,
+		lastLabel:  lastLabel,
+		speedLabel: speedLabel,
+		etaLabel:   etaLabel,
+		lastWidth:  m.lastColumnWidth(compact),
+	}
+}
+
+func (m *Model) renderTableHeader(layout downloadTableLayout) string {
+	var hdr string
+	if layout.compact {
+		hdr = m.th.head.Render(fmt.Sprintf("%-1s %-8s %-3s  %-16s  %-4s  %-12s  %-8s  %-s", "S", "STATUS", "RT", "PROG", "PCT", "SRC", layout.etaLabel, layout.lastLabel))
 	} else {
-		hdr := m.th.head.Render(fmt.Sprintf("%-1s %-8s %-3s  %-16s  %-4s  %-10s  %-10s  %-12s  %-8s  %-s", "S", "STATUS", "RT", "PROG", "PCT", speedLabel, "THR", "SRC", etaLabel, lastLabel))
-		if m.sortMode == "rem" {
-			hdr = hdr + "  [sort: remaining]"
-		}
-		sb.WriteString(hdr)
+		hdr = m.th.head.Render(fmt.Sprintf("%-1s %-8s %-3s  %-16s  %-4s  %-10s  %-10s  %-12s  %-8s  %-s", "S", "STATUS", "RT", "PROG", "PCT", layout.speedLabel, "THR", "SRC", layout.etaLabel, layout.lastLabel))
 	}
+	if m.sortMode == "rem" {
+		hdr += "  [sort: remaining]"
+	}
+	return hdr
+}
+
+func (m *Model) renderTable() string {
+	rows := m.visibleRows()
+	var sb strings.Builder
+	layout := m.downloadTableLayout()
+	sb.WriteString(m.renderTableHeader(layout))
 	sb.WriteString("\n")
 	maxRows := m.h - 10
 	if maxRows < 3 {
@@ -188,73 +227,7 @@ func (m *Model) renderTable() string {
 				prevGroup = host
 			}
 		}
-		// Progress and pct
-		prog := m.renderProgress(r)
-		cur, total, rate, _ := m.progressFor(r)
-		pct := "--%"
-		if total > 0 {
-			ratio := float64(cur) / float64(total)
-			if ratio < 0 {
-				ratio = 0
-			}
-			if ratio > 1 {
-				ratio = 1
-			}
-			pct = fmt.Sprintf("%3.0f%%", ratio*100)
-		}
-		// For completed jobs, force 100%
-		if strings.EqualFold(strings.TrimSpace(r.Status), "complete") {
-			pct = "100%"
-		}
-		eta := m.etaCache[keyFor(r)]
-		thr := m.renderSparkline(keyFor(r))
-		sel := " "
-		if m.selectedKeys[keyFor(r)] {
-			sel = "*"
-		}
-		// status label with transient retrying overlay
-		statusLabel := r.Status
-		if strings.EqualFold(statusLabel, "hold") && strings.Contains(strings.ToLower(strings.TrimSpace(r.LastError)), "rate limited") {
-			statusLabel = "hold(rl)"
-		}
-		if ts, ok := m.retrying[keyFor(r)]; ok {
-			if time.Since(ts) < 4*time.Second {
-				statusLabel = "retrying"
-			} else {
-				delete(m.retrying, keyFor(r))
-			}
-		}
-		last := r.Dest
-		switch m.columnMode {
-		case "url":
-			last = logging.SanitizeURL(r.URL)
-		case "host":
-			last = hostOf(r.URL)
-		}
-		src := hostOf(r.URL)
-		src = truncateMiddle(src, 12)
-		lw := m.lastColumnWidth(m.isCompact())
-		last = truncateMiddle(last, lw)
-		// Speed column value
-		speedStr := humanize.Bytes(uint64(rate)) + "/s"
-		if strings.EqualFold(strings.TrimSpace(r.Status), "complete") {
-			// Show average speed for completed
-			if r.Size > 0 && r.UpdatedAt > 0 && r.CreatedAt > 0 && r.UpdatedAt >= r.CreatedAt {
-				dur := time.Duration(r.UpdatedAt-r.CreatedAt) * time.Second
-				if dur > 0 {
-					avg := float64(r.Size) / dur.Seconds()
-					speedStr = humanize.Bytes(uint64(avg)) + "/s"
-				}
-			} else {
-				speedStr = "-"
-			}
-		}
-		var line string
-		if m.isCompact() {
-			line = fmt.Sprintf("%-1s %-8s %-3d  %-16s  %-4s  %-12s  %-8s  %s", sel, statusLabel, r.Retries, prog, pct, src, eta, last)
-		} else {
-			line = fmt.Sprintf("%-1s %-8s %-3d  %-16s  %-4s  %-10s  %-10s  %-12s  %-8s  %s", sel, statusLabel, r.Retries, prog, pct, speedStr, thr, src, eta, last)
-		}
+		line := m.renderDownloadRow(r, layout)
 		if i == m.selected {
 			line = m.th.rowSelected.Render(line)
 		}
@@ -267,6 +240,84 @@ func (m *Model) renderTable() string {
 		sb.WriteString(m.th.label.Render("(no items)"))
 	}
 	return sb.String()
+}
+
+func (m *Model) renderDownloadRow(r state.DownloadRow, layout downloadTableLayout) string {
+	prog := m.renderProgress(r)
+	cur, total, rate, _ := m.progressFor(r)
+	pct := percentLabel(cur, total, r.Status)
+	key := keyFor(r)
+	eta := m.etaCache[key]
+	sel := " "
+	if m.selectedKeys[key] {
+		sel = "*"
+	}
+	statusLabel := m.downloadStatusLabel(r, key)
+	last := m.lastColumnValue(r)
+	src := truncateMiddle(hostOf(r.URL), 12)
+	last = truncateMiddle(last, layout.lastWidth)
+	if layout.compact {
+		return fmt.Sprintf("%-1s %-8s %-3d  %-16s  %-4s  %-12s  %-8s  %s", sel, statusLabel, r.Retries, prog, pct, src, eta, last)
+	}
+	return fmt.Sprintf("%-1s %-8s %-3d  %-16s  %-4s  %-10s  %-10s  %-12s  %-8s  %s", sel, statusLabel, r.Retries, prog, pct, completedAwareSpeed(r, rate), m.renderSparkline(key), src, eta, last)
+}
+
+func (m *Model) downloadStatusLabel(r state.DownloadRow, key string) string {
+	statusLabel := r.Status
+	if strings.EqualFold(statusLabel, "hold") && strings.Contains(strings.ToLower(strings.TrimSpace(r.LastError)), "rate limited") {
+		statusLabel = "hold(rl)"
+	}
+	if ts, ok := m.retrying[key]; ok {
+		if time.Since(ts) < 4*time.Second {
+			statusLabel = "retrying"
+		} else {
+			delete(m.retrying, key)
+		}
+	}
+	return statusLabel
+}
+
+func (m *Model) lastColumnValue(r state.DownloadRow) string {
+	switch m.columnMode {
+	case "url":
+		return logging.SanitizeURL(r.URL)
+	case "host":
+		return hostOf(r.URL)
+	default:
+		return r.Dest
+	}
+}
+
+func percentLabel(cur, total int64, status string) string {
+	if strings.EqualFold(strings.TrimSpace(status), "complete") {
+		return "100%"
+	}
+	if total <= 0 {
+		return "--%"
+	}
+	ratio := float64(cur) / float64(total)
+	if ratio < 0 {
+		ratio = 0
+	}
+	if ratio > 1 {
+		ratio = 1
+	}
+	return fmt.Sprintf("%3.0f%%", ratio*100)
+}
+
+func completedAwareSpeed(r state.DownloadRow, rate float64) string {
+	if !strings.EqualFold(strings.TrimSpace(r.Status), "complete") {
+		return humanize.Bytes(uint64(rate)) + "/s"
+	}
+	if r.Size <= 0 || r.UpdatedAt <= 0 || r.CreatedAt <= 0 || r.UpdatedAt < r.CreatedAt {
+		return "-"
+	}
+	dur := time.Duration(r.UpdatedAt-r.CreatedAt) * time.Second
+	if dur <= 0 {
+		return "-"
+	}
+	avg := float64(r.Size) / dur.Seconds()
+	return humanize.Bytes(uint64(avg)) + "/s"
 }
 
 func (m *Model) renderInspector() string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -457,7 +457,7 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch s {
 	case "q", "ctrl+c":
-		m.saveUIState()
+		m.saveUIStateIfConfigured()
 		return m, tea.Quit
 	case "/":
 		if m.activeTab == 4 {
@@ -491,15 +491,19 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "s":
 		m.sortMode = "speed"
+		m.saveUIStateIfConfigured()
 		return m, nil
 	case "e":
 		m.sortMode = "eta"
+		m.saveUIStateIfConfigured()
 		return m, nil
 	case "o":
 		m.sortMode = ""
+		m.saveUIStateIfConfigured()
 		return m, nil
 	case "R":
 		m.sortMode = "rem"
+		m.saveUIStateIfConfigured()
 		return m, nil
 	case "g":
 		if m.groupBy == "host" {
@@ -507,6 +511,7 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else {
 			m.groupBy = "host"
 		}
+		m.saveUIStateIfConfigured()
 		return m, nil
 	case "t":
 		switch m.columnMode {
@@ -943,4 +948,11 @@ func (m *Model) saveUIState() {
 	st := uiState{ThemeIndex: m.themeIndex, ShowURL: m.columnMode == "url", ColumnMode: m.columnMode, Compact: m.cfg.UI.Compact, GroupBy: m.groupBy, SortMode: m.sortMode}
 	b, _ := json.MarshalIndent(st, "", "  ")
 	_ = os.WriteFile(p, b, 0o644)
+}
+
+func (m *Model) saveUIStateIfConfigured() {
+	if m.cfg == nil {
+		return
+	}
+	m.saveUIState()
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -457,7 +457,7 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch s {
 	case "q", "ctrl+c":
-		m.saveUIStateIfConfigured()
+		m.saveUIState()
 		return m, tea.Quit
 	case "/":
 		if m.activeTab == 4 {
@@ -491,19 +491,19 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "s":
 		m.sortMode = "speed"
-		m.saveUIStateIfConfigured()
+		m.saveUIState()
 		return m, nil
 	case "e":
 		m.sortMode = "eta"
-		m.saveUIStateIfConfigured()
+		m.saveUIState()
 		return m, nil
 	case "o":
 		m.sortMode = ""
-		m.saveUIStateIfConfigured()
+		m.saveUIState()
 		return m, nil
 	case "R":
 		m.sortMode = "rem"
-		m.saveUIStateIfConfigured()
+		m.saveUIState()
 		return m, nil
 	case "g":
 		if m.groupBy == "host" {
@@ -511,7 +511,7 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else {
 			m.groupBy = "host"
 		}
-		m.saveUIStateIfConfigured()
+		m.saveUIState()
 		return m, nil
 	case "t":
 		switch m.columnMode {
@@ -951,8 +951,4 @@ func (m *Model) saveUIState() {
 	st := uiState{ThemeIndex: m.themeIndex, ShowURL: m.columnMode == "url", ColumnMode: m.columnMode, Compact: m.cfg.UI.Compact, GroupBy: m.groupBy, SortMode: m.sortMode}
 	b, _ := json.MarshalIndent(st, "", "  ")
 	_ = os.WriteFile(p, b, 0o644)
-}
-
-func (m *Model) saveUIStateIfConfigured() {
-	m.saveUIState()
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -943,6 +943,9 @@ func (m *Model) loadUIState() {
 }
 
 func (m *Model) saveUIState() {
+	if m.cfg == nil {
+		return
+	}
 	p := m.uiStatePath()
 	_ = os.MkdirAll(filepath.Dir(p), 0o755)
 	st := uiState{ThemeIndex: m.themeIndex, ShowURL: m.columnMode == "url", ColumnMode: m.columnMode, Compact: m.cfg.UI.Compact, GroupBy: m.groupBy, SortMode: m.sortMode}
@@ -951,8 +954,5 @@ func (m *Model) saveUIState() {
 }
 
 func (m *Model) saveUIStateIfConfigured() {
-	if m.cfg == nil {
-		return
-	}
 	m.saveUIState()
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -91,6 +92,76 @@ func TestUpdateFilterEscPreservesSelectedRowWhenClearingFilter(t *testing.T) {
 	}
 	if rows := m.visibleRows(); rows[m.selected].Dest != "gamma.gguf" {
 		t.Fatalf("expected gamma to remain selected, got %q", rows[m.selected].Dest)
+	}
+}
+
+func TestGroupByHostOrdersRowsIntoContiguousHostGroups(t *testing.T) {
+	m := &Model{
+		activeTab: -1,
+		groupBy:   "host",
+		rows: []state.DownloadRow{
+			{URL: "https://b.example.com/first", Dest: "b-first.gguf", Status: "running"},
+			{URL: "https://a.example.com/first", Dest: "a-first.gguf", Status: "running"},
+			{URL: "https://b.example.com/second", Dest: "b-second.gguf", Status: "running"},
+		},
+		filterInput: textinput.New(),
+	}
+
+	rows := m.visibleRows()
+	if got := []string{hostOf(rows[0].URL), hostOf(rows[1].URL), hostOf(rows[2].URL)}; got[0] != "a.example.com" || got[1] != "b.example.com" || got[2] != "b.example.com" {
+		t.Fatalf("expected contiguous host groups, got %v", got)
+	}
+}
+
+func TestGroupByHostPreservesSortWithinHost(t *testing.T) {
+	m := &Model{
+		activeTab: -1,
+		groupBy:   "host",
+		sortMode:  "speed",
+		rows: []state.DownloadRow{
+			{URL: "https://b.example.com/slow", Dest: "b-slow.gguf", Status: "running"},
+			{URL: "https://a.example.com/only", Dest: "a-only.gguf", Status: "running"},
+			{URL: "https://b.example.com/fast", Dest: "b-fast.gguf", Status: "running"},
+		},
+		filterInput: textinput.New(),
+		rateCache: map[string]float64{
+			"https://b.example.com/slow|b-slow.gguf": 10,
+			"https://a.example.com/only|a-only.gguf": 50,
+			"https://b.example.com/fast|b-fast.gguf": 100,
+		},
+		curBytesCache: map[string]int64{},
+		totalCache:    map[string]int64{},
+		rateHist:      map[string][]float64{},
+	}
+
+	rows := m.visibleRows()
+	got := []string{rows[0].Dest, rows[1].Dest, rows[2].Dest}
+	want := []string{"a-only.gguf", "b-fast.gguf", "b-slow.gguf"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected grouped rows %v, got %v", want, got)
+		}
+	}
+}
+
+func TestSortAndGroupKeysPersistUIState(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := &Model{
+		cfg: &config.Config{General: config.General{DataRoot: tmpDir}},
+	}
+
+	m.updateNormal(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	m.updateNormal(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+
+	b, err := os.ReadFile(filepath.Join(tmpDir, "ui_state_v2.json"))
+	if err != nil {
+		t.Fatalf("read ui state: %v", err)
+	}
+	got := string(b)
+	for _, want := range []string{`"sort_mode": "speed"`, `"group_by": "host"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected saved UI state to contain %s, got %s", want, got)
+		}
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,9 +1,9 @@
 package tui
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -157,11 +157,22 @@ func TestSortAndGroupKeysPersistUIState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read ui state: %v", err)
 	}
-	got := string(b)
-	for _, want := range []string{`"sort_mode": "speed"`, `"group_by": "host"`} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("expected saved UI state to contain %s, got %s", want, got)
-		}
+	var st uiState
+	if err := json.Unmarshal(b, &st); err != nil {
+		t.Fatalf("unmarshal ui state: %v; raw=%s", err, string(b))
+	}
+	if st.SortMode != "speed" {
+		t.Fatalf("expected sort_mode=speed, got %q", st.SortMode)
+	}
+	if st.GroupBy != "host" {
+		t.Fatalf("expected group_by=host, got %q", st.GroupBy)
+	}
+}
+
+func TestCompletedAwareSpeedClampsNegativeRate(t *testing.T) {
+	got := completedAwareSpeed(state.DownloadRow{Status: "running"}, -1)
+	if got != "0 B/s" {
+		t.Fatalf("expected negative rate to render as 0 B/s, got %q", got)
 	}
 }
 

--- a/internal/tui/settings_test.go
+++ b/internal/tui/settings_test.go
@@ -406,6 +406,8 @@ func TestSettings_UIPreferences(t *testing.T) {
 	model, cleanup := setupTestSettings(t, nil)
 	defer cleanup()
 	model.columnMode = "dest"
+	model.sortMode = "rem"
+	model.groupBy = "host"
 
 	output := model.renderSettings()
 
@@ -428,6 +430,22 @@ func TestSettings_UIPreferences(t *testing.T) {
 
 	if !strings.Contains(output, "dest") {
 		t.Error("Should show column mode value")
+	}
+
+	if !strings.Contains(output, "Sort Mode:") {
+		t.Error("Should show sort mode")
+	}
+
+	if !strings.Contains(output, "remaining") {
+		t.Error("Should show sort mode value")
+	}
+
+	if !strings.Contains(output, "Group By:") {
+		t.Error("Should show group by")
+	}
+
+	if !strings.Contains(output, "host") {
+		t.Error("Should show group by value")
 	}
 
 	if !strings.Contains(output, "Compact View:") {
@@ -472,6 +490,10 @@ func TestSettings_UIPreferences_Defaults(t *testing.T) {
 
 	if !strings.Contains(output, "dest") {
 		t.Error("Should show default column mode")
+	}
+
+	if !strings.Contains(output, "none") {
+		t.Error("Should show default sort/group mode")
 	}
 }
 

--- a/internal/tui/settings_test.go
+++ b/internal/tui/settings_test.go
@@ -436,7 +436,7 @@ func TestSettings_UIPreferences(t *testing.T) {
 		t.Error("Should show sort mode")
 	}
 
-	if !strings.Contains(output, "remaining") {
+	if !strings.Contains(output, "Sort Mode: remaining") {
 		t.Error("Should show sort mode value")
 	}
 
@@ -444,7 +444,7 @@ func TestSettings_UIPreferences(t *testing.T) {
 		t.Error("Should show group by")
 	}
 
-	if !strings.Contains(output, "host") {
+	if !strings.Contains(output, "Group By: host") {
 		t.Error("Should show group by value")
 	}
 
@@ -492,8 +492,12 @@ func TestSettings_UIPreferences_Defaults(t *testing.T) {
 		t.Error("Should show default column mode")
 	}
 
-	if !strings.Contains(output, "none") {
-		t.Error("Should show default sort/group mode")
+	if !strings.Contains(output, "Sort Mode: none") {
+		t.Error("Should show default sort mode")
+	}
+
+	if !strings.Contains(output, "Group By: none") {
+		t.Error("Should show default group mode")
 	}
 }
 

--- a/internal/tui/settings_view.go
+++ b/internal/tui/settings_view.go
@@ -179,6 +179,10 @@ func (m *Model) renderSettings() string {
 	} else {
 		sb.WriteString("dest\n")
 	}
+	sb.WriteString(m.th.label.Render("Sort Mode: "))
+	sb.WriteString(displaySortMode(m.sortMode) + "\n")
+	sb.WriteString(m.th.label.Render("Group By: "))
+	sb.WriteString(displayGroupBy(m.groupBy) + "\n")
 	sb.WriteString(m.th.label.Render("Compact View: "))
 	if m.isCompact() {
 		sb.WriteString("Yes\n")
@@ -219,4 +223,24 @@ func (m *Model) renderSettings() string {
 	sb.WriteString(m.th.footer.Render("To edit settings, modify the YAML config file directly and restart"))
 
 	return sb.String()
+}
+
+func displaySortMode(mode string) string {
+	switch mode {
+	case "speed":
+		return "speed"
+	case "eta":
+		return "eta"
+	case "rem":
+		return "remaining"
+	default:
+		return "none"
+	}
+}
+
+func displayGroupBy(group string) string {
+	if group == "host" {
+		return "host"
+	}
+	return "none"
 }


### PR DESCRIPTION
## Summary
- Make TUI host grouping produce contiguous host groups instead of repeated headers for interleaved rows.
- Split download table header/row formatting into smaller helpers for the TUI polish/refactor roadmap item.
- Persist sort/group preference changes immediately and show current sort/group settings in the Settings tab.

## Validation
- `go test ./internal/tui`
- `go test ./... -timeout 180s`
- `git diff --check`