### PR TITLE
[codex] Adapt default chunk size to throughput

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -63,7 +63,7 @@ Technical debt
 Performance optimizations
 - Pre-allocate/truncate files in chunked mode and parallel chunk verification [IMPL]
 - DNS result caching for repeated hosts [IMPL]
-- Adaptive chunk size based on throughput [NEW]
+- Adaptive chunk size based on configured throughput and file size [IMPL]
 
 Breaking changes to consider for v1.0
 - Config schema tidy-up

--- a/internal/downloader/chunked.go
+++ b/internal/downloader/chunked.go
@@ -252,10 +252,7 @@ func (e *Chunked) Download(ctx context.Context, url, destPath, expectedSHA strin
 		return "", "", err
 	}
 	if len(chunks) == 0 {
-		chunkSize := int64(e.cfg.Concurrency.ChunkSizeMB) * 1024 * 1024
-		if chunkSize <= 0 {
-			chunkSize = 8 * 1024 * 1024
-		}
+		chunkSize := chooseChunkSize(e.cfg, h.size)
 		var idx int
 		// Group initial chunk plan into a single transaction for consistency
 		if err := e.st.WithTx(func(tx *sql.Tx) error {
@@ -772,6 +769,43 @@ func hashRange(f *os.File, start, size int64) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func chooseChunkSize(cfg *config.Config, totalSize int64) int64 {
+	const (
+		mb         = int64(1024 * 1024)
+		minChunk   = 1 * mb
+		defaultMin = 8 * mb
+		maxChunk   = 64 * mb
+	)
+	if cfg != nil && cfg.Concurrency.ChunkSizeMB > 0 {
+		return int64(cfg.Concurrency.ChunkSizeMB) * mb
+	}
+	var limit int64
+	if cfg != nil {
+		if cfg.Network.PerDownloadBandwidthBytesPerSecond > 0 {
+			limit = cfg.Network.PerDownloadBandwidthBytesPerSecond
+		} else if cfg.Network.GlobalBandwidthBytesPerSecond > 0 {
+			limit = cfg.Network.GlobalBandwidthBytesPerSecond
+		}
+	}
+	if limit > 0 {
+		return clampInt64(limit*8, minChunk, maxChunk)
+	}
+	if totalSize > 0 {
+		return clampInt64(totalSize/128, defaultMin, maxChunk)
+	}
+	return defaultMin
+}
+
+func clampInt64(v, min, max int64) int64 {
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
+	return v
 }
 
 func hashRangePath(path string, start, size int64) (string, error) {

--- a/internal/downloader/chunked_verify_test.go
+++ b/internal/downloader/chunked_verify_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/jxwalker/modfetch/internal/config"
 	"github.com/jxwalker/modfetch/internal/state"
 )
 
@@ -51,4 +52,33 @@ func TestVerifyCompleteChunksHonorsContextCancellation(t *testing.T) {
 func chunkSHA(s string) string {
 	sum := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(sum[:])
+}
+
+func TestChooseChunkSize(t *testing.T) {
+	const mb = int64(1024 * 1024)
+
+	explicit := &config.Config{}
+	explicit.Concurrency.ChunkSizeMB = 3
+	if got := chooseChunkSize(explicit, 128*mb); got != 3*mb {
+		t.Fatalf("explicit chunk size = %d", got)
+	}
+
+	limited := &config.Config{}
+	limited.Network.PerDownloadBandwidthBytesPerSecond = 512 * 1024
+	if got := chooseChunkSize(limited, 128*mb); got != 4*mb {
+		t.Fatalf("bandwidth-adaptive chunk size = %d", got)
+	}
+
+	slow := &config.Config{}
+	slow.Network.GlobalBandwidthBytesPerSecond = 1
+	if got := chooseChunkSize(slow, 128*mb); got != 1*mb {
+		t.Fatalf("minimum chunk size = %d", got)
+	}
+
+	if got := chooseChunkSize(&config.Config{}, 64*1024*mb); got != 64*mb {
+		t.Fatalf("large file chunk size should clamp to max, got %d", got)
+	}
+	if got := chooseChunkSize(&config.Config{}, 0); got != 8*mb {
+		t.Fatalf("default chunk size = %d", got)
+	}
 }


### PR DESCRIPTION
## Summary
- keep explicit concurrency.chunk_size_mb authoritative
- adapt the default chunk size from configured bandwidth limits, falling back to file-size based sizing with clamps
- add helper coverage and mark adaptive chunk sizing implemented in the roadmap

## Tests
- go test ./internal/downloader -race
- go test ./... -timeout 180s