### PR TITLE
[codex] Add S3 storage backend

### DIFF
--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jxwalker/modfetch/internal/placer"
 	"github.com/jxwalker/modfetch/internal/resolver"
 	"github.com/jxwalker/modfetch/internal/state"
+	"github.com/jxwalker/modfetch/internal/storage"
 	"github.com/jxwalker/modfetch/internal/util"
 )
 
@@ -335,6 +336,9 @@ func handleDownload(ctx context.Context, args []string) error {
 		}
 		*sha = v
 	}
+	if storage.IsS3URI(strings.TrimSpace(*dest)) && (*extractFlag || *placeFlag) {
+		return errors.New("s3 destinations cannot be combined with --extract or --place")
+	}
 	// quiet forces log level to error unless JSON is requested
 	if *quiet && !*jsonOut {
 		*logLevel = "error"
@@ -486,6 +490,9 @@ func handleDownload(ctx context.Context, args []string) error {
 								logMu.Unlock()
 								continue
 							}
+						}
+						if storage.IsS3URI(destCandidate) && (job.Extract || *extractFlag || job.Place || *placeFlag) {
+							return fmt.Errorf("job %d: s3 destinations cannot be combined with extract or place", it.idx)
 						}
 						// Allow global --force to skip expected SHA verification even if job specifies one
 						expected := job.SHA256
@@ -829,6 +836,9 @@ func handleDownload(ctx context.Context, args []string) error {
 			}
 		}
 	}
+	if storage.IsS3URI(destArg) && (*extractFlag || *placeFlag) {
+		return errors.New("s3 destinations cannot be combined with --extract or --place")
+	}
 	expected := *sha
 	if *forceSkip {
 		expected = ""
@@ -853,6 +863,11 @@ func handleDownload(ctx context.Context, args []string) error {
 	}
 	// Final summary
 	fi, _ := os.Stat(final)
+	if fi == nil && storage.IsS3URI(final) {
+		if local, err := storage.StagingPath(c, final, resolvedURL); err == nil {
+			fi, _ = os.Stat(local)
+		}
+	}
 	size := int64(0)
 	if fi != nil {
 		size = fi.Size()

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -23,6 +23,14 @@ Quick start: interactive wizard
   - `partials_root`: string (optional). Directory to store .part files instead of `download_root/.parts` (useful for a faster or larger filesystem).
   - `always_no_resume`: true|false (default false). When true, every download starts fresh (ignores any .part and clears chunk state) unless overridden by CLI.
   - `auto_recover_on_start`: true|false (default false). When true, the TUI auto-resumes downloads found in state with status `running`, `planning`, or `hold` on startup.
+- `storage.s3`
+  - `endpoint`: S3-compatible endpoint, for example `https://s3.amazonaws.com` or `http://localhost:9000`. Can also be supplied with `MODFETCH_S3_ENDPOINT`.
+  - `region`: signing region (defaults to `AWS_REGION`, `AWS_DEFAULT_REGION`, then `us-east-1`).
+  - `use_http`: true when an endpoint without a scheme should use HTTP instead of HTTPS.
+  - `path_style`: true for path-style S3-compatible services such as many MinIO deployments.
+  - `access_key_env`, `secret_key_env`, `session_token_env`: environment variable names for credentials; defaults are `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`.
+  - `upload_sha256_file`: when true, upload the generated `.sha256` sidecar next to the object.
+  - Use an explicit destination like `--dest s3://bucket/path/model.gguf`; modfetch downloads to a resumable local staging path under `data_root/s3-staging`, verifies locally, uploads the artifact, and records the final `s3://` URI in state.
 - `network`
   - `timeout_seconds`, `max_redirects`, `tls_verify`, `user_agent`
   - `global_bandwidth_bytes_per_second`: optional process-wide bandwidth cap in bytes/second; 0 or omitted means unlimited.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -40,7 +40,8 @@ Priority 5 — Advanced features
   - zip, tar, tar.gz, and tgz use native extraction; 7z uses `7zz`, `7z`, or `7za` when available on PATH.
 - Duplicate detection / content-addressable storage [IMPL]
   - Duplicate reporting by completed SHA256 is implemented; `dedupe` can replace verified duplicates with hardlinks or symlinks to canonical content.
-- S3-compatible backend for storage [NEW]
+- S3-compatible backend for storage [IMPL]
+  - Explicit `s3://bucket/key` destinations download through local resumable staging, then upload artifacts and optional `.sha256` sidecars to SigV4 S3-compatible endpoints.
 - Download scheduling (cron-like windows) [IMPL]
 
 Priority 6 — Architecture

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	Logging     Logging          `yaml:"logging"`
 	Metrics     Metrics          `yaml:"metrics"`
 	Validation  Validation       `yaml:"validation"`
+	Storage     Storage          `yaml:"storage"`
 	UI          UIOptions        `yaml:"ui"`
 }
 
@@ -152,6 +153,21 @@ type Validation struct {
 	RequireSHA256                      bool `yaml:"require_sha256"`
 	AcceptMD5SHA1IfProvided            bool `yaml:"accept_md5_sha1_if_provided"`
 	SafetensorsDeepVerifyAfterDownload bool `yaml:"safetensors_deep_verify_after_download"`
+}
+
+type Storage struct {
+	S3 S3Storage `yaml:"s3"`
+}
+
+type S3Storage struct {
+	Endpoint         string `yaml:"endpoint"`
+	Region           string `yaml:"region"`
+	UseHTTP          bool   `yaml:"use_http"`
+	AccessKeyEnv     string `yaml:"access_key_env"`
+	SecretKeyEnv     string `yaml:"secret_key_env"`
+	SessionTokenEnv  string `yaml:"session_token_env"`
+	PathStyle        bool   `yaml:"path_style"`
+	UploadSHA256File bool   `yaml:"upload_sha256_file"`
 }
 
 type UIOptions struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	neturl "net/url"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -268,6 +270,9 @@ func (c *Config) Validate() error {
 	if c.Network.DNSCacheTTLSeconds < 0 {
 		return fmt.Errorf("network.dns_cache_ttl_seconds must be >= 0")
 	}
+	if err := c.validateS3(); err != nil {
+		return err
+	}
 	if c.Concurrency.GlobalFiles < 0 {
 		return fmt.Errorf("concurrency.global_files must be >= 0")
 	}
@@ -315,6 +320,40 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("ui.refresh_hz must be >= 0")
 	}
 	return nil
+}
+
+func (c *Config) validateS3() error {
+	s3 := c.Storage.S3
+	endpoint := strings.TrimSpace(s3.Endpoint)
+	if endpoint == "" {
+		return nil
+	}
+	if !strings.Contains(endpoint, "://") {
+		scheme := "https"
+		if s3.UseHTTP {
+			scheme = "http"
+		}
+		endpoint = scheme + "://" + endpoint
+	}
+	u, err := neturl.Parse(endpoint)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return fmt.Errorf("storage.s3.endpoint must be a valid http or https endpoint")
+	}
+	accessEnv := firstNonEmpty(s3.AccessKeyEnv, "AWS_ACCESS_KEY_ID")
+	secretEnv := firstNonEmpty(s3.SecretKeyEnv, "AWS_SECRET_ACCESS_KEY")
+	if strings.TrimSpace(os.Getenv(accessEnv)) == "" || strings.TrimSpace(os.Getenv(secretEnv)) == "" {
+		return fmt.Errorf("storage.s3 credentials missing: set %s and %s", accessEnv, secretEnv)
+	}
+	return nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
 }
 
 func expandTilde(p string) (string, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestLoadSampleConfig(t *testing.T) {
 	path := "../../assets/sample-config/config.example.yml"
@@ -49,6 +52,69 @@ func TestValidateRejectsNegativeDNSCacheTTL(t *testing.T) {
 	c.Network.DNSCacheTTLSeconds = -1
 	if err := c.Validate(); err == nil {
 		t.Fatal("expected negative DNS cache TTL to fail validation")
+	}
+}
+
+func TestValidateS3RequiresCredentialsWhenEndpointConfigured(t *testing.T) {
+	t.Setenv("MODFETCH_TEST_S3_ACCESS", "")
+	t.Setenv("MODFETCH_TEST_S3_SECRET", "")
+	c := Config{
+		Version: 1,
+		General: General{
+			DataRoot:     t.TempDir(),
+			DownloadRoot: t.TempDir(),
+		},
+		Storage: Storage{S3: S3Storage{
+			Endpoint:     "http://localhost:9000",
+			AccessKeyEnv: "MODFETCH_TEST_S3_ACCESS",
+			SecretKeyEnv: "MODFETCH_TEST_S3_SECRET",
+		}},
+	}
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "storage.s3 credentials missing") {
+		t.Fatalf("expected missing s3 credential error, got %v", err)
+	}
+}
+
+func TestValidateS3AcceptsConfiguredCredentials(t *testing.T) {
+	t.Setenv("MODFETCH_TEST_S3_ACCESS", "access")
+	t.Setenv("MODFETCH_TEST_S3_SECRET", "secret")
+	c := Config{
+		Version: 1,
+		General: General{
+			DataRoot:     t.TempDir(),
+			DownloadRoot: t.TempDir(),
+		},
+		Storage: Storage{S3: S3Storage{
+			Endpoint:     "localhost:9000",
+			UseHTTP:      true,
+			AccessKeyEnv: "MODFETCH_TEST_S3_ACCESS",
+			SecretKeyEnv: "MODFETCH_TEST_S3_SECRET",
+		}},
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("expected s3 config to validate, got %v", err)
+	}
+}
+
+func TestValidateS3RejectsInvalidEndpoint(t *testing.T) {
+	t.Setenv("MODFETCH_TEST_S3_ACCESS", "access")
+	t.Setenv("MODFETCH_TEST_S3_SECRET", "secret")
+	c := Config{
+		Version: 1,
+		General: General{
+			DataRoot:     t.TempDir(),
+			DownloadRoot: t.TempDir(),
+		},
+		Storage: Storage{S3: S3Storage{
+			Endpoint:     "ftp://example.com",
+			AccessKeyEnv: "MODFETCH_TEST_S3_ACCESS",
+			SecretKeyEnv: "MODFETCH_TEST_S3_SECRET",
+		}},
+	}
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "storage.s3.endpoint") {
+		t.Fatalf("expected invalid s3 endpoint error, got %v", err)
 	}
 }
 

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -77,6 +77,17 @@ func (a *Auto) Download(ctx context.Context, url, destPath, expectedSHA string, 
 	}
 	if a.st != nil {
 		if err := a.st.ReplaceDownloadDest(url, finalLocal, destPath); err != nil {
+			if a.l != nil {
+				a.l.Warnf("s3 upload complete but state update failed url=%s local=%s remote=%s: %v; attempting remote cleanup", logging.SanitizeURL(url), finalLocal, destPath, err)
+			}
+			if delErr := client.DeleteObject(ctx, destPath); delErr != nil && a.l != nil {
+				a.l.Warnf("s3 cleanup failed for %s after state update failure: %v; remove the object manually before retrying", destPath, delErr)
+			}
+			if _, statErr := os.Stat(finalLocal + ".sha256"); statErr == nil && a.c.Storage.S3.UploadSHA256File {
+				if delErr := client.DeleteObject(ctx, destPath+".sha256"); delErr != nil && a.l != nil {
+					a.l.Warnf("s3 checksum cleanup failed for %s after state update failure: %v; remove the object manually before retrying", destPath+".sha256", delErr)
+				}
+			}
 			return "", "", err
 		}
 	}

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -71,6 +71,9 @@ func (a *Auto) Download(ctx context.Context, url, destPath, expectedSHA string, 
 	}
 	if _, err := os.Stat(finalLocal + ".sha256"); err == nil && a.c.Storage.S3.UploadSHA256File {
 		if err := client.PutFile(ctx, destPath+".sha256", finalLocal+".sha256", "text/plain; charset=utf-8"); err != nil {
+			if delErr := client.DeleteObject(ctx, destPath); delErr != nil && a.l != nil {
+				a.l.Warnf("s3 cleanup failed for %s after checksum upload failure: %v; remove the object manually before retrying", destPath, delErr)
+			}
 			a.markS3UploadError(url, finalLocal, fmt.Errorf("checksum: %w", err))
 			return "", "", err
 		}

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -2,11 +2,14 @@ package downloader
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/jxwalker/modfetch/internal/config"
 	"github.com/jxwalker/modfetch/internal/logging"
 	"github.com/jxwalker/modfetch/internal/state"
+	"github.com/jxwalker/modfetch/internal/storage"
 )
 
 // Interface is the common downloader interface used across implementations.
@@ -45,5 +48,47 @@ func NewAuto(c *config.Config, l *logging.Logger, st *state.DB, m interface {
 
 func (a *Auto) Download(ctx context.Context, url, destPath, expectedSHA string, headers map[string]string, noResume bool) (string, string, error) {
 	// Delegate to chunked downloader which handles head probe and fallback.
-	return newChunkedWithClientAndLimiters(a.c, a.l, a.st, a.m, a.client, a.globalLimiter, nil).Download(ctx, url, destPath, expectedSHA, headers, noResume)
+	dl := newChunkedWithClientAndLimiters(a.c, a.l, a.st, a.m, a.client, a.globalLimiter, nil)
+	if !storage.IsS3URI(destPath) {
+		return dl.Download(ctx, url, destPath, expectedSHA, headers, noResume)
+	}
+	localDest, err := storage.StagingPath(a.c, destPath, url)
+	if err != nil {
+		return "", "", err
+	}
+	finalLocal, sum, err := dl.Download(ctx, url, localDest, expectedSHA, headers, noResume)
+	if err != nil {
+		return "", "", err
+	}
+	client, err := storage.NewS3ClientFromConfig(a.c)
+	if err != nil {
+		a.markS3UploadError(url, finalLocal, err)
+		return "", "", err
+	}
+	if err := client.PutFile(ctx, destPath, finalLocal, "application/octet-stream"); err != nil {
+		a.markS3UploadError(url, finalLocal, err)
+		return "", "", err
+	}
+	if _, err := os.Stat(finalLocal + ".sha256"); err == nil && a.c.Storage.S3.UploadSHA256File {
+		if err := client.PutFile(ctx, destPath+".sha256", finalLocal+".sha256", "text/plain; charset=utf-8"); err != nil {
+			a.markS3UploadError(url, finalLocal, fmt.Errorf("checksum: %w", err))
+			return "", "", err
+		}
+	}
+	if a.st != nil {
+		if err := a.st.ReplaceDownloadDest(url, finalLocal, destPath); err != nil {
+			return "", "", err
+		}
+	}
+	if a.l != nil {
+		a.l.Infof("uploaded to s3: %s", destPath)
+	}
+	return destPath, sum, nil
+}
+
+func (a *Auto) markS3UploadError(url, dest string, err error) {
+	if a.st == nil || err == nil {
+		return
+	}
+	_ = a.st.UpdateDownloadStatus(url, dest, "error", fmt.Sprintf("s3 upload: %v", err))
 }

--- a/internal/downloader/s3_storage_test.go
+++ b/internal/downloader/s3_storage_test.go
@@ -90,3 +90,65 @@ func TestAutoDownloadsToS3Destination(t *testing.T) {
 		t.Fatalf("expected complete s3 state row, got %+v", rows)
 	}
 }
+
+func TestAutoRollsBackS3ObjectWhenChecksumUploadFails(t *testing.T) {
+	payload := []byte("model payload")
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", "13")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("Content-Length", "13")
+		_, _ = w.Write(payload)
+	}))
+	defer source.Close()
+
+	deletedMain := false
+	s3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && r.URL.EscapedPath() == "/models/remote.bin" {
+			deletedMain = true
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if strings.HasSuffix(r.URL.EscapedPath(), ".sha256") {
+			http.Error(w, "sidecar failed", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s3.Close()
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+
+	tmp := t.TempDir()
+	cfg := &config.Config{
+		General: config.General{DataRoot: filepath.Join(tmp, "data"), DownloadRoot: filepath.Join(tmp, "downloads"), StagePartials: true},
+		Storage: config.Storage{S3: config.S3Storage{
+			Endpoint:         s3.URL,
+			UseHTTP:          true,
+			PathStyle:        true,
+			UploadSHA256File: true,
+		}},
+	}
+	db, err := state.NewDB(filepath.Join(tmp, "state.db"))
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	_, _, err = NewAuto(cfg, logging.New("error", false), db, nil).Download(context.Background(), source.URL+"/model.bin", "s3://models/remote.bin", "", nil, false)
+	if err == nil {
+		t.Fatal("expected checksum upload failure")
+	}
+	if !deletedMain {
+		t.Fatal("expected main S3 object to be deleted after checksum upload failure")
+	}
+	rows, err := db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Status != "error" || !strings.Contains(rows[0].LastError, "s3 upload") {
+		t.Fatalf("expected local state row marked with s3 upload error, got %+v", rows)
+	}
+}

--- a/internal/downloader/s3_storage_test.go
+++ b/internal/downloader/s3_storage_test.go
@@ -1,0 +1,88 @@
+package downloader
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/config"
+	"github.com/jxwalker/modfetch/internal/logging"
+	"github.com/jxwalker/modfetch/internal/state"
+	"github.com/jxwalker/modfetch/internal/storage"
+)
+
+func TestAutoDownloadsToS3Destination(t *testing.T) {
+	payload := []byte("model payload")
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", "13")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("Content-Length", "13")
+		_, _ = w.Write(payload)
+	}))
+	defer source.Close()
+
+	objects := map[string]string{}
+	s3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		objects[r.URL.EscapedPath()] = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s3.Close()
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+
+	tmp := t.TempDir()
+	cfg := &config.Config{
+		General: config.General{DataRoot: filepath.Join(tmp, "data"), DownloadRoot: filepath.Join(tmp, "downloads"), StagePartials: true},
+		Storage: config.Storage{S3: config.S3Storage{
+			Endpoint:         s3.URL,
+			UseHTTP:          true,
+			PathStyle:        true,
+			UploadSHA256File: true,
+		}},
+	}
+	db, err := state.NewDB(filepath.Join(tmp, "state.db"))
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	dest := "s3://models/remote.bin"
+	final, sum, err := NewAuto(cfg, logging.New("error", false), db, nil).Download(context.Background(), source.URL+"/model.bin", dest, "", nil, false)
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if final != dest {
+		t.Fatalf("expected final s3 destination %q, got %q", dest, final)
+	}
+	if sum == "" {
+		t.Fatal("expected sha256")
+	}
+	if got := objects["/models/remote.bin"]; got != string(payload) {
+		t.Fatalf("unexpected uploaded object %q", got)
+	}
+	if got := objects["/models/remote.bin.sha256"]; !strings.Contains(got, sum) {
+		t.Fatalf("expected uploaded checksum sidecar to contain %s, got %q", sum, got)
+	}
+	local, err := storage.StagingPath(cfg, dest, source.URL+"/model.bin")
+	if err != nil {
+		t.Fatalf("staging path: %v", err)
+	}
+	if !strings.Contains(local, filepath.Join("s3-staging", "models")) {
+		t.Fatalf("unexpected local staging path %q", local)
+	}
+	rows, err := db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Dest != dest || rows[0].Status != "complete" {
+		t.Fatalf("expected complete s3 state row, got %+v", rows)
+	}
+}

--- a/internal/downloader/s3_storage_test.go
+++ b/internal/downloader/s3_storage_test.go
@@ -30,7 +30,11 @@ func TestAutoDownloadsToS3Destination(t *testing.T) {
 
 	objects := map[string]string{}
 	s3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, _ := io.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		objects[r.URL.EscapedPath()] = string(b)
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/internal/state/download_tx_test.go
+++ b/internal/state/download_tx_test.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"database/sql"
+	"errors"
 	"path/filepath"
 	"testing"
 )
@@ -193,5 +195,56 @@ func TestReplaceDownloadDest(t *testing.T) {
 	}
 	if len(chunks) != 1 {
 		t.Fatalf("expected chunk to move to new dest, got %d", len(chunks))
+	}
+}
+
+func TestReplaceDownloadDestNotFound(t *testing.T) {
+	db := testDownloadDB(t)
+
+	err := db.ReplaceDownloadDest("https://example.com/missing", "/old/path", "s3://bucket/key")
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows, got %v", err)
+	}
+}
+
+func TestReplaceDownloadDestNoOp(t *testing.T) {
+	db := testDownloadDB(t)
+	url := "https://example.com/model.bin"
+	dest := filepath.Join(t.TempDir(), "model.bin")
+	if err := db.UpsertDownload(DownloadRow{URL: url, Dest: dest, Status: "complete"}); err != nil {
+		t.Fatalf("upsert download: %v", err)
+	}
+	if err := db.UpsertChunk(ChunkRow{URL: url, Dest: dest, Index: 0, Start: 0, End: 3, Size: 4, Status: "complete"}); err != nil {
+		t.Fatalf("upsert chunk: %v", err)
+	}
+
+	for _, tt := range []struct {
+		name    string
+		oldDest string
+		newDest string
+	}{
+		{name: "same", oldDest: dest, newDest: dest},
+		{name: "blank old", oldDest: "", newDest: "s3://bucket/key"},
+		{name: "blank new", oldDest: dest, newDest: ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := db.ReplaceDownloadDest(url, tt.oldDest, tt.newDest); err != nil {
+				t.Fatalf("expected no-op nil error, got %v", err)
+			}
+		})
+	}
+	rows, err := db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Dest != dest {
+		t.Fatalf("expected download dest to remain %q, got %+v", dest, rows)
+	}
+	chunks, err := db.ListChunks(url, dest)
+	if err != nil {
+		t.Fatalf("list chunks: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected chunk to remain at original dest, got %d", len(chunks))
 	}
 }

--- a/internal/state/download_tx_test.go
+++ b/internal/state/download_tx_test.go
@@ -162,3 +162,36 @@ func TestDeleteDownloadsAndChunksByDest(t *testing.T) {
 		t.Fatalf("expected chunks to be removed, got %d", count)
 	}
 }
+
+func TestReplaceDownloadDest(t *testing.T) {
+	db := testDownloadDB(t)
+
+	url := "https://example.com/model.bin"
+	oldDest := filepath.Join(t.TempDir(), "model.bin")
+	newDest := "s3://models/model.bin"
+	if err := db.UpsertDownload(DownloadRow{URL: url, Dest: oldDest, Status: "complete", ActualSHA256: "abc"}); err != nil {
+		t.Fatalf("upsert download: %v", err)
+	}
+	if err := db.UpsertChunk(ChunkRow{URL: url, Dest: oldDest, Index: 0, Start: 0, End: 3, Size: 4, Status: "complete"}); err != nil {
+		t.Fatalf("upsert chunk: %v", err)
+	}
+
+	if err := db.ReplaceDownloadDest(url, oldDest, newDest); err != nil {
+		t.Fatalf("replace dest: %v", err)
+	}
+
+	rows, err := db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Dest != newDest {
+		t.Fatalf("expected download dest %q, got %+v", newDest, rows)
+	}
+	chunks, err := db.ListChunks(url, newDest)
+	if err != nil {
+		t.Fatalf("list chunks: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected chunk to move to new dest, got %d", len(chunks))
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -339,6 +340,28 @@ func (db *DB) ReplaceDownloadURL(oldURL string, row DownloadRow) error {
 			}
 		}
 		return db.UpsertDownloadTx(tx, row)
+	})
+}
+
+// ReplaceDownloadDest updates a download and related rows from a local staging
+// path to a final destination identifier such as an s3:// URI.
+func (db *DB) ReplaceDownloadDest(url, oldDest, newDest string) error {
+	if strings.TrimSpace(oldDest) == "" || strings.TrimSpace(newDest) == "" || oldDest == newDest {
+		return nil
+	}
+	return db.WithTx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`UPDATE chunks SET dest=? WHERE url=? AND dest=?`, newDest, url, oldDest); err != nil {
+			return err
+		}
+		res, err := tx.Exec(`UPDATE downloads SET dest=?, updated_at=strftime('%s','now') WHERE url=? AND dest=?`, newDest, url, oldDest)
+		if err != nil {
+			return err
+		}
+		if n, _ := res.RowsAffected(); n == 0 {
+			return sql.ErrNoRows
+		}
+		_, err = tx.Exec(`UPDATE model_metadata SET dest=? WHERE download_url=? AND dest=?`, newDest, url, oldDest)
+		return err
 	})
 }
 

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -109,8 +109,8 @@ func NewS3ClientFromConfig(cfg *config.Config) (*S3Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("storage.s3.endpoint: %w", err)
 	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return nil, fmt.Errorf("storage.s3.endpoint must use http or https")
+	if u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return nil, fmt.Errorf("storage.s3.endpoint must be a valid http or https endpoint with a host")
 	}
 	region := firstNonEmpty(s3.Region, os.Getenv("AWS_REGION"), os.Getenv("AWS_DEFAULT_REGION"), defaultRegion)
 	accessEnv := firstNonEmpty(s3.AccessKeyEnv, defaultAccessKeyEnv)

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"context"
 	"crypto/hmac"
-	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -79,7 +78,7 @@ func StagingPath(cfg *config.Config, uri, sourceURL string) (string, error) {
 	if root == "" {
 		return "", errors.New("general.data_root or general.download_root is required for s3 staging")
 	}
-	h := sha1.Sum([]byte(sourceURL + "|" + uri))
+	h := sha256.Sum256([]byte(sourceURL + "|" + uri))
 	base := util.SafeFileName(filepath.Base(key))
 	if base == "" || base == "." {
 		base = "object"
@@ -129,7 +128,7 @@ func NewS3ClientFromConfig(cfg *config.Config) (*S3Client, error) {
 		secretKey:    secretKey,
 		sessionToken: strings.TrimSpace(os.Getenv(sessionEnv)),
 		pathStyle:    s3.PathStyle,
-		httpClient:   http.DefaultClient,
+		httpClient:   newS3HTTPClient(cfg),
 	}, nil
 }
 
@@ -177,13 +176,36 @@ func (c *S3Client) PutFile(ctx context.Context, uri, path, contentType string) e
 	return fmt.Errorf("s3 put %s failed: %s %s", uri, resp.Status, strings.TrimSpace(string(b)))
 }
 
+func (c *S3Client) DeleteObject(ctx context.Context, uri string) error {
+	bucket, key, err := ParseS3URI(uri)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.objectURL(bucket, key), nil)
+	if err != nil {
+		return err
+	}
+	emptyHash := sha256.Sum256(nil)
+	c.sign(req, hex.EncodeToString(emptyHash[:]), time.Now().UTC())
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return fmt.Errorf("s3 delete %s failed: %s %s", uri, resp.Status, strings.TrimSpace(string(b)))
+}
+
 func (c *S3Client) objectURL(bucket, key string) string {
 	u := *c.endpoint
 	u.RawQuery = ""
 	u.Fragment = ""
 	escapedKey := escapeS3Key(key)
 	if c.pathStyle || isLocalHost(u.Hostname()) {
-		u.Path = joinURLPath(u.Path, neturl.PathEscape(bucket), escapedKey)
+		u.Path = joinURLPath(u.Path, bucket, escapedKey)
 		return u.String()
 	}
 	u.Host = bucket + "." + u.Host
@@ -292,7 +314,11 @@ func joinURLPath(parts ...string) string {
 
 func isLocalHost(host string) bool {
 	host = strings.ToLower(strings.TrimSpace(host))
-	return host == "localhost" || net.ParseIP(host) != nil
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func firstNonEmpty(values ...string) string {
@@ -302,4 +328,21 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func newS3HTTPClient(cfg *config.Config) *http.Client {
+	timeout := 6 * time.Hour
+	if cfg != nil && cfg.Network.TimeoutSeconds > 0 {
+		timeout = time.Duration(cfg.Network.TimeoutSeconds) * time.Second
+	}
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+			TLSHandshakeTimeout:   30 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+			IdleConnTimeout:       90 * time.Second,
+		},
+	}
 }

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -1,0 +1,305 @@
+package storage
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	neturl "net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jxwalker/modfetch/internal/config"
+	"github.com/jxwalker/modfetch/internal/util"
+)
+
+const (
+	defaultRegion       = "us-east-1"
+	defaultS3Service    = "s3"
+	defaultAccessKeyEnv = "AWS_ACCESS_KEY_ID"
+	defaultSecretKeyEnv = "AWS_SECRET_ACCESS_KEY"
+	defaultSessionEnv   = "AWS_SESSION_TOKEN"
+)
+
+type S3Client struct {
+	endpoint     *neturl.URL
+	region       string
+	accessKey    string
+	secretKey    string
+	sessionToken string
+	pathStyle    bool
+	httpClient   *http.Client
+}
+
+func IsS3URI(s string) bool {
+	u, err := neturl.Parse(strings.TrimSpace(s))
+	return err == nil && strings.EqualFold(u.Scheme, "s3") && u.Host != "" && strings.TrimPrefix(u.Path, "/") != ""
+}
+
+func ParseS3URI(uri string) (bucket, key string, err error) {
+	u, err := neturl.Parse(strings.TrimSpace(uri))
+	if err != nil {
+		return "", "", err
+	}
+	if !strings.EqualFold(u.Scheme, "s3") {
+		return "", "", fmt.Errorf("not an s3 URI: %s", uri)
+	}
+	bucket = strings.TrimSpace(u.Host)
+	key = strings.TrimPrefix(u.EscapedPath(), "/")
+	if bucket == "" || key == "" {
+		return "", "", fmt.Errorf("s3 URI must include bucket and key: %s", uri)
+	}
+	if decoded, err := neturl.PathUnescape(key); err == nil {
+		key = decoded
+	}
+	return bucket, key, nil
+}
+
+func StagingPath(cfg *config.Config, uri, sourceURL string) (string, error) {
+	bucket, key, err := ParseS3URI(uri)
+	if err != nil {
+		return "", err
+	}
+	root := ""
+	if cfg != nil {
+		root = strings.TrimSpace(cfg.General.DataRoot)
+		if root == "" {
+			root = strings.TrimSpace(cfg.General.DownloadRoot)
+		}
+	}
+	if root == "" {
+		return "", errors.New("general.data_root or general.download_root is required for s3 staging")
+	}
+	h := sha1.Sum([]byte(sourceURL + "|" + uri))
+	base := util.SafeFileName(filepath.Base(key))
+	if base == "" || base == "." {
+		base = "object"
+	}
+	return filepath.Join(root, "s3-staging", util.SafeFileName(bucket), hex.EncodeToString(h[:])[:12]+"-"+base), nil
+}
+
+func NewS3ClientFromConfig(cfg *config.Config) (*S3Client, error) {
+	if cfg == nil {
+		return nil, errors.New("config is required")
+	}
+	s3 := cfg.Storage.S3
+	endpoint := strings.TrimSpace(s3.Endpoint)
+	if endpoint == "" {
+		endpoint = strings.TrimSpace(os.Getenv("MODFETCH_S3_ENDPOINT"))
+	}
+	if endpoint == "" {
+		return nil, errors.New("storage.s3.endpoint or MODFETCH_S3_ENDPOINT is required")
+	}
+	if !strings.Contains(endpoint, "://") {
+		scheme := "https"
+		if s3.UseHTTP {
+			scheme = "http"
+		}
+		endpoint = scheme + "://" + endpoint
+	}
+	u, err := neturl.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("storage.s3.endpoint: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("storage.s3.endpoint must use http or https")
+	}
+	region := firstNonEmpty(s3.Region, os.Getenv("AWS_REGION"), os.Getenv("AWS_DEFAULT_REGION"), defaultRegion)
+	accessEnv := firstNonEmpty(s3.AccessKeyEnv, defaultAccessKeyEnv)
+	secretEnv := firstNonEmpty(s3.SecretKeyEnv, defaultSecretKeyEnv)
+	sessionEnv := firstNonEmpty(s3.SessionTokenEnv, defaultSessionEnv)
+	accessKey := strings.TrimSpace(os.Getenv(accessEnv))
+	secretKey := strings.TrimSpace(os.Getenv(secretEnv))
+	if accessKey == "" || secretKey == "" {
+		return nil, fmt.Errorf("missing S3 credentials: set %s and %s", accessEnv, secretEnv)
+	}
+	return &S3Client{
+		endpoint:     u,
+		region:       region,
+		accessKey:    accessKey,
+		secretKey:    secretKey,
+		sessionToken: strings.TrimSpace(os.Getenv(sessionEnv)),
+		pathStyle:    s3.PathStyle,
+		httpClient:   http.DefaultClient,
+	}, nil
+}
+
+func (c *S3Client) PutFile(ctx context.Context, uri, path, contentType string) error {
+	bucket, key, err := ParseS3URI(uri)
+	if err != nil {
+		return err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	stat, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, f); err != nil {
+		return err
+	}
+	payloadHash := hex.EncodeToString(hasher.Sum(nil))
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	reqURL := c.objectURL(bucket, key)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, f)
+	if err != nil {
+		return err
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	req.ContentLength = stat.Size()
+	c.sign(req, payloadHash, time.Now().UTC())
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return fmt.Errorf("s3 put %s failed: %s %s", uri, resp.Status, strings.TrimSpace(string(b)))
+}
+
+func (c *S3Client) objectURL(bucket, key string) string {
+	u := *c.endpoint
+	u.RawQuery = ""
+	u.Fragment = ""
+	escapedKey := escapeS3Key(key)
+	if c.pathStyle || isLocalHost(u.Hostname()) {
+		u.Path = joinURLPath(u.Path, neturl.PathEscape(bucket), escapedKey)
+		return u.String()
+	}
+	u.Host = bucket + "." + u.Host
+	u.Path = joinURLPath(u.Path, escapedKey)
+	return u.String()
+}
+
+func (c *S3Client) sign(req *http.Request, payloadHash string, now time.Time) {
+	amzDate := now.Format("20060102T150405Z")
+	shortDate := now.Format("20060102")
+	req.Header.Set("X-Amz-Date", amzDate)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+	if c.sessionToken != "" {
+		req.Header.Set("X-Amz-Security-Token", c.sessionToken)
+	}
+	headers, signedHeaders := canonicalHeaders(req)
+	canonical := strings.Join([]string{
+		req.Method,
+		canonicalURI(req.URL),
+		req.URL.RawQuery,
+		headers,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+	scope := shortDate + "/" + c.region + "/" + defaultS3Service + "/aws4_request"
+	canonicalHash := sha256.Sum256([]byte(canonical))
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		scope,
+		hex.EncodeToString(canonicalHash[:]),
+	}, "\n")
+	signingKey := deriveSigningKey(c.secretKey, shortDate, c.region, defaultS3Service)
+	signature := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
+	req.Header.Set("Authorization", fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s", c.accessKey, scope, signedHeaders, signature))
+}
+
+func canonicalHeaders(req *http.Request) (string, string) {
+	values := map[string]string{
+		"host": req.URL.Host,
+	}
+	for k, vals := range req.Header {
+		lk := strings.ToLower(strings.TrimSpace(k))
+		if lk == "authorization" {
+			continue
+		}
+		joined := strings.Join(vals, ",")
+		values[lk] = strings.Join(strings.Fields(joined), " ")
+	}
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte(':')
+		b.WriteString(values[k])
+		b.WriteByte('\n')
+	}
+	return b.String(), strings.Join(keys, ";")
+}
+
+func canonicalURI(u *neturl.URL) string {
+	if u == nil || u.EscapedPath() == "" {
+		return "/"
+	}
+	return u.EscapedPath()
+}
+
+func deriveSigningKey(secret, date, region, service string) []byte {
+	kDate := hmacSHA256([]byte("AWS4"+secret), []byte(date))
+	kRegion := hmacSHA256(kDate, []byte(region))
+	kService := hmacSHA256(kRegion, []byte(service))
+	return hmacSHA256(kService, []byte("aws4_request"))
+}
+
+func hmacSHA256(key, data []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(data)
+	return mac.Sum(nil)
+}
+
+func escapeS3Key(key string) string {
+	parts := strings.Split(key, "/")
+	for i, part := range parts {
+		parts[i] = neturl.PathEscape(part)
+	}
+	return strings.Join(parts, "/")
+}
+
+func joinURLPath(parts ...string) string {
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.Trim(p, "/")
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return "/"
+	}
+	return "/" + strings.Join(out, "/")
+}
+
+func isLocalHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "localhost" || net.ParseIP(host) != nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}

--- a/internal/storage/s3_test.go
+++ b/internal/storage/s3_test.go
@@ -1,0 +1,73 @@
+package storage
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/config"
+)
+
+func TestPutFileSignsAndUploadsPathStyleObject(t *testing.T) {
+	var gotPath, gotAuth, gotHash, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		gotAuth = r.Header.Get("Authorization")
+		gotHash = r.Header.Get("X-Amz-Content-Sha256")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "model.bin")
+	if err := os.WriteFile(src, []byte("payload"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	client, err := NewS3ClientFromConfig(&config.Config{Storage: config.Storage{S3: config.S3Storage{Endpoint: srv.URL, UseHTTP: true}}})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if err := client.PutFile(context.Background(), "s3://models/path/to/model.bin", src, "application/octet-stream"); err != nil {
+		t.Fatalf("put file: %v", err)
+	}
+
+	if gotPath != "/models/path/to/model.bin" {
+		t.Fatalf("unexpected path %q", gotPath)
+	}
+	if !strings.HasPrefix(gotAuth, "AWS4-HMAC-SHA256 Credential=test-access/") {
+		t.Fatalf("expected SigV4 authorization header, got %q", gotAuth)
+	}
+	if gotHash == "" {
+		t.Fatal("expected payload hash header")
+	}
+	if gotBody != "payload" {
+		t.Fatalf("unexpected body %q", gotBody)
+	}
+}
+
+func TestStagingPathIsStableForS3Destination(t *testing.T) {
+	cfg := &config.Config{General: config.General{DataRoot: t.TempDir()}}
+	a, err := StagingPath(cfg, "s3://bucket/models/file.bin", "https://example.com/file.bin")
+	if err != nil {
+		t.Fatalf("staging path: %v", err)
+	}
+	b, err := StagingPath(cfg, "s3://bucket/models/file.bin", "https://example.com/file.bin")
+	if err != nil {
+		t.Fatalf("staging path second call: %v", err)
+	}
+	if a != b {
+		t.Fatalf("expected stable staging path, got %q and %q", a, b)
+	}
+	if !strings.Contains(a, filepath.Join("s3-staging", "bucket")) {
+		t.Fatalf("expected staging path under s3-staging bucket dir, got %q", a)
+	}
+}

--- a/internal/storage/s3_test.go
+++ b/internal/storage/s3_test.go
@@ -71,3 +71,12 @@ func TestStagingPathIsStableForS3Destination(t *testing.T) {
 		t.Fatalf("expected staging path under s3-staging bucket dir, got %q", a)
 	}
 }
+
+func TestNewS3ClientRejectsEndpointWithoutHost(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+	_, err := NewS3ClientFromConfig(&config.Config{Storage: config.Storage{S3: config.S3Storage{Endpoint: "http://"}}})
+	if err == nil || !strings.Contains(err.Error(), "storage.s3.endpoint") {
+		t.Fatalf("expected endpoint validation error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a SigV4 S3-compatible storage client with `s3://bucket/key` URI parsing and deterministic local staging
- route explicit S3 destinations through resumable local download/verification, then upload the artifact and optional `.sha256` sidecar
- update state rows from local staging paths to final S3 URIs after upload
- document `storage.s3` config and mark the roadmap item implemented

## Validation
- go test ./internal/storage ./internal/downloader ./internal/state ./cmd/modfetch
- go test ./... -timeout 180s
