### PR TITLE
[codex] Trim unused legacy TUI model state

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,7 +57,7 @@ Technical debt
 - Remove duplicate SafeFileName implementations (ensure all call util.SafeFileName) [IMPL]
 - Consolidate HTTP client creation to a shared pool [IMPL]
 - Standardize error wrapping and logging redaction [IMPL]
-- Trim dead code in legacy TUI model [NEW]
+- Trim dead code in legacy TUI model [IMPL]
 - Audit metrics writes/guards when disabled [IMPL]
 
 Performance optimizations

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -94,7 +94,6 @@ type Model struct {
 	filterInput     textinput.Model
 	sortMode        string // ""|"speed"|"eta"|"rem"
 	groupBy         string // ""|"host"
-	lastRefresh     time.Time
 	prog            progress.Model
 	prev            map[string]obs
 	prevStatus      map[string]string
@@ -114,7 +113,6 @@ type Model struct {
 	newAutoSuggested string // latest auto-suggested dest (to avoid overriding manual edits)
 	newTypeDetected  string // detected artifact type (from civitai or heuristics)
 	newTypeSource    string // e.g., "civitai", "heuristic"
-	newDetectedName  string // suggested filename/name from resolver (for display)
 	// Extension suggestion when filename lacks suffix (e.g., .safetensors, .gguf)
 	newSuggestExt string
 	// Quantization selection state (HuggingFace)
@@ -169,7 +167,6 @@ type Model struct {
 	librarySearchInput   textinput.Model // Search input for library
 	librarySearchActive  bool            // Search input is active
 	libraryScanning      bool            // Currently scanning directories
-	libraryScanProgress  string          // Scan progress message
 	log                  *logging.Logger
 }
 
@@ -309,7 +306,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case metaMsg:
 		if m.newJob && strings.TrimSpace(m.newURL) == strings.TrimSpace(msg.url) {
-			m.newDetectedName = msg.suggested
 			// Map civitai type to artifact type; fallback to heuristic from filename
 			t := mapCivitFileType(msg.civType, msg.fileName)
 			m.newTypeDetected = t
@@ -362,7 +358,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case scanCompleteMsg:
 		// Handle directory scan completion
 		m.libraryScanning = false
-		m.libraryScanProgress = ""
 
 		if msg.err != nil {
 			m.addToast(fmt.Sprintf("scan error: %v", msg.err))
@@ -833,7 +828,6 @@ func (m *Model) refresh() tea.Cmd {
 		_ = logging.New("error", false)
 	}
 	m.rows = rows
-	m.lastRefresh = time.Now()
 	m.gcToasts()
 	// determine visible keys to focus updates
 	vis := map[string]struct{}{}


### PR DESCRIPTION
## Summary
- remove legacy TUI model fields that were only written and never read
- drop the corresponding dead assignments in metadata, scan completion, and refresh paths
- mark the TUI dead-code roadmap item implemented

## Tests
- go test ./internal/tui
- go test ./... -timeout 180s