### PR TITLE
[codex] Parallelize chunk verification

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,7 +61,7 @@ Technical debt
 - Audit metrics writes/guards when disabled [IMPL]
 
 Performance optimizations
-- Pre-allocate/truncate files in chunked mode (done) and consider parallel chunk verification [NEW]
+- Pre-allocate/truncate files in chunked mode and parallel chunk verification [IMPL]
 - DNS result caching for repeated hosts [IMPL]
 - Adaptive chunk size based on throughput [NEW]
 

--- a/internal/downloader/chunked.go
+++ b/internal/downloader/chunked.go
@@ -12,6 +12,7 @@ import (
 	neturl "net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -282,20 +283,15 @@ func (e *Chunked) Download(ctx context.Context, url, destPath, expectedSHA strin
 
 	// Preflight: verify any previously complete chunks before writing further
 	if len(chunks) > 0 {
-		markedDirty := 0
-		for _, c := range chunks {
-			if strings.EqualFold(c.Status, "complete") {
-				sha2, err := hashRange(f, c.Start, c.Size)
-				if err != nil {
-					return "", "", err
-				}
-				if !stringsEqualHex(sha2, c.SHA256) {
-					e.log.Debugf("chunk %d sha mismatch on resume; marking dirty", c.Index)
-					_ = e.st.UpdateChunkStatus(url, destPath, c.Index, "dirty")
-					markedDirty++
-				}
-			}
+		dirty, err := verifyCompleteChunks(ctx, part, chunks, e.cfg.Concurrency.PerFileChunks)
+		if err != nil {
+			return "", "", err
 		}
+		for _, c := range dirty {
+			e.log.Debugf("chunk %d sha mismatch on resume; marking dirty", c.Index)
+			_ = e.st.UpdateChunkStatus(url, destPath, c.Index, "dirty")
+		}
+		markedDirty := len(dirty)
 		if markedDirty > 0 {
 			key := fmt.Sprintf("dirty:%s|%s", url, destPath)
 			e.log.WarnfThrottled(key, 2*time.Second, "resume verification: %d chunk(s) marked dirty; will refetch", markedDirty)
@@ -365,29 +361,21 @@ func (e *Chunked) Download(ctx context.Context, url, destPath, expectedSHA strin
 	// Self-consistency check: ensure each written chunk matches its recorded SHA even without an expected file SHA
 	chunks, _ = e.st.ListChunks(url, destPath)
 	repaired := false
-	for _, c := range chunks {
-		if ctx.Err() != nil {
-			return "", "", ctx.Err()
-		}
-		if !strings.EqualFold(c.Status, "complete") {
-			continue
-		}
-		sha2, err := hashRange(f, c.Start, c.Size)
+	dirty, err := verifyCompleteChunks(ctx, part, chunks, e.cfg.Concurrency.PerFileChunks)
+	if err != nil {
+		return "", "", err
+	}
+	for _, c := range dirty {
+		// re-download this chunk
+		e.log.WarnfThrottled(fmt.Sprintf("repair:%s|%s", url, destPath), 2*time.Second, "chunk %d sha mismatch on self-check; re-fetching", c.Index)
+		_ = e.st.UpdateChunkStatus(url, destPath, c.Index, "dirty")
+		sha3, err := e.fetchChunk(ctx, url, destPath, h, f, c, headers, perDownloadLimiter)
 		if err != nil {
 			return "", "", err
 		}
-		if c.SHA256 != "" && !stringsEqualHex(sha2, c.SHA256) {
-			// re-download this chunk
-			e.log.WarnfThrottled(fmt.Sprintf("repair:%s|%s", url, destPath), 2*time.Second, "chunk %d sha mismatch on self-check; re-fetching", c.Index)
-			_ = e.st.UpdateChunkStatus(url, destPath, c.Index, "dirty")
-			sha3, err := e.fetchChunk(ctx, url, destPath, h, f, c, headers, perDownloadLimiter)
-			if err != nil {
-				return "", "", err
-			}
-			_ = e.st.UpdateChunkSHA(url, destPath, c.Index, sha3)
-			_ = e.st.UpdateChunkStatus(url, destPath, c.Index, "complete")
-			repaired = true
-		}
+		_ = e.st.UpdateChunkSHA(url, destPath, c.Index, sha3)
+		_ = e.st.UpdateChunkStatus(url, destPath, c.Index, "complete")
+		repaired = true
 	}
 	// Verify final SHA by streaming the part file
 	hasher := sha256.New()
@@ -402,26 +390,21 @@ func (e *Chunked) Download(ctx context.Context, url, destPath, expectedSHA strin
 		e.log.Warnf("final sha mismatch; scanning chunks for corruption")
 		// Re-hash each chunk and compare with recorded chunk sha
 		chunks, _ = e.st.ListChunks(url, destPath)
-		for _, c := range chunks {
-			if ctx.Err() != nil {
-				return "", "", ctx.Err()
-			}
-			sha2, err := hashRange(f, c.Start, c.Size)
+		dirty, err := verifyCompleteChunks(ctx, part, chunks, e.cfg.Concurrency.PerFileChunks)
+		if err != nil {
+			return "", "", err
+		}
+		for _, c := range dirty {
+			// re-download this chunk
+			e.log.Debugf("chunk %d sha mismatch; re-fetching", c.Index)
+			_ = e.st.UpdateChunkStatus(url, destPath, c.Index, "dirty")
+			sha3, err := e.fetchChunk(ctx, url, destPath, h, f, c, headers, perDownloadLimiter)
 			if err != nil {
 				return "", "", err
 			}
-			if !stringsEqualHex(sha2, c.SHA256) {
-				// re-download this chunk
-				e.log.Debugf("chunk %d sha mismatch; re-fetching", c.Index)
-				_ = e.st.UpdateChunkStatus(url, destPath, c.Index, "dirty")
-				sha3, err := e.fetchChunk(ctx, url, destPath, h, f, c, headers, perDownloadLimiter)
-				if err != nil {
-					return "", "", err
-				}
-				_ = e.st.UpdateChunkSHA(url, destPath, c.Index, sha3)
-				_ = e.st.UpdateChunkStatus(url, destPath, c.Index, "complete")
-				repaired = true
-			}
+			_ = e.st.UpdateChunkSHA(url, destPath, c.Index, sha3)
+			_ = e.st.UpdateChunkStatus(url, destPath, c.Index, "complete")
+			repaired = true
 		}
 		if repaired {
 			// re-hash full file
@@ -789,6 +772,71 @@ func hashRange(f *os.File, start, size int64) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func hashRangePath(path string, start, size int64) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	return hashRange(f, start, size)
+}
+
+func verifyCompleteChunks(ctx context.Context, path string, chunks []state.ChunkRow, parallel int) ([]state.ChunkRow, error) {
+	if parallel <= 0 {
+		parallel = 1
+	}
+	sem := make(chan struct{}, parallel)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var dirty []state.ChunkRow
+	var firstErr error
+
+	for _, c := range chunks {
+		if !strings.EqualFold(c.Status, "complete") {
+			continue
+		}
+		if strings.TrimSpace(c.SHA256) == "" {
+			mu.Lock()
+			dirty = append(dirty, c)
+			mu.Unlock()
+			continue
+		}
+		c := c
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case <-ctx.Done():
+				setErr(&firstErr, &mu, ctx.Err())
+				return
+			case sem <- struct{}{}:
+			}
+			defer func() { <-sem }()
+
+			if err := ctx.Err(); err != nil {
+				setErr(&firstErr, &mu, err)
+				return
+			}
+			sha, err := hashRangePath(path, c.Start, c.Size)
+			if err != nil {
+				setErr(&firstErr, &mu, err)
+				return
+			}
+			if !stringsEqualHex(sha, c.SHA256) {
+				mu.Lock()
+				dirty = append(dirty, c)
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	sort.Slice(dirty, func(i, j int) bool { return dirty[i].Index < dirty[j].Index })
+	return dirty, nil
 }
 
 func setErr(dst *error, mu *sync.Mutex, err error) {

--- a/internal/downloader/chunked_verify_test.go
+++ b/internal/downloader/chunked_verify_test.go
@@ -1,0 +1,54 @@
+package downloader
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+func TestVerifyCompleteChunksFindsDirtyChunks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "model.part")
+	if err := os.WriteFile(path, []byte("aaaabbbbcccc"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	chunks := []state.ChunkRow{
+		{Index: 2, Start: 8, Size: 4, SHA256: chunkSHA("cccc"), Status: "running"},
+		{Index: 1, Start: 4, Size: 4, SHA256: chunkSHA("xxxx"), Status: "complete"},
+		{Index: 0, Start: 0, Size: 4, SHA256: chunkSHA("aaaa"), Status: "complete"},
+		{Index: 3, Start: 8, Size: 4, SHA256: "", Status: "complete"},
+	}
+
+	dirty, err := verifyCompleteChunks(context.Background(), path, chunks, 2)
+	if err != nil {
+		t.Fatalf("verify chunks: %v", err)
+	}
+	if len(dirty) != 2 || dirty[0].Index != 1 || dirty[1].Index != 3 {
+		t.Fatalf("expected chunks 1 and 3 dirty, got %+v", dirty)
+	}
+}
+
+func TestVerifyCompleteChunksHonorsContextCancellation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "model.part")
+	if err := os.WriteFile(path, []byte("aaaa"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := verifyCompleteChunks(ctx, path, []state.ChunkRow{
+		{Index: 0, Start: 0, Size: 4, SHA256: chunkSHA("aaaa"), Status: "complete"},
+	}, 1)
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func chunkSHA(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}


### PR DESCRIPTION
## Summary
- add a bounded parallel verifier for completed chunk hashes using independent file handles
- use it for resume preflight, self-check repair, and final mismatch repair scans
- add verifier unit coverage and mark the parallel chunk verification roadmap item implemented

## Tests
- go test ./internal/downloader -race
- go test ./... -timeout 180s