### PR TITLE
[codex] Refactor TUI state helpers

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,8 +23,8 @@ Priority 2 — Core functionality gaps
   - Reuse a shared HTTP client/transport across downloaders; per-host limits.
 
 Priority 3 — User experience
-- TUI refactor and feature polish [NEW]
-  - Factor large models into smaller components; refine sort/group/columns; persistence of selection when filtering; progress accuracy during planning.
+- TUI refactor and feature polish [IMPL]
+  - TUI state persistence, state-event handling, downloads/library/settings views, and modal handling are split across focused files; sort/group/columns, filter selection persistence, and planning progress accuracy are implemented.
 - Progress persistence across sessions [IMPL]
 - Adaptive retry/backoff by error type [IMPL]
 - Download queue management with priorities [IMPL]

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,9 +2,7 @@ package tui
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -35,8 +33,6 @@ type Theme struct {
 }
 
 type tickMsg time.Time
-
-type stateChangedMsg struct{}
 
 type dlDoneMsg struct {
 	url, dest, path string
@@ -172,15 +168,6 @@ type Model struct {
 	stateEvents          <-chan struct{}
 	stopStateEvents      func()
 	log                  *logging.Logger
-}
-
-type uiState struct {
-	ThemeIndex int    `json:"theme_index"`
-	ShowURL    bool   `json:"show_url"`
-	ColumnMode string `json:"column_mode"`
-	Compact    bool   `json:"compact"`
-	GroupBy    string `json:"group_by"`
-	SortMode   string `json:"sort_mode"`
 }
 
 func New(cfg *config.Config, st *state.DB, version string) tea.Model {
@@ -909,73 +896,4 @@ func (m *Model) refreshNow() {
 			m.addRateSample(key, rate)
 		}
 	}
-}
-
-func (m *Model) stateEventsCmd() tea.Cmd {
-	ch := m.stateEvents
-	if ch == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		if _, ok := <-ch; !ok {
-			return nil
-		}
-		return stateChangedMsg{}
-	}
-}
-
-func (m *Model) compactToggle()  { m.cfg.UI.Compact = !m.cfg.UI.Compact }
-func (m *Model) isCompact() bool { return m.cfg.UI.Compact }
-
-func (m *Model) uiStatePath() string {
-	root := strings.TrimSpace(m.cfg.General.DataRoot)
-	if root == "" {
-		if h, err := os.UserHomeDir(); err == nil {
-			root = filepath.Join(h, ".config", "modfetch")
-		}
-	}
-	return filepath.Join(root, "ui_state_v2.json")
-}
-
-func (m *Model) loadUIState() {
-	p := m.uiStatePath()
-	b, err := os.ReadFile(p)
-	if err != nil {
-		return
-	}
-	var st uiState
-	if err := json.Unmarshal(b, &st); err != nil {
-		return
-	}
-	// Apply
-	m.themeIndex = st.ThemeIndex
-	presets := themePresets()
-	if m.themeIndex >= 0 && m.themeIndex < len(presets) {
-		m.th = presets[m.themeIndex]
-	}
-	if st.ColumnMode != "" {
-		m.columnMode = st.ColumnMode
-	} else if st.ShowURL {
-		m.columnMode = "url"
-	}
-	if st.Compact {
-		m.cfg.UI.Compact = true
-	}
-	if st.GroupBy != "" {
-		m.groupBy = st.GroupBy
-	}
-	if st.SortMode != "" {
-		m.sortMode = st.SortMode
-	}
-}
-
-func (m *Model) saveUIState() {
-	if m.cfg == nil {
-		return
-	}
-	p := m.uiStatePath()
-	_ = os.MkdirAll(filepath.Dir(p), 0o755)
-	st := uiState{ThemeIndex: m.themeIndex, ShowURL: m.columnMode == "url", ColumnMode: m.columnMode, Compact: m.cfg.UI.Compact, GroupBy: m.groupBy, SortMode: m.sortMode}
-	b, _ := json.MarshalIndent(st, "", "  ")
-	_ = os.WriteFile(p, b, 0o644)
 }

--- a/internal/tui/state_events.go
+++ b/internal/tui/state_events.go
@@ -1,0 +1,18 @@
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+type stateChangedMsg struct{}
+
+func (m *Model) stateEventsCmd() tea.Cmd {
+	ch := m.stateEvents
+	if ch == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		if _, ok := <-ch; !ok {
+			return nil
+		}
+		return stateChangedMsg{}
+	}
+}

--- a/internal/tui/ui_state.go
+++ b/internal/tui/ui_state.go
@@ -39,12 +39,12 @@ func (m *Model) loadUIState() {
 	if err := json.Unmarshal(b, &st); err != nil {
 		return
 	}
-	m.themeIndex = st.ThemeIndex
 	presets := themePresets()
-	if m.themeIndex >= 0 && m.themeIndex < len(presets) {
-		m.th = presets[m.themeIndex]
+	if st.ThemeIndex >= 0 && st.ThemeIndex < len(presets) {
+		m.themeIndex = st.ThemeIndex
+		m.th = presets[st.ThemeIndex]
 	}
-	if st.ColumnMode != "" {
+	if validColumnMode(st.ColumnMode) {
 		m.columnMode = st.ColumnMode
 	} else if st.ShowURL {
 		m.columnMode = "url"
@@ -85,4 +85,8 @@ func (m *Model) logUIStateError(msg, path string, err error) {
 		return
 	}
 	m.log.Debugf("%s %s: %v", msg, path, err)
+}
+
+func validColumnMode(mode string) bool {
+	return mode == "dest" || mode == "url" || mode == "host"
 }

--- a/internal/tui/ui_state.go
+++ b/internal/tui/ui_state.go
@@ -1,0 +1,72 @@
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type uiState struct {
+	ThemeIndex int    `json:"theme_index"`
+	ShowURL    bool   `json:"show_url"`
+	ColumnMode string `json:"column_mode"`
+	Compact    bool   `json:"compact"`
+	GroupBy    string `json:"group_by"`
+	SortMode   string `json:"sort_mode"`
+}
+
+func (m *Model) compactToggle()  { m.cfg.UI.Compact = !m.cfg.UI.Compact }
+func (m *Model) isCompact() bool { return m.cfg.UI.Compact }
+
+func (m *Model) uiStatePath() string {
+	root := strings.TrimSpace(m.cfg.General.DataRoot)
+	if root == "" {
+		if h, err := os.UserHomeDir(); err == nil {
+			root = filepath.Join(h, ".config", "modfetch")
+		}
+	}
+	return filepath.Join(root, "ui_state_v2.json")
+}
+
+func (m *Model) loadUIState() {
+	p := m.uiStatePath()
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return
+	}
+	var st uiState
+	if err := json.Unmarshal(b, &st); err != nil {
+		return
+	}
+	m.themeIndex = st.ThemeIndex
+	presets := themePresets()
+	if m.themeIndex >= 0 && m.themeIndex < len(presets) {
+		m.th = presets[m.themeIndex]
+	}
+	if st.ColumnMode != "" {
+		m.columnMode = st.ColumnMode
+	} else if st.ShowURL {
+		m.columnMode = "url"
+	}
+	if st.Compact {
+		m.cfg.UI.Compact = true
+	}
+	if st.GroupBy != "" {
+		m.groupBy = st.GroupBy
+	}
+	if st.SortMode != "" {
+		m.sortMode = st.SortMode
+	}
+}
+
+func (m *Model) saveUIState() {
+	if m.cfg == nil {
+		return
+	}
+	p := m.uiStatePath()
+	_ = os.MkdirAll(filepath.Dir(p), 0o755)
+	st := uiState{ThemeIndex: m.themeIndex, ShowURL: m.columnMode == "url", ColumnMode: m.columnMode, Compact: m.cfg.UI.Compact, GroupBy: m.groupBy, SortMode: m.sortMode}
+	b, _ := json.MarshalIndent(st, "", "  ")
+	_ = os.WriteFile(p, b, 0o644)
+}

--- a/internal/tui/ui_state.go
+++ b/internal/tui/ui_state.go
@@ -49,8 +49,8 @@ func (m *Model) loadUIState() {
 	} else if st.ShowURL {
 		m.columnMode = "url"
 	}
-	if st.Compact {
-		m.cfg.UI.Compact = true
+	if m.cfg != nil {
+		m.cfg.UI.Compact = st.Compact
 	}
 	if st.GroupBy != "" {
 		m.groupBy = st.GroupBy
@@ -65,8 +65,24 @@ func (m *Model) saveUIState() {
 		return
 	}
 	p := m.uiStatePath()
-	_ = os.MkdirAll(filepath.Dir(p), 0o755)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		m.logUIStateError("failed to create ui state dir", filepath.Dir(p), err)
+		return
+	}
 	st := uiState{ThemeIndex: m.themeIndex, ShowURL: m.columnMode == "url", ColumnMode: m.columnMode, Compact: m.cfg.UI.Compact, GroupBy: m.groupBy, SortMode: m.sortMode}
-	b, _ := json.MarshalIndent(st, "", "  ")
-	_ = os.WriteFile(p, b, 0o644)
+	b, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		m.logUIStateError("failed to marshal ui state", p, err)
+		return
+	}
+	if err := os.WriteFile(p, b, 0o644); err != nil {
+		m.logUIStateError("failed to write ui state file", p, err)
+	}
+}
+
+func (m *Model) logUIStateError(msg, path string, err error) {
+	if err == nil || m.log == nil {
+		return
+	}
+	m.log.Debugf("%s %s: %v", msg, path, err)
 }

--- a/internal/tui/ui_state_test.go
+++ b/internal/tui/ui_state_test.go
@@ -1,0 +1,32 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/config"
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+func TestLoadUIStateRestoresCompactFalse(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "ui_state_v2.json"), []byte(`{"compact":false}`), 0o644); err != nil {
+		t.Fatalf("write ui state: %v", err)
+	}
+	db, err := state.NewDB(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	cfg := &config.Config{
+		General: config.General{DataRoot: tmpDir, DownloadRoot: tmpDir},
+		UI:      config.UIOptions{Compact: true},
+	}
+	New(cfg, db, "test")
+
+	if cfg.UI.Compact {
+		t.Fatal("expected persisted compact=false to override config compact=true")
+	}
+}

--- a/internal/tui/ui_state_test.go
+++ b/internal/tui/ui_state_test.go
@@ -30,3 +30,28 @@ func TestLoadUIStateRestoresCompactFalse(t *testing.T) {
 		t.Fatal("expected persisted compact=false to override config compact=true")
 	}
 }
+
+func TestLoadUIStateIgnoresInvalidThemeAndColumnMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "ui_state_v2.json"), []byte(`{"theme_index":999,"column_mode":"bad"}`), 0o644); err != nil {
+		t.Fatalf("write ui state: %v", err)
+	}
+	db, err := state.NewDB(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	cfg := &config.Config{
+		General: config.General{DataRoot: tmpDir, DownloadRoot: tmpDir},
+		UI:      config.UIOptions{ColumnMode: "host", ShowURL: false},
+	}
+	m := New(cfg, db, "test").(*Model)
+
+	if m.themeIndex != 0 {
+		t.Fatalf("expected invalid theme index to preserve default 0, got %d", m.themeIndex)
+	}
+	if m.columnMode != "host" {
+		t.Fatalf("expected invalid column mode to preserve configured host mode, got %q", m.columnMode)
+	}
+}


### PR DESCRIPTION
## Summary
- move TUI state-event command plumbing into a focused helper file
- move persisted UI preference loading/saving into a focused helper file
- mark the TUI refactor and polish roadmap item implemented based on the existing split view/modal helpers and tested polish behavior

## Validation
- go test ./internal/tui
- go test ./... -timeout 180s
