### PR TITLE
[codex] Expand resolver unit test coverage

### DIFF
--- a/internal/resolver/cache_test.go
+++ b/internal/resolver/cache_test.go
@@ -1,0 +1,125 @@
+package resolver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jxwalker/modfetch/internal/config"
+)
+
+func testCacheConfig(root string, ttlHours int) *config.Config {
+	return &config.Config{
+		General:  config.General{DataRoot: root},
+		Resolver: config.ResolverConf{CacheTTLHours: ttlHours},
+	}
+}
+
+func TestResolverCacheRoundTripDeleteAndClear(t *testing.T) {
+	cfg := testCacheConfig(t.TempDir(), 24)
+	uri := "hf://owner/repo/model.gguf"
+	want := &Resolved{
+		URL:               "https://example.com/model.gguf",
+		Headers:           map[string]string{"Authorization": "Bearer token"},
+		SuggestedFilename: "model.gguf",
+		RepoOwner:         "owner",
+		RepoName:          "repo",
+	}
+
+	if err := cacheSet(cfg, uri, want); err != nil {
+		t.Fatalf("cacheSet: %v", err)
+	}
+	got, ok, err := cacheGet(cfg, uri)
+	if err != nil {
+		t.Fatalf("cacheGet: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if got.URL != want.URL || got.Headers["Authorization"] != want.Headers["Authorization"] || got.SuggestedFilename != want.SuggestedFilename {
+		t.Fatalf("unexpected cached result: %+v", got)
+	}
+
+	if err := cacheDelete(cfg, uri); err != nil {
+		t.Fatalf("cacheDelete: %v", err)
+	}
+	if _, ok, err := cacheGet(cfg, uri); err != nil {
+		t.Fatalf("cacheGet after delete: %v", err)
+	} else if ok {
+		t.Fatal("expected cache miss after delete")
+	}
+
+	if err := cacheSet(cfg, uri, want); err != nil {
+		t.Fatalf("cacheSet after delete: %v", err)
+	}
+	if err := ClearCache(cfg); err != nil {
+		t.Fatalf("ClearCache: %v", err)
+	}
+	path, err := cacheFilePath(cfg)
+	if err != nil {
+		t.Fatalf("cacheFilePath: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected cache file to be removed, stat err=%v", err)
+	}
+	if err := ClearCache(cfg); err != nil {
+		t.Fatalf("ClearCache missing file: %v", err)
+	}
+}
+
+func TestResolverCacheExpiresEntries(t *testing.T) {
+	cfg := testCacheConfig(t.TempDir(), 1)
+	uri := "civitai://model/123"
+	path, err := cacheFilePath(cfg)
+	if err != nil {
+		t.Fatalf("cacheFilePath: %v", err)
+	}
+	old := time.Now().Add(-2 * time.Hour).Unix()
+	if err := saveCache(path, map[string]cacheEntry{
+		uri: {Resolved: Resolved{URL: "https://example.com/old.bin"}, UpdatedAt: old},
+	}); err != nil {
+		t.Fatalf("saveCache: %v", err)
+	}
+
+	if _, ok, err := cacheGet(cfg, uri); err != nil {
+		t.Fatalf("cacheGet: %v", err)
+	} else if ok {
+		t.Fatal("expected expired entry to miss")
+	}
+	entries, err := loadCache(path)
+	if err != nil {
+		t.Fatalf("loadCache: %v", err)
+	}
+	if _, ok := entries[uri]; ok {
+		t.Fatal("expected expired entry to be removed")
+	}
+}
+
+func TestResolverCachePathValidationAndLoadErrors(t *testing.T) {
+	if _, err := cacheFilePath(nil); err == nil {
+		t.Fatal("expected nil config error")
+	}
+	if _, err := cacheFilePath(&config.Config{}); err == nil {
+		t.Fatal("expected empty data_root error")
+	}
+
+	tmp := t.TempDir()
+	empty := filepath.Join(tmp, "empty.json")
+	if err := os.WriteFile(empty, nil, 0o644); err != nil {
+		t.Fatalf("write empty cache: %v", err)
+	}
+	if entries, err := loadCache(empty); err != nil {
+		t.Fatalf("load empty cache: %v", err)
+	} else if len(entries) != 0 {
+		t.Fatalf("expected empty cache, got %+v", entries)
+	}
+
+	invalid := filepath.Join(tmp, "invalid.json")
+	if err := os.WriteFile(invalid, []byte("{"), 0o644); err != nil {
+		t.Fatalf("write invalid cache: %v", err)
+	}
+	if _, err := loadCache(invalid); err == nil {
+		t.Fatal("expected invalid JSON error")
+	}
+}

--- a/internal/resolver/cache_test.go
+++ b/internal/resolver/cache_test.go
@@ -37,7 +37,8 @@ func TestResolverCacheRoundTripDeleteAndClear(t *testing.T) {
 	if !ok {
 		t.Fatal("expected cache hit")
 	}
-	if got.URL != want.URL || got.Headers["Authorization"] != want.Headers["Authorization"] || got.SuggestedFilename != want.SuggestedFilename {
+	if got.URL != want.URL || got.Headers["Authorization"] != want.Headers["Authorization"] ||
+		got.SuggestedFilename != want.SuggestedFilename || got.RepoOwner != want.RepoOwner || got.RepoName != want.RepoName {
 		t.Fatalf("unexpected cached result: %+v", got)
 	}
 

--- a/internal/resolver/civitai_unit_test.go
+++ b/internal/resolver/civitai_unit_test.go
@@ -3,9 +3,11 @@ package resolver
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/jxwalker/modfetch/internal/config"
@@ -16,12 +18,15 @@ func TestCivitAIResolveWithLocalModelEndpoint(t *testing.T) {
 	defer SetCivitaiBaseForTest(oldBase)
 	t.Setenv("CIVITAI_TEST_TOKEN", "secret")
 
-	var sawAuth bool
+	var sawAuth atomic.Bool
+	var handlerErr atomic.Value
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/models/123" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			handlerErr.Store(fmt.Sprintf("unexpected path: %s", r.URL.Path))
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
 		}
-		sawAuth = r.Header.Get("Authorization") == "Bearer secret"
+		sawAuth.Store(r.Header.Get("Authorization") == "Bearer secret")
 		model := civitModel{
 			Name: "Example Model",
 			ModelVersions: []civitVersion{
@@ -43,7 +48,8 @@ func TestCivitAIResolveWithLocalModelEndpoint(t *testing.T) {
 			},
 		}
 		if err := json.NewEncoder(w).Encode(model); err != nil {
-			t.Fatalf("encode model: %v", err)
+			handlerErr.Store(fmt.Sprintf("encode model: %v", err))
+			return
 		}
 	}))
 	defer server.Close()
@@ -64,7 +70,10 @@ func TestCivitAIResolveWithLocalModelEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
-	if !sawAuth {
+	if v := handlerErr.Load(); v != nil {
+		t.Fatal(v)
+	}
+	if !sawAuth.Load() {
 		t.Fatal("expected Authorization header on model request")
 	}
 	if res.URL != "https://cdn.example/vae" || res.FileName != "vae file.safetensors" || res.FileType != "VAE" {
@@ -85,6 +94,7 @@ func TestCivitAIResolveWithLocalVersionEndpoint(t *testing.T) {
 	oldBase := CivitaiBaseForTest()
 	defer SetCivitaiBaseForTest(oldBase)
 
+	var handlerErr atomic.Value
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v1/model-versions/44":
@@ -98,14 +108,18 @@ func TestCivitAIResolveWithLocalVersionEndpoint(t *testing.T) {
 				},
 			}
 			if err := json.NewEncoder(w).Encode(version); err != nil {
-				t.Fatalf("encode version: %v", err)
+				handlerErr.Store(fmt.Sprintf("encode version: %v", err))
+				return
 			}
 		case "/api/v1/models/123":
 			if err := json.NewEncoder(w).Encode(civitModel{Name: "Versioned Model"}); err != nil {
-				t.Fatalf("encode model: %v", err)
+				handlerErr.Store(fmt.Sprintf("encode model: %v", err))
+				return
 			}
 		default:
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			handlerErr.Store(fmt.Sprintf("unexpected path: %s", r.URL.Path))
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
 		}
 	}))
 	defer server.Close()
@@ -114,6 +128,9 @@ func TestCivitAIResolveWithLocalVersionEndpoint(t *testing.T) {
 	res, err := (&CivitAI{}).Resolve(context.Background(), "civitai://model/123?version=44", nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
+	}
+	if v := handlerErr.Load(); v != nil {
+		t.Fatal(v)
 	}
 	if res.URL != "https://cdn.example/model" {
 		t.Fatalf("expected Model file fallback, got %+v", res)
@@ -124,7 +141,7 @@ func TestCivitAIResolveWithLocalVersionEndpoint(t *testing.T) {
 }
 
 func TestCivitAIResolveLocalErrorsAndFilenameHelpers(t *testing.T) {
-	if hasPrefixName("Example_Model-v1", "example model") != true {
+	if !hasPrefixName("Example_Model-v1", "example model") {
 		t.Fatal("expected normalized prefix match")
 	}
 	if normalizeAlphaNum("A b_C-1!") != "abc1" {

--- a/internal/resolver/civitai_unit_test.go
+++ b/internal/resolver/civitai_unit_test.go
@@ -1,0 +1,156 @@
+package resolver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/config"
+)
+
+func TestCivitAIResolveWithLocalModelEndpoint(t *testing.T) {
+	oldBase := CivitaiBaseForTest()
+	defer SetCivitaiBaseForTest(oldBase)
+	t.Setenv("CIVITAI_TEST_TOKEN", "secret")
+
+	var sawAuth bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/models/123" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		sawAuth = r.Header.Get("Authorization") == "Bearer secret"
+		model := civitModel{
+			Name: "Example Model",
+			ModelVersions: []civitVersion{
+				{
+					ID:   1,
+					Name: "old",
+					Files: []civitFile{
+						{ID: 10, Name: "old.safetensors", Type: "Model", Primary: true, DownloadURL: "https://cdn.example/old"},
+					},
+				},
+				{
+					ID:   2,
+					Name: "new",
+					Files: []civitFile{
+						{ID: 20, Name: "preview.txt", Type: "Other", DownloadURL: "https://cdn.example/preview"},
+						{ID: 21, Name: "vae file.safetensors", Type: "VAE", Primary: true, DownloadURL: "https://cdn.example/vae"},
+					},
+				},
+			},
+		}
+		if err := json.NewEncoder(w).Encode(model); err != nil {
+			t.Fatalf("encode model: %v", err)
+		}
+	}))
+	defer server.Close()
+	SetCivitaiBaseForTest(server.URL)
+
+	cfg := &config.Config{
+		Sources: config.Sources{
+			CivitAI: config.SourceWithToken{
+				Enabled:  true,
+				TokenEnv: "CIVITAI_TEST_TOKEN",
+				Naming: config.SourceNaming{
+					Pattern: "{model_name}-{version_id}-{file_type}-{file_name}",
+				},
+			},
+		},
+	}
+	res, err := (&CivitAI{}).Resolve(context.Background(), "civitai://model/123?file=vae", cfg)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !sawAuth {
+		t.Fatal("expected Authorization header on model request")
+	}
+	if res.URL != "https://cdn.example/vae" || res.FileName != "vae file.safetensors" || res.FileType != "VAE" {
+		t.Fatalf("unexpected resolved file: %+v", res)
+	}
+	if res.ModelName != "Example Model" || res.VersionName != "new" || res.VersionID != "2" {
+		t.Fatalf("unexpected model metadata: %+v", res)
+	}
+	if res.Headers["Authorization"] != "Bearer secret" {
+		t.Fatalf("expected auth header in result, got %+v", res.Headers)
+	}
+	if res.SuggestedFilename != "Example-Model-2-VAE-vae-file.safetensors" {
+		t.Fatalf("unexpected suggested filename: %q", res.SuggestedFilename)
+	}
+}
+
+func TestCivitAIResolveWithLocalVersionEndpoint(t *testing.T) {
+	oldBase := CivitaiBaseForTest()
+	defer SetCivitaiBaseForTest(oldBase)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/model-versions/44":
+			version := civitVersion{
+				ID:      44,
+				Name:    "v44",
+				ModelID: 123,
+				Files: []civitFile{
+					{ID: 1, Name: "notes.txt", Type: "Other", DownloadURL: "https://cdn.example/notes"},
+					{ID: 2, Name: "model.safetensors", Type: "Model", DownloadURL: "https://cdn.example/model"},
+				},
+			}
+			if err := json.NewEncoder(w).Encode(version); err != nil {
+				t.Fatalf("encode version: %v", err)
+			}
+		case "/api/v1/models/123":
+			if err := json.NewEncoder(w).Encode(civitModel{Name: "Versioned Model"}); err != nil {
+				t.Fatalf("encode model: %v", err)
+			}
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	SetCivitaiBaseForTest(server.URL)
+
+	res, err := (&CivitAI{}).Resolve(context.Background(), "civitai://model/123?version=44", nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.URL != "https://cdn.example/model" {
+		t.Fatalf("expected Model file fallback, got %+v", res)
+	}
+	if res.SuggestedFilename != "Versioned-Model-model.safetensors" {
+		t.Fatalf("unexpected suggested filename: %q", res.SuggestedFilename)
+	}
+}
+
+func TestCivitAIResolveLocalErrorsAndFilenameHelpers(t *testing.T) {
+	if hasPrefixName("Example_Model-v1", "example model") != true {
+		t.Fatal("expected normalized prefix match")
+	}
+	if normalizeAlphaNum("A b_C-1!") != "abc1" {
+		t.Fatalf("unexpected normalization")
+	}
+	if slugFilename("  weird ++ name!!.safetensors") != "weird-name.safetensors" {
+		t.Fatalf("unexpected slug filename")
+	}
+	if slugFilename("!!.bin") != "download.bin" {
+		t.Fatalf("expected download fallback")
+	}
+
+	oldBase := CivitaiBaseForTest()
+	defer SetCivitaiBaseForTest(oldBase)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusNotFound)
+	}))
+	defer server.Close()
+	SetCivitaiBaseForTest(server.URL)
+
+	_, err := (&CivitAI{}).Resolve(context.Background(), "civitai://model/404", nil)
+	if err == nil || !strings.Contains(err.Error(), "civitai models: 404") {
+		t.Fatalf("expected model 404 error, got %v", err)
+	}
+	_, err = (&CivitAI{}).Resolve(context.Background(), "civitai://model/123?version=404", nil)
+	if err == nil || !strings.Contains(err.Error(), "civitai version: 404") {
+		t.Fatalf("expected version 404 error, got %v", err)
+	}
+}

--- a/internal/resolver/huggingface_unit_test.go
+++ b/internal/resolver/huggingface_unit_test.go
@@ -3,9 +3,11 @@ package resolver
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/jxwalker/modfetch/internal/config"
@@ -64,18 +66,22 @@ func TestHuggingFaceResolveWithLocalTreeAndNamingPattern(t *testing.T) {
 		return ""
 	}
 
-	var sawAuth bool
+	var sawAuth atomic.Bool
+	var handlerErr atomic.Value
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/models/acme/tiny/tree/main" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			handlerErr.Store(fmt.Sprintf("unexpected path: %s", r.URL.Path))
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
 		}
-		sawAuth = r.Header.Get("Authorization") == "Bearer secret"
+		sawAuth.Store(r.Header.Get("Authorization") == "Bearer secret")
 		files := []hfRepoFile{
 			{Path: "tiny.Q4_K_M.gguf", Type: "file", Size: 42},
 			{Path: "tiny.Q8_0.gguf", Type: "file", Size: 84},
 		}
 		if err := json.NewEncoder(w).Encode(files); err != nil {
-			t.Fatalf("encode files: %v", err)
+			handlerErr.Store(fmt.Sprintf("encode files: %v", err))
+			return
 		}
 	}))
 	defer server.Close()
@@ -96,7 +102,10 @@ func TestHuggingFaceResolveWithLocalTreeAndNamingPattern(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
-	if !sawAuth {
+	if v := handlerErr.Load(); v != nil {
+		t.Fatal(v)
+	}
+	if !sawAuth.Load() {
 		t.Fatal("expected Authorization header on tree request")
 	}
 	if res.SelectedQuantization != "Q8_0" || res.RepoPath != "tiny.Q8_0.gguf" {

--- a/internal/resolver/huggingface_unit_test.go
+++ b/internal/resolver/huggingface_unit_test.go
@@ -1,0 +1,153 @@
+package resolver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/config"
+)
+
+func TestHuggingFaceQuantizationHelpers(t *testing.T) {
+	if got, ok := detectQuantization("models/TinyLlama.Q4_K_M.gguf"); !ok || got != "Q4_K_M" {
+		t.Fatalf("expected Q4_K_M, got %q ok=%v", got, ok)
+	}
+	if _, ok := detectQuantization("models/TinyLlama.gguf"); ok {
+		t.Fatal("did not expect quantization for untagged filename")
+	}
+
+	groups := groupQuantizations([]hfRepoFile{
+		{Path: "models", Type: "directory"},
+		{Path: "README.md", Type: "file", Size: 10},
+		{Path: "model.Q5_K_M.gguf", Type: "file", Size: 100},
+		{Path: "model.Q4_K_M.gguf", Type: "file", Size: 80},
+		{Path: "full/model.safetensors", Type: "file", Size: 200},
+		{Path: "full/model-small.safetensors", Type: "file", Size: 50},
+	})
+	if len(groups["Q4_K_M"]) != 1 || len(groups["Q5_K_M"]) != 1 || len(groups["default"]) != 2 {
+		t.Fatalf("unexpected groups: %+v", groups)
+	}
+
+	if q, ok := selectBestQuantization(groups, "q5_k_m"); !ok || q.Name != "Q5_K_M" {
+		t.Fatalf("expected requested Q5_K_M, got %+v ok=%v", q, ok)
+	}
+	if q, ok := selectBestQuantization(groups, "missing"); ok || q.Name != "" {
+		t.Fatalf("expected missing requested quant to fail, got %+v ok=%v", q, ok)
+	}
+	if q, ok := selectBestQuantization(groups, ""); !ok || q.Name != "Q4_K_M" {
+		t.Fatalf("expected preferred Q4_K_M, got %+v ok=%v", q, ok)
+	}
+	if q, ok := selectBestQuantization(map[string][]Quantization{"default": groups["default"]}, ""); !ok || q.Size != 200 {
+		t.Fatalf("expected largest default file, got %+v ok=%v", q, ok)
+	}
+
+	flat := flattenQuantizations(groups)
+	if len(flat) != 4 || flat[0].Name != "Q4_K_M" || flat[1].Name != "Q5_K_M" {
+		t.Fatalf("unexpected flattened quantization order: %+v", flat)
+	}
+}
+
+func TestHuggingFaceResolveWithLocalTreeAndNamingPattern(t *testing.T) {
+	oldBase := hfBaseURL
+	oldGetenv := getenv
+	defer func() {
+		hfBaseURL = oldBase
+		getenv = oldGetenv
+	}()
+	getenv = func(key string) string {
+		if key == "HF_TEST_TOKEN" {
+			return "secret"
+		}
+		return ""
+	}
+
+	var sawAuth bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/models/acme/tiny/tree/main" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		sawAuth = r.Header.Get("Authorization") == "Bearer secret"
+		files := []hfRepoFile{
+			{Path: "tiny.Q4_K_M.gguf", Type: "file", Size: 42},
+			{Path: "tiny.Q8_0.gguf", Type: "file", Size: 84},
+		}
+		if err := json.NewEncoder(w).Encode(files); err != nil {
+			t.Fatalf("encode files: %v", err)
+		}
+	}))
+	defer server.Close()
+	hfBaseURL = server.URL
+
+	cfg := &config.Config{
+		Sources: config.Sources{
+			HuggingFace: config.SourceWithToken{
+				Enabled:  true,
+				TokenEnv: "HF_TEST_TOKEN",
+				Naming: config.SourceNaming{
+					Pattern: "{owner}-{repo}-{quantization}-{file_name}",
+				},
+			},
+		},
+	}
+	res, err := (&HuggingFace{}).Resolve(context.Background(), "hf://acme/tiny?quant=q8_0", cfg)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !sawAuth {
+		t.Fatal("expected Authorization header on tree request")
+	}
+	if res.SelectedQuantization != "Q8_0" || res.RepoPath != "tiny.Q8_0.gguf" {
+		t.Fatalf("unexpected selected quantization: %+v", res)
+	}
+	if !strings.Contains(res.URL, "/acme/tiny/resolve/main/tiny.Q8_0.gguf") {
+		t.Fatalf("unexpected resolve URL: %s", res.URL)
+	}
+	if res.Headers["Authorization"] != "Bearer secret" {
+		t.Fatalf("expected auth header in resolved result, got %+v", res.Headers)
+	}
+	if res.SuggestedFilename != "acme-tiny-Q8_0-tiny.Q8_0.gguf" {
+		t.Fatalf("unexpected suggested filename: %q", res.SuggestedFilename)
+	}
+	if len(res.AvailableQuantizations) != 2 {
+		t.Fatalf("expected available quantizations, got %+v", res.AvailableQuantizations)
+	}
+}
+
+func TestHuggingFaceResolveLocalTreeErrors(t *testing.T) {
+	oldBase := hfBaseURL
+	defer func() { hfBaseURL = oldBase }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+	hfBaseURL = server.URL
+
+	_, err := (&HuggingFace{}).Resolve(context.Background(), "hf://acme/tiny", nil)
+	if err == nil || !strings.Contains(err.Error(), "hf api returned 404") {
+		t.Fatalf("expected 404 tree error, got %v", err)
+	}
+}
+
+func TestHuggingFaceDirectFileResolutionAndSuggestedFilename(t *testing.T) {
+	cfg := &config.Config{
+		Sources: config.Sources{
+			HuggingFace: config.SourceWithToken{
+				Naming: config.SourceNaming{Pattern: "{owner}_{repo}_{rev}_{file_name}"},
+			},
+		},
+	}
+	res, err := (&HuggingFace{}).Resolve(context.Background(), "hf://acme/tiny/path/to/model+v1.gguf?rev=dev", cfg)
+	if err != nil {
+		t.Fatalf("Resolve direct file: %v", err)
+	}
+	if !strings.Contains(res.URL, "model%2Bv1.gguf") {
+		t.Fatalf("expected plus to be escaped in URL, got %s", res.URL)
+	}
+	if res.SuggestedFilename != "acme_tiny_dev_model-v1.gguf" {
+		t.Fatalf("unexpected suggested filename: %q", res.SuggestedFilename)
+	}
+}


### PR DESCRIPTION
## Summary
- Add resolver cache unit tests for round-trip reads, deletion, clearing, expiry, path validation, and malformed cache files.
- Add local-server CivitAI resolver tests for model and version endpoints, auth propagation, file selection, naming patterns, and helper behavior.
- Add local-server HuggingFace resolver tests for quantization selection, naming patterns, direct file resolution, and API error handling.

## Impact
- Raises `internal/resolver` local test coverage from 8.6% to 87.8% without requiring live HuggingFace/CivitAI credentials or network access.

## Validation
- `go test ./internal/resolver -coverprofile=/tmp/resolver-coverage.out`
- `go test ./internal/resolver ./internal/state ./internal/placer ./internal/downloader -coverprofile=/tmp/modfetch-coverage.out`
- `go test ./... -timeout 180s`
- `git diff --check`