### PR TITLE
[codex] Expand state placer downloader test coverage

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,7 +31,7 @@ Priority 3 — User experience
 
 Priority 4 — Quality improvements
 - Rich, structured error context with remediation hints [IMPL]
-- Test coverage expansion (resolvers/state/placer/downloaders) [NEW]
+- Test coverage expansion (resolvers/state/placer/downloaders) [IMPL]
 - Metrics expansion (per-download stats, percentiles) [IMPL]
 - Configuration validation hardening [IMPL]
 

--- a/internal/downloader/errors_test.go
+++ b/internal/downloader/errors_test.go
@@ -10,6 +10,33 @@ import (
 	"github.com/jxwalker/modfetch/internal/config"
 )
 
+func TestDownloadErrorMessagesAndUnwrap(t *testing.T) {
+	if got := (rateLimitedError{after: time.Second, msg: "slow down"}).Error(); got != "slow down" {
+		t.Fatalf("rateLimitedError Error() = %q", got)
+	}
+	if got := (checksumMismatchError{msg: "bad sha"}).Error(); got != "bad sha" {
+		t.Fatalf("checksumMismatchError Error() = %q", got)
+	}
+
+	status := httpStatusError{statusCode: http.StatusForbidden, msg: "403 Forbidden", remediation: "add token"}
+	if got := status.Error(); !strings.Contains(got, "403 Forbidden") || !strings.Contains(got, "remediation: add token") {
+		t.Fatalf("unexpected status error message: %q", got)
+	}
+	status.remediation = ""
+	if got := status.Error(); got != "403 Forbidden" {
+		t.Fatalf("expected bare status message, got %q", got)
+	}
+
+	base := errors.New("wrapped")
+	nonRetryable := nonRetryableError{err: base}
+	if got := nonRetryable.Error(); got != "wrapped" {
+		t.Fatalf("nonRetryableError Error() = %q", got)
+	}
+	if !errors.Is(nonRetryable, base) {
+		t.Fatal("expected nonRetryableError to unwrap base error")
+	}
+}
+
 func TestFriendlyStatus_429_RateLimited(t *testing.T) {
 	cfg := &config.Config{}
 	cases := []struct {
@@ -69,5 +96,53 @@ func TestIsRetryableDownloadErrorSpecialCases(t *testing.T) {
 	}
 	if !isRetryableDownloadError(errors.New("temporary network failure")) {
 		t.Fatal("plain transport-style errors should retry")
+	}
+}
+
+func TestRetryAfterAndHostHelpers(t *testing.T) {
+	if got := parseRetryAfter("3"); got != 3*time.Second {
+		t.Fatalf("delta retry-after = %v", got)
+	}
+	if got := parseRetryAfter("-1"); got != 0 {
+		t.Fatalf("negative retry-after = %v", got)
+	}
+	if got := parseRetryAfter("not a date"); got != 0 {
+		t.Fatalf("invalid retry-after = %v", got)
+	}
+	future := time.Now().Add(2 * time.Second).UTC().Format(http.TimeFormat)
+	if got := parseRetryAfter(future); got <= 0 {
+		t.Fatalf("future HTTP-date retry-after = %v", got)
+	}
+
+	if !hostIs("cdn.huggingface.co.", "huggingface.co") {
+		t.Fatal("expected subdomain host match")
+	}
+	if hostIs("not-huggingface.co", "huggingface.co") {
+		t.Fatal("did not expect suffix without dot to match")
+	}
+	if got := hostFromURL("https://cdn.example.com/path"); got != "cdn.example.com" {
+		t.Fatalf("hostFromURL = %q", got)
+	}
+	if got := hostFromURL("://bad"); got != "" {
+		t.Fatalf("bad hostFromURL = %q", got)
+	}
+}
+
+func TestFriendlyHTTPStatusProblemUsesConfiguredTokenEnv(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Sources.HuggingFace.TokenEnv = "CUSTOM_HF"
+	cfg.Sources.CivitAI.TokenEnv = "CUSTOM_CIVITAI"
+
+	msg, remediation := friendlyHTTPStatusProblem(cfg, "huggingface.co", http.StatusUnauthorized, "401 Unauthorized", false)
+	if !strings.Contains(msg, "token required") || !strings.Contains(remediation, "CUSTOM_HF") {
+		t.Fatalf("unexpected hf 401 guidance msg=%q remediation=%q", msg, remediation)
+	}
+	msg, remediation = friendlyHTTPStatusProblem(cfg, "civitai.com", http.StatusForbidden, "403 Forbidden", false)
+	if !strings.Contains(msg, "access denied") || !strings.Contains(remediation, "CUSTOM_CIVITAI") {
+		t.Fatalf("unexpected civitai 403 guidance msg=%q remediation=%q", msg, remediation)
+	}
+	msg, remediation = friendlyHTTPStatusProblem(cfg, "example.com", http.StatusTeapot, "418 I'm a teapot", false)
+	if msg != "418 I'm a teapot" || remediation != "" {
+		t.Fatalf("unexpected default status guidance msg=%q remediation=%q", msg, remediation)
 	}
 }

--- a/internal/downloader/probe_coverage_test.go
+++ b/internal/downloader/probe_coverage_test.go
@@ -1,0 +1,248 @@
+package downloader
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/config"
+)
+
+func TestStagePartPathModes(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := &config.Config{General: config.General{DownloadRoot: filepath.Join(tmp, "downloads"), StagePartials: true}}
+	dest := filepath.Join(tmp, "models", "model.gguf")
+
+	got := StagePartPath(cfg, "https://example.com/model.gguf", dest)
+	if !strings.HasPrefix(got, filepath.Join(cfg.General.DownloadRoot, ".parts")+string(os.PathSeparator)) {
+		t.Fatalf("expected part under download_root .parts, got %q", got)
+	}
+	if !strings.HasSuffix(got, ".part") || !strings.Contains(filepath.Base(got), "model.gguf.") {
+		t.Fatalf("unexpected stage part name: %q", got)
+	}
+
+	custom := filepath.Join(tmp, "partials")
+	cfg.General.PartialsRoot = custom
+	if got := stagePartPath(cfg, "https://example.com/model.gguf", dest); !strings.HasPrefix(got, custom+string(os.PathSeparator)) {
+		t.Fatalf("expected custom partials root, got %q", got)
+	}
+
+	cfg.General.StagePartials = false
+	if got := StagePartPath(cfg, "https://example.com/model.gguf", dest); got != dest+".part" {
+		t.Fatalf("expected legacy part path, got %q", got)
+	}
+}
+
+func TestRenameOrCopyAndCopyFile(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src.txt")
+	dst := filepath.Join(tmp, "dst.txt")
+	if err := os.WriteFile(src, []byte("payload"), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copy file: %v", err)
+	}
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(data) != "payload" {
+		t.Fatalf("unexpected copied data: %q", string(data))
+	}
+
+	renamed := filepath.Join(tmp, "renamed.txt")
+	if err := renameOrCopy(dst, renamed); err != nil {
+		t.Fatalf("rename or copy: %v", err)
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Fatalf("expected source removed after rename, err=%v", err)
+	}
+	if data, err := os.ReadFile(renamed); err != nil || string(data) != "payload" {
+		t.Fatalf("unexpected renamed data=%q err=%v", string(data), err)
+	}
+	if err := renameOrCopy(filepath.Join(tmp, "missing"), filepath.Join(tmp, "other")); err == nil {
+		t.Fatal("expected missing source error")
+	}
+}
+
+func TestProbeURLRangeFallbackAndComputeRemoteSHA256(t *testing.T) {
+	body := []byte("hash me")
+	var sawAuth atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer token" {
+			sawAuth.Store(true)
+		}
+		switch r.Method {
+		case http.MethodHead:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.Header.Get("Range") == "bytes=0-0" {
+				w.Header().Set("Content-Range", "bytes 0-0/7")
+				w.Header().Set("Content-Disposition", `attachment; filename="model.gguf"`)
+				w.WriteHeader(http.StatusPartialContent)
+				_, _ = w.Write(body[:1])
+				return
+			}
+			_, _ = w.Write(body)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{Network: config.Network{TimeoutSeconds: 2}}
+	headers := map[string]string{"Authorization": "Bearer token"}
+	meta, err := ProbeURL(context.Background(), cfg, server.URL, headers)
+	if err != nil {
+		t.Fatalf("probe url: %v", err)
+	}
+	if !sawAuth.Load() {
+		t.Fatal("expected probe requests to include auth header")
+	}
+	if meta.Size != 7 || !meta.AcceptRange || meta.Filename != "model.gguf" || meta.FinalURL != server.URL {
+		t.Fatalf("unexpected probe metadata: %+v", meta)
+	}
+
+	sum, err := ComputeRemoteSHA256(context.Background(), cfg, server.URL, headers)
+	if err != nil {
+		t.Fatalf("compute remote sha: %v", err)
+	}
+	want := sha256.Sum256(body)
+	if sum != hex.EncodeToString(want[:]) {
+		t.Fatalf("unexpected remote sha: %s", sum)
+	}
+}
+
+func TestComputeRemoteSHA256RejectsNonSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	_, err := ComputeRemoteSHA256(context.Background(), &config.Config{Network: config.Network{TimeoutSeconds: 2}}, server.URL, nil)
+	if err == nil || !strings.Contains(err.Error(), "GET status: 403") {
+		t.Fatalf("expected non-success status error, got %v", err)
+	}
+}
+
+func TestSafetensorsAdjustAndDeepVerify(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "model.safetensors")
+	writeSafetensorsFile(t, path, map[string]any{
+		"tensor": map[string]any{
+			"dtype":        "F32",
+			"shape":        []int{2},
+			"data_offsets": []int{0, 8},
+		},
+	}, []byte("12345678extra"))
+
+	changed, err := adjustSafetensors(path, nil)
+	if err != nil {
+		t.Fatalf("adjust safetensors: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected trailing bytes to be truncated")
+	}
+	ok, declared, err := deepVerifySafetensors(path)
+	if err != nil || !ok {
+		t.Fatalf("deep verify adjusted file ok=%v declared=%d err=%v", ok, declared, err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat adjusted file: %v", err)
+	}
+	if fi.Size() != declared {
+		t.Fatalf("expected file size %d, got %d", declared, fi.Size())
+	}
+
+	plain := filepath.Join(t.TempDir(), "plain.bin")
+	if err := os.WriteFile(plain, []byte("not safetensors"), 0o644); err != nil {
+		t.Fatalf("write plain: %v", err)
+	}
+	if changed, err := adjustSafetensors(plain, nil); err != nil || changed {
+		t.Fatalf("plain adjust changed=%v err=%v", changed, err)
+	}
+	if ok, declared, err := deepVerifySafetensors(plain); err != nil || !ok || declared != 0 {
+		t.Fatalf("plain deep verify ok=%v declared=%d err=%v", ok, declared, err)
+	}
+}
+
+func TestSafetensorsValidationErrors(t *testing.T) {
+	tmp := t.TempDir()
+	short := filepath.Join(tmp, "short.safetensors")
+	if err := os.WriteFile(short, []byte("tiny"), 0o644); err != nil {
+		t.Fatalf("write short: %v", err)
+	}
+	if _, err := adjustSafetensors(short, nil); err == nil || !strings.Contains(err.Error(), "file too small") {
+		t.Fatalf("expected small file error, got %v", err)
+	}
+
+	badSize := filepath.Join(tmp, "bad-size.safetensors")
+	writeSafetensorsFile(t, badSize, map[string]any{
+		"tensor": map[string]any{
+			"dtype":        "F32",
+			"shape":        []int{3},
+			"data_offsets": []int{0, 8},
+		},
+	}, []byte("12345678"))
+	if ok, _, err := deepVerifySafetensors(badSize); err == nil || ok || !strings.Contains(err.Error(), "size 8 != 3*4") {
+		t.Fatalf("expected tensor size error, ok=%v err=%v", ok, err)
+	}
+
+	beyond := filepath.Join(tmp, "beyond.safetensors")
+	writeSafetensorsFile(t, beyond, map[string]any{
+		"tensor": map[string]any{
+			"dtype":        "U8",
+			"shape":        []int{3},
+			"data_offsets": []int{0, 4},
+		},
+	}, []byte("123"))
+	if _, err := adjustSafetensors(beyond, nil); err == nil || !strings.Contains(err.Error(), "beyond data length") {
+		t.Fatalf("expected beyond data length error, got %v", err)
+	}
+}
+
+func TestSafetensorsDtypeBytesAndToInt64(t *testing.T) {
+	if dtypeBytes(" bf16 ") != 2 || dtypeBytes("BOOL") != 1 || dtypeBytes("unknown") != 0 {
+		t.Fatal("unexpected dtype byte sizes")
+	}
+	if got, ok := toInt64(float64(42)); !ok || got != 42 {
+		t.Fatalf("float64 conversion got %d ok=%v", got, ok)
+	}
+	if got, ok := toInt64(int64(43)); !ok || got != 43 {
+		t.Fatalf("int64 conversion got %d ok=%v", got, ok)
+	}
+	if got, ok := toInt64(44); !ok || got != 44 {
+		t.Fatalf("int conversion got %d ok=%v", got, ok)
+	}
+	if _, ok := toInt64("45"); ok {
+		t.Fatal("string should not convert to int64")
+	}
+}
+
+func writeSafetensorsFile(t *testing.T, path string, header map[string]any, data []byte) {
+	t.Helper()
+	hdr, err := json.Marshal(header)
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.LittleEndian, uint64(len(hdr))); err != nil {
+		t.Fatalf("write header length: %v", err)
+	}
+	buf.Write(hdr)
+	buf.Write(data)
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write safetensors: %v", err)
+	}
+}

--- a/internal/placer/placer_test.go
+++ b/internal/placer/placer_test.go
@@ -3,6 +3,7 @@ package placer
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jxwalker/modfetch/internal/config"
@@ -63,5 +64,121 @@ func TestPlaceSymlinkCheckpoint(t *testing.T) {
 	// And parent directory is the configured checkpoints dir
 	if filepath.Dir(dst) != checkpointDir {
 		t.Fatalf("expected parent %s, got %s", checkpointDir, filepath.Dir(dst))
+	}
+}
+
+func TestPlaceCopySkipsSameContentAndRejectsDifferentExistingFile(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := &config.Config{
+		General: config.General{PlacementMode: "copy", AllowOverwrite: false},
+		Placement: config.Placement{
+			Apps: map[string]config.AppPlacement{
+				"app": {Base: tmp, Paths: map[string]string{"models": "models"}},
+			},
+			Mapping: []config.MappingRule{
+				{Match: "llm", Targets: []config.MappingTarget{{App: "app", PathKey: "models"}}},
+			},
+		},
+	}
+	src := filepath.Join(tmp, "src", "model.gguf")
+	if err := os.MkdirAll(filepath.Dir(src), 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if err := os.WriteFile(src, []byte("same"), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	dst := filepath.Join(tmp, "models", "model.gguf")
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatalf("mkdir dst: %v", err)
+	}
+	if err := os.WriteFile(dst, []byte("same"), 0o644); err != nil {
+		t.Fatalf("write existing same: %v", err)
+	}
+
+	placed, err := Place(cfg, src, "llm", "copy")
+	if err != nil {
+		t.Fatalf("place same content: %v", err)
+	}
+	if len(placed) != 1 || placed[0] != dst {
+		t.Fatalf("expected existing destination to be reported, got %+v", placed)
+	}
+
+	if err := os.WriteFile(dst, []byte("different"), 0o644); err != nil {
+		t.Fatalf("write existing different: %v", err)
+	}
+	_, err = Place(cfg, src, "llm", "copy")
+	if err == nil || !strings.Contains(err.Error(), "destination exists and differs") {
+		t.Fatalf("expected differing destination error, got %v", err)
+	}
+}
+
+func TestPlaceCopyOverwriteAndUnknownMode(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := &config.Config{
+		General: config.General{PlacementMode: "copy", AllowOverwrite: true},
+		Placement: config.Placement{
+			Apps: map[string]config.AppPlacement{
+				"app": {Base: tmp, Paths: map[string]string{"models": "models"}},
+			},
+			Mapping: []config.MappingRule{
+				{Match: "llm", Targets: []config.MappingTarget{{App: "app", PathKey: "models"}}},
+			},
+		},
+	}
+	src := filepath.Join(tmp, "src", "model.gguf")
+	if err := os.MkdirAll(filepath.Dir(src), 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if err := os.WriteFile(src, []byte("new"), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	dst := filepath.Join(tmp, "models", "model.gguf")
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatalf("mkdir dst: %v", err)
+	}
+	if err := os.WriteFile(dst, []byte("old"), 0o644); err != nil {
+		t.Fatalf("write old dst: %v", err)
+	}
+
+	placed, err := Place(cfg, src, "llm", "copy")
+	if err != nil {
+		t.Fatalf("place overwrite copy: %v", err)
+	}
+	if len(placed) != 1 || placed[0] != dst {
+		t.Fatalf("unexpected placed paths: %+v", placed)
+	}
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(data) != "new" {
+		t.Fatalf("expected overwritten content, got %q", string(data))
+	}
+
+	if _, err := Place(cfg, src, "llm", "mystery"); err == nil || !strings.Contains(err.Error(), "unknown placement mode") {
+		t.Fatalf("expected unknown mode error, got %v", err)
+	}
+}
+
+func TestComputeTargetsReportsMappingErrors(t *testing.T) {
+	cfg := &config.Config{
+		Placement: config.Placement{
+			Apps: map[string]config.AppPlacement{
+				"app": {Base: "/tmp/app", Paths: map[string]string{"models": "models"}},
+			},
+			Mapping: []config.MappingRule{
+				{Match: "missing-app", Targets: []config.MappingTarget{{App: "other", PathKey: "models"}}},
+				{Match: "missing-key", Targets: []config.MappingTarget{{App: "app", PathKey: "other"}}},
+			},
+		},
+	}
+	if _, err := ComputeTargets(nil, "llm"); err == nil {
+		t.Fatal("expected nil config error")
+	}
+	if _, err := ComputeTargets(cfg, "missing-app"); err == nil || !strings.Contains(err.Error(), "unknown app") {
+		t.Fatalf("expected unknown app error, got %v", err)
+	}
+	if _, err := ComputeTargets(cfg, "missing-key"); err == nil || !strings.Contains(err.Error(), "missing path key") {
+		t.Fatalf("expected missing path key error, got %v", err)
 	}
 }

--- a/internal/state/state_coverage_test.go
+++ b/internal/state/state_coverage_test.go
@@ -1,0 +1,208 @@
+package state
+
+import (
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestChunkLifecycleTxAndDirectUpdates(t *testing.T) {
+	db := testDownloadDB(t)
+	url := "https://example.com/model.bin"
+	dest := filepath.Join(t.TempDir(), "model.bin")
+
+	if err := db.WithTx(func(tx *sql.Tx) error {
+		if err := db.UpsertChunkTx(tx, ChunkRow{URL: url, Dest: dest, Index: 1, Start: 10, End: 19, Size: 10, SHA256: "abc", Status: "pending"}); err != nil {
+			return err
+		}
+		if err := db.UpsertChunkTx(tx, ChunkRow{URL: url, Dest: dest, Index: 0, Start: 0, End: 9, Size: 10, Status: "running"}); err != nil {
+			return err
+		}
+		if err := db.UpdateChunkStatusTx(tx, url, dest, 1, "complete"); err != nil {
+			return err
+		}
+		return db.UpdateChunkSHATx(tx, url, dest, 0, "def")
+	}); err != nil {
+		t.Fatalf("chunk tx lifecycle: %v", err)
+	}
+
+	chunks, err := db.ListChunks(url, dest)
+	if err != nil {
+		t.Fatalf("list chunks: %v", err)
+	}
+	if len(chunks) != 2 || chunks[0].Index != 0 || chunks[1].Index != 1 {
+		t.Fatalf("expected chunks ordered by index, got %+v", chunks)
+	}
+	if chunks[0].SHA256 != "def" || chunks[1].Status != "complete" {
+		t.Fatalf("unexpected chunk state: %+v", chunks)
+	}
+
+	if err := db.UpsertChunk(ChunkRow{URL: url, Dest: dest, Index: 1, Start: 10, End: 19, Size: 10, Status: "dirty"}); err != nil {
+		t.Fatalf("upsert chunk with empty sha: %v", err)
+	}
+	chunks, err = db.ListChunks(url, dest)
+	if err != nil {
+		t.Fatalf("list chunks after upsert: %v", err)
+	}
+	if chunks[1].SHA256 != "abc" || chunks[1].Status != "dirty" {
+		t.Fatalf("expected sha preservation and status update, got %+v", chunks[1])
+	}
+
+	if err := db.UpdateChunkStatus(url, dest, 1, "complete"); err != nil {
+		t.Fatalf("direct status update: %v", err)
+	}
+	if err := db.UpdateChunkSHA(url, dest, 1, "ghi"); err != nil {
+		t.Fatalf("direct sha update: %v", err)
+	}
+	if err := db.DeleteChunks(url, dest); err != nil {
+		t.Fatalf("delete chunks: %v", err)
+	}
+	chunks, err = db.ListChunks(url, dest)
+	if err != nil {
+		t.Fatalf("list chunks after delete: %v", err)
+	}
+	if len(chunks) != 0 {
+		t.Fatalf("expected chunks deleted, got %+v", chunks)
+	}
+}
+
+func TestDownloadStatusRetriesAndDelete(t *testing.T) {
+	db := testDownloadDB(t)
+	row := DownloadRow{URL: "https://example.com/a", Dest: "/tmp/a.bin", Status: "pending"}
+	if err := db.UpsertDownload(row); err != nil {
+		t.Fatalf("upsert download: %v", err)
+	}
+	if err := db.IncDownloadRetries(row.URL, row.Dest, 2); err != nil {
+		t.Fatalf("increment retries: %v", err)
+	}
+	if err := db.IncDownloadRetries(row.URL, row.Dest, 0); err != nil {
+		t.Fatalf("zero retry increment should be a no-op: %v", err)
+	}
+	if err := db.UpdateDownloadStatus(row.URL, row.Dest, "error", "network"); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+	if err := db.UpdateDownloadStatus("missing", row.Dest, "error", "missing"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows for missing update, got %v", err)
+	}
+
+	rows, err := db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Retries != 2 || rows[0].Status != "error" || rows[0].LastError != "network" {
+		t.Fatalf("unexpected download row: %+v", rows)
+	}
+
+	if err := db.DeleteDownload(row.URL, row.Dest); err != nil {
+		t.Fatalf("delete download: %v", err)
+	}
+	rows, err = db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list after delete: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected download deleted, got %+v", rows)
+	}
+}
+
+func TestHostCapsListDeleteClearAndNilDB(t *testing.T) {
+	db := testDownloadDB(t)
+	if err := db.UpsertHostCaps("b.example", false, true); err != nil {
+		t.Fatalf("upsert b: %v", err)
+	}
+	if err := db.UpsertHostCaps("a.example", true, false); err != nil {
+		t.Fatalf("upsert a: %v", err)
+	}
+
+	caps, err := db.ListHostCaps()
+	if err != nil {
+		t.Fatalf("list host caps: %v", err)
+	}
+	if len(caps) != 2 || caps[0].Host != "a.example" || !caps[0].HeadOK || caps[0].AcceptRanges {
+		t.Fatalf("unexpected listed host caps: %+v", caps)
+	}
+
+	if err := db.DeleteHostCaps("a.example"); err != nil {
+		t.Fatalf("delete host cap: %v", err)
+	}
+	if _, ok, err := db.GetHostCaps("a.example"); err != nil || ok {
+		t.Fatalf("expected deleted host cap to be missing, ok=%v err=%v", ok, err)
+	}
+	if err := db.ClearHostCaps(); err != nil {
+		t.Fatalf("clear host caps: %v", err)
+	}
+	caps, err = db.ListHostCaps()
+	if err != nil {
+		t.Fatalf("list after clear: %v", err)
+	}
+	if len(caps) != 0 {
+		t.Fatalf("expected empty host caps, got %+v", caps)
+	}
+
+	var nilDB *DB
+	if err := nilDB.InitHostCapsTable(); err == nil {
+		t.Fatal("expected nil db init error")
+	}
+	if err := nilDB.UpsertHostCaps("example.com", true, true); err == nil {
+		t.Fatal("expected nil db upsert error")
+	}
+	if _, _, err := nilDB.GetHostCaps("example.com"); err == nil {
+		t.Fatal("expected nil db get error")
+	}
+	if _, err := nilDB.ListHostCaps(); err == nil {
+		t.Fatal("expected nil db list error")
+	}
+	if err := nilDB.DeleteHostCaps("example.com"); err == nil {
+		t.Fatal("expected nil db delete error")
+	}
+	if err := nilDB.ClearHostCaps(); err == nil {
+		t.Fatal("expected nil db clear error")
+	}
+}
+
+func TestGetMetadataByDestAndUsage(t *testing.T) {
+	db := testDB(t)
+	meta := &ModelMetadata{
+		DownloadURL: "https://example.com/model.gguf",
+		Dest:        "/models/model.gguf",
+		ModelName:   "Model",
+		Tags:        []string{"llm", "gguf"},
+		Favorite:    true,
+	}
+	if err := db.UpsertMetadata(meta); err != nil {
+		t.Fatalf("upsert metadata: %v", err)
+	}
+
+	got, err := db.GetMetadataByDest(meta.Dest)
+	if err != nil {
+		t.Fatalf("get metadata by dest: %v", err)
+	}
+	if got == nil || got.DownloadURL != meta.DownloadURL || len(got.Tags) != 2 || !got.Favorite {
+		t.Fatalf("unexpected metadata by dest: %+v", got)
+	}
+	missing, err := db.GetMetadataByDest("/models/missing.gguf")
+	if err != nil {
+		t.Fatalf("missing metadata by dest: %v", err)
+	}
+	if missing != nil {
+		t.Fatalf("expected nil missing metadata, got %+v", missing)
+	}
+	if _, err := db.GetMetadataByDest(""); err == nil {
+		t.Fatal("expected empty dest error")
+	}
+
+	if err := db.UpdateMetadataUsage(meta.DownloadURL); err != nil {
+		t.Fatalf("update metadata usage: %v", err)
+	}
+	got, err = db.GetMetadataByDest(meta.Dest)
+	if err != nil {
+		t.Fatalf("get metadata after usage: %v", err)
+	}
+	if got.TimesUsed != 1 || got.LastUsed == nil {
+		t.Fatalf("expected usage update, got %+v", got)
+	}
+	if err := db.UpdateMetadataUsage("missing"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows for missing usage update, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add state lifecycle coverage for chunks, downloads, host capabilities, and metadata lookup/usage
- add placer coverage for copy conflicts, overwrite behavior, and mapping errors
- add downloader helper coverage for staged partial paths, probe metadata, remote SHA256, error helpers, and safetensors validation
- mark the resolver/state/placer/downloader coverage roadmap item implemented

## Tests
- go test ./internal/state ./internal/placer ./internal/downloader -coverprofile=/tmp/spd-cover.out
- go test ./internal/downloader -race
- go test ./... -timeout 180s