### PR TITLE
[codex] Add duplicate dedupe link command

### DIFF
--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -34,7 +34,7 @@ _modfetch_completions()
 {
     local cur prev words cword
     _init_completion || return
-    local cmds="config download place verify status tui batch version help completion"
+    local cmds="config download place verify status tui batch dedupe version help completion"
     if [[ ${cword} -eq 1 ]]; then
         COMPREPLY=( $(compgen -W "${cmds}" -- "$cur") )
         return
@@ -44,6 +44,8 @@ _modfetch_completions()
             COMPREPLY=( $(compgen -W "validate print wizard --config --log-level --json" -- "$cur") ) ;;
         download)
             COMPREPLY=( $(compgen -W "--config --log-level --json --quiet --url --dest --sha256 --sha256-file --batch --place --extract --extract-dir" -- "$cur") ) ;;
+        dedupe)
+            COMPREPLY=( $(compgen -W "--config --log-level --json --mode --dry-run" -- "$cur") ) ;;
         place)
             COMPREPLY=( $(compgen -W "--config --log-level --json --path --type --mode" -- "$cur") ) ;;
         verify)
@@ -68,7 +70,7 @@ const zshCompletion = `#compdef modfetch
 # zsh completion for modfetch (basic)
 _modfetch() {
   local -a cmds
-  cmds=(config download place verify status tui batch version help completion)
+  cmds=(config download place verify status tui batch dedupe version help completion)
   if (( CURRENT == 2 )); then
     _describe 'command' cmds
     return
@@ -79,6 +81,9 @@ _modfetch() {
       ;;
     download)
       _arguments '*:options:(--config --log-level --json --quiet --url --dest --sha256 --sha256-file --batch --place --extract --extract-dir)'
+      ;;
+    dedupe)
+      _arguments '*:options:(--config --log-level --json --mode --dry-run)'
       ;;
     place)
       _arguments '*:options:(--config --log-level --json --path --type --mode)'
@@ -109,6 +114,7 @@ compdef _modfetch modfetch
 const fishCompletion = `# fish completion for modfetch
 complete -c modfetch -f -n "__fish_use_subcommand" -a "config" -d "config ops"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "download" -d "download assets"
+complete -c modfetch -f -n "__fish_use_subcommand" -a "dedupe" -d "dedupe duplicate downloads"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "place" -d "place files"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "verify" -d "verify checksums"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "status" -d "show status"
@@ -126,7 +132,7 @@ complete -c modfetch -n "__fish_seen_subcommand_from clean" -l include-next-to-d
 complete -c modfetch -n "__fish_seen_subcommand_from clean" -l sidecars -d "Remove orphan .sha256"
 
 # Common flags
-for cmd in config download place verify status tui batch
+for cmd in config download place verify status tui batch dedupe
   complete -c modfetch -n "__fish_seen_subcommand_from $cmd" -l config -d "Path to config"
   complete -c modfetch -n "__fish_seen_subcommand_from $cmd" -l log-level -d "Log level"
 end
@@ -138,6 +144,8 @@ complete -c modfetch -n "__fish_seen_subcommand_from download" -l batch -d "Batc
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l place -d "Place after download"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l extract -d "Extract zip/tar/tar.gz/tgz/7z archive after download"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l extract-dir -d "Extraction directory"
+complete -c modfetch -n "__fish_seen_subcommand_from dedupe" -l mode -d "hardlink|symlink"
+complete -c modfetch -n "__fish_seen_subcommand_from dedupe" -l dry-run -d "Show dedupe changes without modifying files"
 # batch import flags
 complete -c modfetch -n "__fish_seen_subcommand_from batch" -a "import" -d "Import URLs to YAML batch"
 complete -c modfetch -n "__fish_seen_subcommand_from batch" -l input -d "Text file with URLs"

--- a/cmd/modfetch/dedupe_test.go
+++ b/cmd/modfetch/dedupe_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+func TestDedupeDuplicateGroupsHardlinksVerifiedDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("same model")
+	sum := sha256.Sum256(content)
+	sha := hex.EncodeToString(sum[:])
+	canonical := filepath.Join(dir, "a.gguf")
+	duplicate := filepath.Join(dir, "b.gguf")
+	if err := os.WriteFile(canonical, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(duplicate, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results := dedupeDuplicateGroups([]duplicateGroup{{
+		SHA256: sha,
+		Rows: []state.DownloadRow{
+			{Dest: canonical, ActualSHA256: sha, Status: "complete"},
+			{Dest: duplicate, ActualSHA256: sha, Status: "complete"},
+		},
+	}}, "hardlink", false)
+	if len(results) != 2 {
+		t.Fatalf("expected two results, got %+v", results)
+	}
+	if results[0].Action != "canonical" || results[1].Action != "hardlink" || results[1].Error != "" {
+		t.Fatalf("unexpected dedupe results: %+v", results)
+	}
+	aInfo, err := os.Stat(canonical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bInfo, err := os.Stat(duplicate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(aInfo, bInfo) {
+		t.Fatal("expected duplicate to be replaced with hardlink to canonical")
+	}
+}
+
+func TestDedupeDuplicateGroupsDryRunDoesNotModify(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("same model")
+	sum := sha256.Sum256(content)
+	sha := hex.EncodeToString(sum[:])
+	canonical := filepath.Join(dir, "a.gguf")
+	duplicate := filepath.Join(dir, "b.gguf")
+	if err := os.WriteFile(canonical, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(duplicate, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results := dedupeDuplicateGroups([]duplicateGroup{{
+		SHA256: sha,
+		Rows: []state.DownloadRow{
+			{Dest: canonical, ActualSHA256: sha, Status: "complete"},
+			{Dest: duplicate, ActualSHA256: sha, Status: "complete"},
+		},
+	}}, "symlink", true)
+	if len(results) != 2 || results[1].Action != "would_symlink" {
+		t.Fatalf("unexpected dry-run results: %+v", results)
+	}
+	info, err := os.Lstat(duplicate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("dry run should not replace duplicate")
+	}
+}
+
+func TestDedupeDuplicateGroupsSkipsMismatchedContent(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("same model")
+	sum := sha256.Sum256(content)
+	sha := hex.EncodeToString(sum[:])
+	canonical := filepath.Join(dir, "a.gguf")
+	duplicate := filepath.Join(dir, "b.gguf")
+	if err := os.WriteFile(canonical, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(duplicate, []byte("different"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results := dedupeDuplicateGroups([]duplicateGroup{{
+		SHA256: sha,
+		Rows: []state.DownloadRow{
+			{Dest: canonical, ActualSHA256: sha, Status: "complete"},
+			{Dest: duplicate, ActualSHA256: sha, Status: "complete"},
+		},
+	}}, "hardlink", false)
+	if len(results) != 2 || results[1].Action != "skipped" || results[1].Error == "" {
+		t.Fatalf("expected mismatch skip, got %+v", results)
+	}
+}

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -74,6 +74,8 @@ func run(ctx context.Context, args []string) error {
 		return handleHostCaps(ctx, args[1:])
 	case "clean":
 		return handleClean(ctx, args[1:])
+	case "dedupe":
+		return handleDedupe(ctx, args[1:])
 	case "batch":
 		return handleBatch(ctx, args[1:])
 	case "help", "-h", "--help":
@@ -106,6 +108,7 @@ Commands:
   completion        Generate shell completion scripts (bash|zsh|fish)
   hostcaps          Manage host capability cache (list/clear)
   clean             Prune staged partials and other cached artifacts
+  dedupe            Replace duplicate completed downloads with hardlinks or symlinks
 
 Flags:
   --config PATH     Path to YAML config file (or MODFETCH_CONFIG env var; default: ~/.config/modfetch/config.yml)
@@ -200,6 +203,64 @@ func handleStatus(ctx context.Context, args []string) error {
 type duplicateGroup struct {
 	SHA256 string              `json:"sha256"`
 	Rows   []state.DownloadRow `json:"rows"`
+}
+
+type dedupeResult struct {
+	SHA256    string `json:"sha256"`
+	Canonical string `json:"canonical"`
+	Dest      string `json:"dest"`
+	Action    string `json:"action"`
+	Error     string `json:"error,omitempty"`
+}
+
+func handleDedupe(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("dedupe", flag.ContinueOnError)
+	cfgPath := fs.String("config", "", "Path to YAML config file")
+	logLevel := fs.String("log-level", "info", "log level")
+	jsonOut := fs.Bool("json", false, "json logs")
+	mode := fs.String("mode", "hardlink", "dedupe mode: hardlink|symlink")
+	dryRun := fs.Bool("dry-run", false, "show changes without modifying files")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *cfgPath == "" {
+		if env := os.Getenv("MODFETCH_CONFIG"); env != "" {
+			*cfgPath = env
+		} else if h, err := os.UserHomeDir(); err == nil && h != "" {
+			*cfgPath = filepath.Join(h, ".config", "modfetch", "config.yml")
+		}
+	}
+	if _, err := os.Stat(*cfgPath); err != nil {
+		return fmt.Errorf("config file not found: %s", *cfgPath)
+	}
+	c, err := config.Load(*cfgPath)
+	if err != nil {
+		return err
+	}
+	log := logging.New(*logLevel, *jsonOut)
+	st, err := state.Open(c)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = st.SQL.Close() }()
+	rows, err := st.ListDownloads()
+	if err != nil {
+		return err
+	}
+	results := dedupeDuplicateGroups(duplicateDownloadGroups(rows), strings.ToLower(strings.TrimSpace(*mode)), *dryRun)
+	if *jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(results)
+	}
+	for _, r := range results {
+		if r.Error != "" {
+			log.Warnf("dedupe %s: %s", r.Dest, r.Error)
+			continue
+		}
+		log.Infof("dedupe %s: %s -> %s", r.Action, r.Dest, r.Canonical)
+	}
+	return nil
 }
 
 func handleConfig(ctx context.Context, args []string) error {
@@ -1259,6 +1320,126 @@ func duplicateDownloadGroups(rows []state.DownloadRow) []duplicateGroup {
 		return groups[i].SHA256 < groups[j].SHA256
 	})
 	return groups
+}
+
+func dedupeDuplicateGroups(groups []duplicateGroup, mode string, dryRun bool) []dedupeResult {
+	if mode == "" {
+		mode = "hardlink"
+	}
+	var results []dedupeResult
+	for _, group := range groups {
+		canonical, canonInfo, err := chooseCanonicalDuplicate(group)
+		if err != nil {
+			for _, row := range group.Rows {
+				results = append(results, dedupeResult{SHA256: group.SHA256, Dest: row.Dest, Action: "skipped", Error: err.Error()})
+			}
+			continue
+		}
+		for _, row := range group.Rows {
+			if row.Dest == canonical {
+				results = append(results, dedupeResult{SHA256: group.SHA256, Canonical: canonical, Dest: row.Dest, Action: "canonical"})
+				continue
+			}
+			results = append(results, dedupeOne(row.Dest, group.SHA256, canonical, canonInfo, mode, dryRun))
+		}
+	}
+	return results
+}
+
+func chooseCanonicalDuplicate(group duplicateGroup) (string, os.FileInfo, error) {
+	for _, row := range group.Rows {
+		info, err := os.Stat(row.Dest)
+		if err != nil {
+			continue
+		}
+		if info.Mode().IsRegular() {
+			return row.Dest, info, nil
+		}
+	}
+	return "", nil, fmt.Errorf("no existing regular canonical file for sha256=%s", group.SHA256)
+}
+
+func dedupeOne(dest, sha, canonical string, canonInfo os.FileInfo, mode string, dryRun bool) dedupeResult {
+	res := dedupeResult{SHA256: sha, Canonical: canonical, Dest: dest}
+	info, err := os.Stat(dest)
+	if err != nil {
+		res.Action = "skipped"
+		res.Error = err.Error()
+		return res
+	}
+	if !info.Mode().IsRegular() {
+		res.Action = "skipped"
+		res.Error = "destination is not a regular file"
+		return res
+	}
+	if os.SameFile(canonInfo, info) {
+		res.Action = "already_linked"
+		return res
+	}
+	actual, err := util.HashFileSHA256(dest)
+	if err != nil {
+		res.Action = "skipped"
+		res.Error = err.Error()
+		return res
+	}
+	if !strings.EqualFold(strings.TrimSpace(actual), strings.TrimSpace(sha)) {
+		res.Action = "skipped"
+		res.Error = fmt.Sprintf("sha256 mismatch: state=%s actual=%s", sha, actual)
+		return res
+	}
+	switch mode {
+	case "hardlink", "symlink":
+	default:
+		res.Action = "skipped"
+		res.Error = fmt.Sprintf("unknown dedupe mode: %s", mode)
+		return res
+	}
+	if dryRun {
+		res.Action = "would_" + mode
+		return res
+	}
+	if err := replaceWithLink(dest, canonical, mode); err != nil {
+		res.Action = "skipped"
+		res.Error = err.Error()
+		return res
+	}
+	res.Action = mode
+	return res
+}
+
+func replaceWithLink(dest, canonical, mode string) error {
+	dir := filepath.Dir(dest)
+	tmp, err := os.CreateTemp(dir, ".modfetch-dedupe-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Remove(tmpPath); err != nil {
+		return err
+	}
+	switch mode {
+	case "hardlink":
+		if err := os.Link(canonical, tmpPath); err != nil {
+			return err
+		}
+	case "symlink":
+		target := canonical
+		if rel, err := filepath.Rel(dir, canonical); err == nil && rel != "" && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			target = rel
+		}
+		if err := os.Symlink(target, tmpPath); err != nil {
+			return err
+		}
+	}
+	if err := os.Rename(tmpPath, dest); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
 }
 
 func countDuplicateFiles(groups []duplicateGroup) int {

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -144,6 +144,18 @@ Show rows from the download state database.
 - `--duplicates` - Group completed downloads by matching SHA256 content
 - `--json` - Emit machine-readable JSON
 
+### dedupe
+
+Replace verified duplicate downloads with links to the canonical copy:
+
+```bash
+modfetch dedupe --config ~/.config/modfetch/config.yml --dry-run
+modfetch dedupe --config ~/.config/modfetch/config.yml --mode hardlink
+modfetch dedupe --config ~/.config/modfetch/config.yml --mode symlink
+```
+
+The command uses completed rows with matching SHA256 values, re-hashes each duplicate before modifying it, and atomically swaps duplicate paths to hardlinks or symlinks.
+
 **Output:**
 
 Human-readable (default):

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,8 +38,8 @@ Priority 4 — Quality improvements
 Priority 5 — Advanced features
 - Archive extraction post-download (zip/tar/7z) [IMPL]
   - zip, tar, tar.gz, and tgz use native extraction; 7z uses `7zz`, `7z`, or `7za` when available on PATH.
-- Duplicate detection / content-addressable storage [WIP]
-  - Duplicate reporting by completed SHA256 is implemented; content-addressable storage/linking remains open.
+- Duplicate detection / content-addressable storage [IMPL]
+  - Duplicate reporting by completed SHA256 is implemented; `dedupe` can replace verified duplicates with hardlinks or symlinks to canonical content.
 - S3-compatible backend for storage [NEW]
 - Download scheduling (cron-like windows) [IMPL]
 


### PR DESCRIPTION
## Summary
- add a dedupe command that groups completed duplicate SHA256 rows and replaces verified duplicates with hardlinks or symlinks
- re-hash duplicate files before modifying them and swap links atomically through a temp path
- add command tests, completions, CLI docs, and mark the duplicate/content-addressable roadmap item implemented

## Tests
- go test ./cmd/modfetch
- go test ./... -timeout 180s