### PR TITLE
[codex] Add event-driven TUI state refresh

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -46,7 +46,7 @@ Priority 5 — Advanced features
 Priority 6 — Architecture
 - Context propagation pattern improvements [IMPL]
 - Plugin architecture for resolvers [IMPL]
-- Event-driven updates vs polling [NEW]
+- Event-driven TUI updates with polling fallback [IMPL]
 
 Quick wins (remaining)
 - Add a flag to skip SHA256 verification intentionally for trusted sources (implemented as --force) [IMPL]

--- a/internal/state/chunks.go
+++ b/internal/state/chunks.go
@@ -42,6 +42,9 @@ func (db *DB) UpsertChunk(c ChunkRow) error {
 	_, err := db.SQL.Exec(`INSERT INTO chunks(url,dest,idx,start,end,size,sha256,status,updated_at) VALUES(?,?,?,?,?,?,?,?,strftime('%s','now'))
 ON CONFLICT(url,dest,idx) DO UPDATE SET start=excluded.start,end=excluded.end,size=excluded.size,sha256=COALESCE(NULLIF(excluded.sha256, ''), chunks.sha256),status=excluded.status,updated_at=strftime('%s','now')`,
 		c.URL, c.Dest, c.Index, c.Start, c.End, c.Size, c.SHA256, c.Status)
+	if err == nil {
+		db.NotifyChange()
+	}
 	return err
 }
 
@@ -87,16 +90,25 @@ func (db *DB) ListChunks(url, dest string) ([]ChunkRow, error) {
 
 func (db *DB) UpdateChunkStatus(url, dest string, idx int, status string) error {
 	_, err := db.SQL.Exec(`UPDATE chunks SET status=?, updated_at=strftime('%s','now') WHERE url=? AND dest=? AND idx=?`, status, url, dest, idx)
+	if err == nil {
+		db.NotifyChange()
+	}
 	return err
 }
 
 func (db *DB) UpdateChunkSHA(url, dest string, idx int, sha string) error {
 	_, err := db.SQL.Exec(`UPDATE chunks SET sha256=?, updated_at=strftime('%s','now') WHERE url=? AND dest=? AND idx=?`, sha, url, dest, idx)
+	if err == nil {
+		db.NotifyChange()
+	}
 	return err
 }
 
 // DeleteChunks removes all chunk rows for a given url+dest pair.
 func (db *DB) DeleteChunks(url, dest string) error {
 	_, err := db.SQL.Exec(`DELETE FROM chunks WHERE url=? AND dest=?`, url, dest)
+	if err == nil {
+		db.NotifyChange()
+	}
 	return err
 }

--- a/internal/state/metadata.go
+++ b/internal/state/metadata.go
@@ -218,6 +218,9 @@ func (db *DB) UpsertMetadata(meta *ModelMetadata) error {
 		meta.CreatedAt.Unix(), meta.UpdatedAt.Unix(),
 		meta.UserNotes, meta.UserRating, meta.Favorite,
 	)
+	if err == nil {
+		db.NotifyChange()
+	}
 
 	return err
 }
@@ -470,12 +473,16 @@ func (db *DB) UpdateMetadataUsage(downloadURL string) error {
 		return sql.ErrNoRows
 	}
 
+	db.NotifyChange()
 	return nil
 }
 
 // DeleteMetadata removes metadata for a specific download URL
 func (db *DB) DeleteMetadata(downloadURL string) error {
 	_, err := db.SQL.Exec(`DELETE FROM model_metadata WHERE download_url = ?`, downloadURL)
+	if err == nil {
+		db.NotifyChange()
+	}
 	return err
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	_ "github.com/glebarez/sqlite"
@@ -19,6 +20,9 @@ type DB struct {
 	stmtUpsertDownload     *sql.Stmt
 	stmtIncDownloadRetries *sql.Stmt
 	stmtListDownloads      *sql.Stmt
+
+	eventsMu    sync.Mutex
+	subscribers map[chan struct{}]struct{}
 }
 
 // Close closes the database connection
@@ -26,6 +30,12 @@ func (db *DB) Close() error {
 	if db == nil || db.SQL == nil {
 		return nil
 	}
+	db.eventsMu.Lock()
+	for ch := range db.subscribers {
+		close(ch)
+		delete(db.subscribers, ch)
+	}
+	db.eventsMu.Unlock()
 	return db.SQL.Close()
 }
 
@@ -48,7 +58,51 @@ func (db *DB) WithTx(fn func(tx *sql.Tx) error) error {
 		_ = tx.Rollback()
 		return err
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	db.NotifyChange()
+	return nil
+}
+
+// Subscribe returns a channel that receives a signal whenever DB state changes.
+// Signals are coalesced when the receiver is slow.
+func (db *DB) Subscribe() (<-chan struct{}, func()) {
+	ch := make(chan struct{}, 1)
+	if db == nil {
+		close(ch)
+		return ch, func() {}
+	}
+	db.eventsMu.Lock()
+	if db.subscribers == nil {
+		db.subscribers = map[chan struct{}]struct{}{}
+	}
+	db.subscribers[ch] = struct{}{}
+	db.eventsMu.Unlock()
+	cancel := func() {
+		db.eventsMu.Lock()
+		if _, ok := db.subscribers[ch]; ok {
+			delete(db.subscribers, ch)
+			close(ch)
+		}
+		db.eventsMu.Unlock()
+	}
+	return ch, cancel
+}
+
+// NotifyChange broadcasts a coalesced state-change signal to subscribers.
+func (db *DB) NotifyChange() {
+	if db == nil {
+		return
+	}
+	db.eventsMu.Lock()
+	defer db.eventsMu.Unlock()
+	for ch := range db.subscribers {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
 }
 
 func Open(cfg *config.Config) (*DB, error) {
@@ -183,6 +237,7 @@ func (db *DB) UpdateDownloadStatus(url, dest, status, lastError string) error {
 	if n, _ := res.RowsAffected(); n == 0 {
 		return sql.ErrNoRows
 	}
+	db.NotifyChange()
 	return nil
 }
 
@@ -204,6 +259,9 @@ type DownloadRow struct {
 func (db *DB) UpsertDownload(row DownloadRow) error {
 	now := time.Now().Unix()
 	_, err := db.stmtUpsertDownload.Exec(row.URL, row.Dest, row.ExpectedSHA256, row.ActualSHA256, row.ETag, row.LastModified, row.Size, row.Status, row.LastError, now, now, now)
+	if err == nil {
+		db.NotifyChange()
+	}
 	return err
 }
 
@@ -231,12 +289,18 @@ func (db *DB) IncDownloadRetries(url, dest string, delta int64) error {
 		return nil
 	}
 	_, err := db.stmtIncDownloadRetries.Exec(delta, url, dest)
+	if err == nil {
+		db.NotifyChange()
+	}
 	return err
 }
 
 // DeleteDownload removes a download row for the given url+dest.
 func (db *DB) DeleteDownload(url, dest string) error {
 	_, err := db.SQL.Exec(`DELETE FROM downloads WHERE url=? AND dest=?`, url, dest)
+	if err == nil {
+		db.NotifyChange()
+	}
 	return err
 }
 

--- a/internal/state/state_coverage_test.go
+++ b/internal/state/state_coverage_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestChunkLifecycleTxAndDirectUpdates(t *testing.T) {
@@ -204,5 +205,37 @@ func TestGetMetadataByDestAndUsage(t *testing.T) {
 	}
 	if err := db.UpdateMetadataUsage("missing"); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("expected sql.ErrNoRows for missing usage update, got %v", err)
+	}
+}
+
+func TestSubscribeReceivesCoalescedStateChanges(t *testing.T) {
+	db := testDownloadDB(t)
+	events, cancel := db.Subscribe()
+	defer cancel()
+
+	if err := db.UpsertDownload(DownloadRow{URL: "https://example.com/a", Dest: "/tmp/a", Status: "pending"}); err != nil {
+		t.Fatalf("upsert download: %v", err)
+	}
+	expectEvent(t, events)
+
+	if err := db.WithTx(func(tx *sql.Tx) error {
+		return db.UpsertDownloadTx(tx, DownloadRow{URL: "https://example.com/b", Dest: "/tmp/b", Status: "pending"})
+	}); err != nil {
+		t.Fatalf("tx upsert: %v", err)
+	}
+	expectEvent(t, events)
+
+	cancel()
+	if _, ok := <-events; ok {
+		t.Fatal("expected subscription channel to close after cancel")
+	}
+}
+
+func expectEvent(t *testing.T, events <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-events:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for state event")
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -275,6 +275,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tickMsg:
 		return m, m.refresh()
 	case stateChangedMsg:
+		m.libraryNeedsRefresh = true
 		m.refreshNow()
 		return m, m.stateEventsCmd()
 	case recoverRowsMsg:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -36,6 +36,8 @@ type Theme struct {
 
 type tickMsg time.Time
 
+type stateChangedMsg struct{}
+
 type dlDoneMsg struct {
 	url, dest, path string
 	err             error
@@ -167,6 +169,8 @@ type Model struct {
 	librarySearchInput   textinput.Model // Search input for library
 	librarySearchActive  bool            // Search input is active
 	libraryScanning      bool            // Currently scanning directories
+	stateEvents          <-chan struct{}
+	stopStateEvents      func()
 	log                  *logging.Logger
 }
 
@@ -230,19 +234,23 @@ func New(cfg *config.Config, st *state.DB, version string) tea.Model {
 		}
 	}
 	m.configTypes = computeTypesFromConfig(cfg)
+	if st != nil {
+		m.stateEvents, m.stopStateEvents = st.Subscribe()
+	}
 	// Load UI state overrides if present
 	m.loadUIState()
 	return m
 }
 
 func (m *Model) Init() tea.Cmd {
-	if m.cfg != nil && m.cfg.General.AutoRecoverOnStart {
-		return tea.Batch(
-			tea.Tick(m.tickEvery, func(t time.Time) tea.Msg { return tickMsg(t) }),
-			m.recoverCmd(),
-		)
+	cmds := []tea.Cmd{
+		tea.Tick(m.tickEvery, func(t time.Time) tea.Msg { return tickMsg(t) }),
+		m.stateEventsCmd(),
 	}
-	return tea.Tick(m.tickEvery, func(t time.Time) tea.Msg { return tickMsg(t) })
+	if m.cfg != nil && m.cfg.General.AutoRecoverOnStart {
+		cmds = append(cmds, m.recoverCmd())
+	}
+	return tea.Batch(cmds...)
 }
 
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -266,6 +274,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateNormal(msg)
 	case tickMsg:
 		return m, m.refresh()
+	case stateChangedMsg:
+		m.refreshNow()
+		return m, m.stateEventsCmd()
 	case recoverRowsMsg:
 		// Start downloads for rows that appear to have been running previously
 		rows := msg.rows
@@ -452,6 +463,10 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch s {
 	case "q", "ctrl+c":
+		if m.stopStateEvents != nil {
+			m.stopStateEvents()
+			m.stopStateEvents = nil
+		}
 		m.saveUIState()
 		return m, tea.Quit
 	case "/":
@@ -821,6 +836,11 @@ func (m *Model) View() string {
 }
 
 func (m *Model) refresh() tea.Cmd {
+	m.refreshNow()
+	return tea.Tick(m.tickEvery, func(t time.Time) tea.Msg { return tickMsg(t) })
+}
+
+func (m *Model) refreshNow() {
 	// Update token env presence status on each refresh tick
 	m.updateTokenEnvStatus()
 	rows, err := m.st.ListDownloads()
@@ -888,7 +908,19 @@ func (m *Model) refresh() tea.Cmd {
 			m.addRateSample(key, rate)
 		}
 	}
-	return tea.Tick(m.tickEvery, func(t time.Time) tea.Msg { return tickMsg(t) })
+}
+
+func (m *Model) stateEventsCmd() tea.Cmd {
+	ch := m.stateEvents
+	if ch == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		if _, ok := <-ch; !ok {
+			return nil
+		}
+		return stateChangedMsg{}
+	}
 }
 
 func (m *Model) compactToggle()  { m.cfg.UI.Compact = !m.cfg.UI.Compact }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -45,13 +46,36 @@ func TestStateChangedMessageRefreshesRows(t *testing.T) {
 		t.Fatalf("upsert download: %v", err)
 	}
 
-	msg := m.stateEventsCmd()()
+	msg := receiveStateEventMsg(t, m)
 	if _, ok := msg.(stateChangedMsg); !ok {
 		t.Fatalf("expected stateChangedMsg, got %T", msg)
 	}
+	m.libraryNeedsRefresh = false
 	m.Update(msg)
 	if len(m.rows) != 1 || m.rows[0].URL != "https://example.com/a" {
 		t.Fatalf("expected rows to refresh from state event, got %+v", m.rows)
+	}
+	if !m.libraryNeedsRefresh {
+		t.Fatal("expected state event to invalidate library data")
+	}
+}
+
+func receiveStateEventMsg(t *testing.T, m *Model) tea.Msg {
+	t.Helper()
+	cmd := m.stateEventsCmd()
+	if cmd == nil {
+		t.Fatal("expected state event command")
+	}
+	msgs := make(chan tea.Msg, 1)
+	go func() {
+		msgs <- cmd()
+	}()
+	select {
+	case msg := <-msgs:
+		return msg
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for state event")
+		return nil
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -28,6 +28,33 @@ func TestUpdateBatchModeEsc(t *testing.T) {
 	}
 }
 
+func TestStateChangedMessageRefreshesRows(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := state.NewDB(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	cfg := &config.Config{General: config.General{DataRoot: tmpDir, DownloadRoot: tmpDir}}
+	m := New(cfg, db, "test").(*Model)
+	if m.stateEvents == nil {
+		t.Fatal("expected TUI model to subscribe to state events")
+	}
+	if err := db.UpsertDownload(state.DownloadRow{URL: "https://example.com/a", Dest: "/tmp/a", Status: "pending"}); err != nil {
+		t.Fatalf("upsert download: %v", err)
+	}
+
+	msg := m.stateEventsCmd()()
+	if _, ok := msg.(stateChangedMsg); !ok {
+		t.Fatalf("expected stateChangedMsg, got %T", msg)
+	}
+	m.Update(msg)
+	if len(m.rows) != 1 || m.rows[0].URL != "https://example.com/a" {
+		t.Fatalf("expected rows to refresh from state event, got %+v", m.rows)
+	}
+}
+
 func TestUpdateFilterEsc(t *testing.T) {
 	m := &Model{filterOn: true, filterInput: textinput.New()}
 	m.updateFilter(tea.KeyMsg{Type: tea.KeyEsc})


### PR DESCRIPTION
## Summary
- add a coalesced state-change subscription API to the sqlite state DB
- notify TUI subscribers from download, chunk, metadata, and transaction mutations
- refresh the TUI immediately on state events while keeping the polling tick as a fallback
- mark the roadmap item implemented

## Validation
- go test ./internal/state ./internal/tui
- go test ./... -timeout 180s
