### PR TITLE
[codex] Add optional 7z archive extraction backend

### DIFF
--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -136,7 +136,7 @@ complete -c modfetch -n "__fish_seen_subcommand_from download" -l sha256 -d "Exp
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l sha256-file -d "File containing expected hash"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l batch -d "Batch file"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l place -d "Place after download"
-complete -c modfetch -n "__fish_seen_subcommand_from download" -l extract -d "Extract archive after download"
+complete -c modfetch -n "__fish_seen_subcommand_from download" -l extract -d "Extract zip/tar/tar.gz/7z archive after download"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l extract-dir -d "Extraction directory"
 # batch import flags
 complete -c modfetch -n "__fish_seen_subcommand_from batch" -a "import" -d "Import URLs to YAML batch"

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -136,7 +136,7 @@ complete -c modfetch -n "__fish_seen_subcommand_from download" -l sha256 -d "Exp
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l sha256-file -d "File containing expected hash"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l batch -d "Batch file"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l place -d "Place after download"
-complete -c modfetch -n "__fish_seen_subcommand_from download" -l extract -d "Extract zip/tar/tar.gz/7z archive after download"
+complete -c modfetch -n "__fish_seen_subcommand_from download" -l extract -d "Extract zip/tar/tar.gz/tgz/7z archive after download"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l extract-dir -d "Extraction directory"
 # batch import flags
 complete -c modfetch -n "__fish_seen_subcommand_from batch" -a "import" -d "Import URLs to YAML batch"

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -244,7 +244,7 @@ func handleDownload(ctx context.Context, args []string) error {
 	dryRun := fs.Bool("dry-run", false, "plan only: resolve URL/URI and compute default destination; no download")
 	forceSkip := fs.Bool("force", false, "skip SHA256 verification even if --sha256/--sha256-file is provided")
 	noAuthPreflight := fs.Bool("no-auth-preflight", false, "skip auth preflight probe")
-	extractFlag := fs.Bool("extract", false, "extract zip/tar/tar.gz archives after download")
+	extractFlag := fs.Bool("extract", false, "extract zip/tar/tar.gz/7z archives after download")
 	extractDir := fs.String("extract-dir", "", "directory for extracted archives (default: archive path without extension)")
 	quant := fs.String("quant", "", "HuggingFace quantization to download (e.g., Q4_K_M, fp16)")
 	listQuants := fs.Bool("list-quants", false, "list available quantizations for HuggingFace URI and exit")

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -244,7 +244,7 @@ func handleDownload(ctx context.Context, args []string) error {
 	dryRun := fs.Bool("dry-run", false, "plan only: resolve URL/URI and compute default destination; no download")
 	forceSkip := fs.Bool("force", false, "skip SHA256 verification even if --sha256/--sha256-file is provided")
 	noAuthPreflight := fs.Bool("no-auth-preflight", false, "skip auth preflight probe")
-	extractFlag := fs.Bool("extract", false, "extract zip/tar/tar.gz/7z archives after download")
+	extractFlag := fs.Bool("extract", false, "extract zip/tar/tar.gz/tgz/7z archives after download")
 	extractDir := fs.String("extract-dir", "", "directory for extracted archives (default: archive path without extension)")
 	quant := fs.String("quant", "", "HuggingFace quantization to download (e.g., Q4_K_M, fp16)")
 	listQuants := fs.Bool("list-quants", false, "list available quantizations for HuggingFace URI and exit")

--- a/docs/BATCH.md
+++ b/docs/BATCH.md
@@ -6,7 +6,7 @@ Key properties:
 - YAML-driven; versioned schema (current version: 1)
 - No secrets in YAML; tokens must be provided via environment variables (HF_TOKEN, CIVITAI_TOKEN) when the corresponding sources are enabled in config
 - Per-job or global placement control
-- Per-job archive extraction for `.zip`, `.tar`, `.tar.gz`, and `.tgz`
+- Per-job archive extraction for `.zip`, `.tar`, `.tar.gz`, `.tgz`, and `.7z` when a 7z backend is installed
 - Optional local daily schedule windows for jobs
 
 ## Schema (version 1)
@@ -37,7 +37,7 @@ BatchJob fields:
 - mode: string (optional)
   - Placement mode override: `symlink` | `hardlink` | `copy`. If omitted, falls back to `general.placement_mode` from your config.
 - extract: boolean (optional; default false)
-  - Extract the downloaded file after it completes. Supported formats are `.zip`, `.tar`, `.tar.gz`, and `.tgz`. `.7z` currently returns a clear unsupported-format error.
+  - Extract the downloaded file after it completes. Supported formats are `.zip`, `.tar`, `.tar.gz`, `.tgz`, and `.7z` when `7zz`, `7z`, or `7za` is available on `PATH`.
 - extract_dir: string (optional)
   - Directory for extracted files. If omitted, modfetch uses the archive path without its extension.
 - schedule_window: string (optional)

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -84,7 +84,7 @@ modfetch download --url URL [OPTIONS]
 - `--sha256-file PATH` - File containing expected hash (`.sha256` format)
 - `--batch PATH` - YAML file with multiple downloads (see [BATCH.md](BATCH.md))
 - `--place` - Automatically place files after download (with `--batch`)
-- `--extract` - Extract `.zip`, `.tar`, `.tar.gz`, or `.tgz` archives after download
+- `--extract` - Extract `.zip`, `.tar`, `.tar.gz`, `.tgz`, or `.7z` archives after download. 7z archives require `7zz`, `7z`, or `7za` on `PATH`.
 - `--extract-dir PATH` - Directory for extracted archive contents
 - `--batch-parallel N` - Concurrent downloads in batch mode
 - `--dry-run` - Preview download without actually downloading

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,8 +36,8 @@ Priority 4 — Quality improvements
 - Configuration validation hardening [IMPL]
 
 Priority 5 — Advanced features
-- Archive extraction post-download (zip/tar/7z) [WIP]
-  - zip, tar, tar.gz, and tgz are implemented; 7z reports a clear unsupported-format error until a 7z backend is selected.
+- Archive extraction post-download (zip/tar/7z) [IMPL]
+  - zip, tar, tar.gz, and tgz use native extraction; 7z uses `7zz`, `7z`, or `7za` when available on PATH.
 - Duplicate detection / content-addressable storage [WIP]
   - Duplicate reporting by completed SHA256 is implemented; content-addressable storage/linking remains open.
 - S3-compatible backend for storage [NEW]

--- a/internal/archive/extract.go
+++ b/internal/archive/extract.go
@@ -76,16 +76,20 @@ func extract7z(ctx context.Context, src, destDir string) ([]string, error) {
 	}
 	defer func() { _ = os.RemoveAll(tmp) }()
 
+	var stderr limitedBuffer
+	stderr.max = 8 * 1024
 	cmd := commandContext(ctx, bin, "x", "-y", "-o"+tmp, src)
-	out, err := cmd.CombinedOutput()
+	cmd.Stdout = io.Discard
+	cmd.Stderr = &stderr
+	err = cmd.Run()
 	if err != nil {
-		msg := strings.TrimSpace(string(out))
+		msg := strings.TrimSpace(stderr.String())
 		if msg == "" {
 			return nil, err
 		}
 		return nil, fmt.Errorf("%w: %s", err, msg)
 	}
-	return moveExtractedTree(tmp, cleanDest)
+	return moveExtractedTree(ctx, tmp, cleanDest)
 }
 
 func find7z() (string, error) {
@@ -209,7 +213,7 @@ func writeFile(path string, r io.Reader, mode os.FileMode) error {
 	return f.Close()
 }
 
-func moveExtractedTree(srcDir, destDir string) ([]string, error) {
+func moveExtractedTree(ctx context.Context, srcDir, destDir string) ([]string, error) {
 	var out []string
 	cleanDest, err := filepath.Abs(destDir)
 	if err != nil {
@@ -221,6 +225,9 @@ func moveExtractedTree(srcDir, destDir string) ([]string, error) {
 	}
 	if err := filepath.WalkDir(cleanSrc, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 		rel, err := filepath.Rel(cleanSrc, path)
@@ -237,12 +244,18 @@ func moveExtractedTree(srcDir, destDir string) ([]string, error) {
 		if d.IsDir() {
 			return os.MkdirAll(target, 0o755)
 		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("archive entry is a symlink: %s", rel)
+		}
 		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 			return err
 		}
 		info, err := d.Info()
 		if err != nil {
 			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("archive entry is not a regular file: %s", rel)
 		}
 		f, err := os.Open(path)
 		if err != nil {
@@ -261,4 +274,27 @@ func moveExtractedTree(srcDir, destDir string) ([]string, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+type limitedBuffer struct {
+	max int
+	buf []byte
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	if b.max <= 0 {
+		return len(p), nil
+	}
+	if len(b.buf) < b.max {
+		n := b.max - len(b.buf)
+		if n > len(p) {
+			n = len(p)
+		}
+		b.buf = append(b.buf, p[:n]...)
+	}
+	return len(p), nil
+}
+
+func (b *limitedBuffer) String() string {
+	return string(b.buf)
 }

--- a/internal/archive/extract.go
+++ b/internal/archive/extract.go
@@ -271,7 +271,7 @@ func moveExtractedTree(ctx context.Context, srcDir, destDir string) ([]string, e
 		out = append(out, target)
 		return nil
 	}); err != nil {
-		return nil, err
+		return out, err
 	}
 	return out, nil
 }

--- a/internal/archive/extract.go
+++ b/internal/archive/extract.go
@@ -9,8 +9,15 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+)
+
+var (
+	sevenZipCommands = []string{"7zz", "7z", "7za"}
+	lookPath         = exec.LookPath
+	commandContext   = exec.CommandContext
 )
 
 func Extract(ctx context.Context, src, destDir string) ([]string, error) {
@@ -44,10 +51,50 @@ func Extract(ctx context.Context, src, destDir string) ([]string, error) {
 		defer func() { _ = gz.Close() }()
 		return extractTar(ctx, gz, destDir)
 	case strings.HasSuffix(lower, ".7z"):
-		return nil, errors.New("7z extraction is not supported by this build")
+		return extract7z(ctx, src, destDir)
 	default:
 		return nil, fmt.Errorf("unsupported archive format: %s", filepath.Ext(src))
 	}
+}
+
+func extract7z(ctx context.Context, src, destDir string) ([]string, error) {
+	bin, err := find7z()
+	if err != nil {
+		return nil, err
+	}
+	cleanDest, err := filepath.Abs(destDir)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(cleanDest, 0o755); err != nil {
+		return nil, err
+	}
+
+	tmp, err := os.MkdirTemp(filepath.Dir(cleanDest), ".modfetch-7z-*")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+
+	cmd := commandContext(ctx, bin, "x", "-y", "-o"+tmp, src)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			return nil, err
+		}
+		return nil, fmt.Errorf("%w: %s", err, msg)
+	}
+	return moveExtractedTree(tmp, cleanDest)
+}
+
+func find7z() (string, error) {
+	for _, name := range sevenZipCommands {
+		if path, err := lookPath(name); err == nil {
+			return path, nil
+		}
+	}
+	return "", errors.New("7z extraction requires 7zz, 7z, or 7za on PATH")
 }
 
 func extractZip(ctx context.Context, src, destDir string) ([]string, error) {
@@ -160,4 +207,58 @@ func writeFile(path string, r io.Reader, mode os.FileMode) error {
 		return err
 	}
 	return f.Close()
+}
+
+func moveExtractedTree(srcDir, destDir string) ([]string, error) {
+	var out []string
+	cleanDest, err := filepath.Abs(destDir)
+	if err != nil {
+		return nil, err
+	}
+	cleanSrc, err := filepath.Abs(srcDir)
+	if err != nil {
+		return nil, err
+	}
+	if err := filepath.WalkDir(cleanSrc, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(cleanSrc, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		target, err := safeArchivePath(cleanDest, rel)
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		if err := writeFile(target, f, info.Mode()); err != nil {
+			_ = f.Close()
+			return err
+		}
+		if err := f.Close(); err != nil {
+			return err
+		}
+		out = append(out, target)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return out, nil
 }

--- a/internal/archive/extract_test.go
+++ b/internal/archive/extract_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -67,5 +69,65 @@ func TestExtractRejectsTraversal(t *testing.T) {
 
 	if _, err := Extract(context.Background(), src, filepath.Join(dir, "out")); err == nil {
 		t.Fatal("expected traversal error")
+	}
+}
+
+func TestExtract7zUsesExternalBackend(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell script fake")
+	}
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fake := filepath.Join(binDir, "7zz")
+	script := `#!/bin/sh
+set -eu
+out=""
+for arg in "$@"; do
+  case "$arg" in
+    -o*) out="${arg#-o}" ;;
+  esac
+done
+mkdir -p "$out/nested"
+printf model > "$out/nested/model.bin"
+`
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+"/bin"+string(os.PathListSeparator)+"/usr/bin")
+
+	src := filepath.Join(dir, "model.7z")
+	if err := os.WriteFile(src, []byte("fake archive"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outDir := filepath.Join(dir, "out")
+	files, err := Extract(context.Background(), src, outDir)
+	if err != nil {
+		t.Fatalf("extract 7z: %v", err)
+	}
+	if len(files) != 1 || files[0] != filepath.Join(outDir, "nested", "model.bin") {
+		t.Fatalf("unexpected extracted files: %+v", files)
+	}
+	got, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "model" {
+		t.Fatalf("unexpected extracted content: %q", string(got))
+	}
+}
+
+func TestExtract7zReportsMissingBackend(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PATH", filepath.Join(dir, "empty-bin"))
+	src := filepath.Join(dir, "model.7z")
+	if err := os.WriteFile(src, []byte("fake archive"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Extract(context.Background(), src, filepath.Join(dir, "out"))
+	if err == nil || !strings.Contains(err.Error(), "requires 7zz, 7z, or 7za") {
+		t.Fatalf("expected missing 7z backend error, got %v", err)
 	}
 }

--- a/internal/archive/extract_test.go
+++ b/internal/archive/extract_test.go
@@ -131,3 +131,40 @@ func TestExtract7zReportsMissingBackend(t *testing.T) {
 		t.Fatalf("expected missing 7z backend error, got %v", err)
 	}
 }
+
+func TestMoveExtractedTreeRejectsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink setup is platform-specific")
+	}
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("/etc/passwd", filepath.Join(src, "link")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	_, err := moveExtractedTree(context.Background(), src, filepath.Join(dir, "out"))
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+}
+
+func TestMoveExtractedTreeHonorsContextCancellation(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "model.bin"), []byte("model"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := moveExtractedTree(ctx, src, filepath.Join(dir, "out"))
+	if err == nil || err != context.Canceled {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+}

--- a/internal/archive/extract_test.go
+++ b/internal/archive/extract_test.go
@@ -132,6 +132,43 @@ func TestExtract7zReportsMissingBackend(t *testing.T) {
 	}
 }
 
+func TestExtract7zRejectsSymlinkInExtractedTree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell script fake")
+	}
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fake := filepath.Join(binDir, "7zz")
+	script := `#!/bin/sh
+set -eu
+out=""
+for arg in "$@"; do
+  case "$arg" in
+    -o*) out="${arg#-o}" ;;
+  esac
+done
+mkdir -p "$out/nested"
+printf model > "$out/nested/model.bin"
+ln -s model.bin "$out/nested/link.bin"
+`
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+"/bin"+string(os.PathListSeparator)+"/usr/bin")
+
+	src := filepath.Join(dir, "model.7z")
+	if err := os.WriteFile(src, []byte("fake archive"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Extract(context.Background(), src, filepath.Join(dir, "out"))
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+}
+
 func TestMoveExtractedTreeRejectsSymlink(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink setup is platform-specific")


### PR DESCRIPTION
## Summary
- add .7z extraction through an external 7zz, 7z, or 7za binary when available
- extract 7z archives into a temporary directory, then copy files through existing safe destination path checks
- update CLI help, shell completion text, batch docs, CLI docs, and roadmap status

## Tests
- go test ./internal/archive ./cmd/modfetch
- go test ./... -timeout 180s