### PR TITLE
[codex] Standardize config flag resolution

### DIFF
--- a/cmd/modfetch/batch_cmd.go
+++ b/cmd/modfetch/batch_cmd.go
@@ -14,7 +14,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/jxwalker/modfetch/internal/batch"
-	"github.com/jxwalker/modfetch/internal/config"
 	"github.com/jxwalker/modfetch/internal/downloader"
 	"github.com/jxwalker/modfetch/internal/logging"
 	"github.com/jxwalker/modfetch/internal/resolver"
@@ -51,19 +50,10 @@ func handleBatchImport(ctx context.Context, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *cfgPath == "" {
-		if env := os.Getenv("MODFETCH_CONFIG"); env != "" {
-			*cfgPath = env
-		} else {
-			if h, err := os.UserHomeDir(); err == nil && h != "" {
-				*cfgPath = filepath.Join(h, ".config", "modfetch", "config.yml")
-			}
-		}
-	}
 	if *inPath == "" {
 		return errors.New("--input is required")
 	}
-	c, err := config.Load(*cfgPath)
+	c, _, err := loadConfig(*cfgPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/modfetch/config_path.go
+++ b/cmd/modfetch/config_path.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jxwalker/modfetch/internal/config"
+)
+
+func resolveConfigPath(flagPath string) (string, error) {
+	if p := strings.TrimSpace(flagPath); p != "" {
+		return expandHomeConfigPath(p)
+	}
+	if env := strings.TrimSpace(os.Getenv("MODFETCH_CONFIG")); env != "" {
+		return expandHomeConfigPath(env)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return "", errors.New("--config is required or set MODFETCH_CONFIG")
+	}
+	return filepath.Join(home, ".config", "modfetch", "config.yml"), nil
+}
+
+func expandHomeConfigPath(path string) (string, error) {
+	if path == "~" || strings.HasPrefix(path, "~/") || strings.HasPrefix(path, "~\\") {
+		home, err := os.UserHomeDir()
+		if err != nil || strings.TrimSpace(home) == "" {
+			return "", errors.New("--config is required or set MODFETCH_CONFIG")
+		}
+		if path == "~" {
+			return home, nil
+		}
+		return filepath.Join(home, path[2:]), nil
+	}
+	return path, nil
+}
+
+func loadConfig(flagPath string) (*config.Config, string, error) {
+	cfgPath, err := resolveConfigPath(flagPath)
+	if err != nil {
+		return nil, "", err
+	}
+	c, err := config.Load(cfgPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, cfgPath, fmt.Errorf("config file not found: %s", cfgPath)
+		}
+		return nil, cfgPath, err
+	}
+	return c, cfgPath, nil
+}

--- a/cmd/modfetch/config_path_test.go
+++ b/cmd/modfetch/config_path_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveConfigPathPrecedence(t *testing.T) {
+	home := t.TempDir()
+	envPath := filepath.Join(t.TempDir(), "env.yml")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("MODFETCH_CONFIG", envPath)
+
+	if got, err := resolveConfigPath(" /tmp/explicit.yml "); err != nil || got != "/tmp/explicit.yml" {
+		t.Fatalf("explicit path = %q, %v", got, err)
+	}
+	if got, err := resolveConfigPath(""); err != nil || got != envPath {
+		t.Fatalf("env path = %q, %v", got, err)
+	}
+	t.Setenv("MODFETCH_CONFIG", "")
+	want := filepath.Join(home, ".config", "modfetch", "config.yml")
+	if got, err := resolveConfigPath(""); err != nil || got != want {
+		t.Fatalf("default path = %q, %v; want %q", got, err, want)
+	}
+}
+
+func TestResolveConfigPathExpandsTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	wantExplicit := filepath.Join(home, "explicit.yml")
+	if got, err := resolveConfigPath("~/explicit.yml"); err != nil || got != wantExplicit {
+		t.Fatalf("explicit tilde path = %q, %v; want %q", got, err, wantExplicit)
+	}
+
+	wantEnv := filepath.Join(home, "env.yml")
+	t.Setenv("MODFETCH_CONFIG", "~/env.yml")
+	if got, err := resolveConfigPath(""); err != nil || got != wantEnv {
+		t.Fatalf("env tilde path = %q, %v; want %q", got, err, wantEnv)
+	}
+}
+
+func TestLoadConfigUsesDefaultPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("MODFETCH_CONFIG", "")
+	cfgPath := filepath.Join(home, ".config", "modfetch", "config.yml")
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dataRoot := filepath.Join(home, "data")
+	downloadRoot := filepath.Join(home, "downloads")
+	cfg := "version: 1\n" +
+		"general:\n" +
+		"  data_root: " + fmt.Sprintf("%q", dataRoot) + "\n" +
+		"  download_root: " + fmt.Sprintf("%q", downloadRoot) + "\n"
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, gotPath, err := loadConfig("")
+	if err != nil {
+		t.Fatalf("load default config: %v", err)
+	}
+	if gotPath != cfgPath {
+		t.Fatalf("loaded path = %q; want %q", gotPath, cfgPath)
+	}
+	if c.General.DataRoot != dataRoot || c.General.DownloadRoot != downloadRoot {
+		t.Fatalf("unexpected config roots: %+v", c.General)
+	}
+}
+
+func TestLoadConfigAllowsTildePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("MODFETCH_CONFIG", "")
+	cfgPath := filepath.Join(home, "modfetch.yml")
+	dataRoot := filepath.Join(home, "data")
+	downloadRoot := filepath.Join(home, "downloads")
+	cfg := "version: 1\n" +
+		"general:\n" +
+		"  data_root: " + fmt.Sprintf("%q", dataRoot) + "\n" +
+		"  download_root: " + fmt.Sprintf("%q", downloadRoot) + "\n"
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, gotPath, err := loadConfig("~/modfetch.yml")
+	if err != nil {
+		t.Fatalf("load tilde config: %v", err)
+	}
+	if gotPath != cfgPath {
+		t.Fatalf("loaded path = %q; want %q", gotPath, cfgPath)
+	}
+	if c.General.DataRoot != dataRoot || c.General.DownloadRoot != downloadRoot {
+		t.Fatalf("unexpected config roots: %+v", c.General)
+	}
+}
+
+func TestLoadConfigAllowsTildeEnvPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	cfgPath := filepath.Join(home, "env.yml")
+	t.Setenv("MODFETCH_CONFIG", "~/env.yml")
+	dataRoot := filepath.Join(home, "data")
+	downloadRoot := filepath.Join(home, "downloads")
+	cfg := "version: 1\n" +
+		"general:\n" +
+		"  data_root: " + fmt.Sprintf("%q", dataRoot) + "\n" +
+		"  download_root: " + fmt.Sprintf("%q", downloadRoot) + "\n"
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, gotPath, err := loadConfig("")
+	if err != nil {
+		t.Fatalf("load tilde env config: %v", err)
+	}
+	if gotPath != cfgPath {
+		t.Fatalf("loaded path = %q; want %q", gotPath, cfgPath)
+	}
+	if c.General.DataRoot != dataRoot || c.General.DownloadRoot != downloadRoot {
+		t.Fatalf("unexpected config roots: %+v", c.General)
+	}
+}

--- a/cmd/modfetch/hostcaps.go
+++ b/cmd/modfetch/hostcaps.go
@@ -7,10 +7,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/jxwalker/modfetch/internal/config"
 	"github.com/jxwalker/modfetch/internal/state"
 )
 
@@ -24,19 +22,7 @@ func handleHostCaps(ctx context.Context, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *cfgPath == "" {
-		if env := os.Getenv("MODFETCH_CONFIG"); env != "" {
-			*cfgPath = env
-		} else {
-			if h, err := os.UserHomeDir(); err == nil && h != "" {
-				*cfgPath = filepath.Join(h, ".config", "modfetch", "config.yml")
-			}
-		}
-	}
-	if _, err := os.Stat(*cfgPath); err != nil {
-		return fmt.Errorf("config file not found: %s", *cfgPath)
-	}
-	c, err := config.Load(*cfgPath)
+	c, _, err := loadConfig(*cfgPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -129,19 +129,7 @@ func handleStatus(ctx context.Context, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *cfgPath == "" {
-		if env := os.Getenv("MODFETCH_CONFIG"); env != "" {
-			*cfgPath = env
-		} else {
-			if h, err := os.UserHomeDir(); err == nil && h != "" {
-				*cfgPath = filepath.Join(h, ".config", "modfetch", "config.yml")
-			}
-		}
-	}
-	if _, err := os.Stat(*cfgPath); err != nil {
-		return fmt.Errorf("config file not found: %s", *cfgPath)
-	}
-	c, err := config.Load(*cfgPath)
+	c, _, err := loadConfig(*cfgPath)
 	if err != nil {
 		return err
 	}
@@ -224,17 +212,7 @@ func handleDedupe(ctx context.Context, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *cfgPath == "" {
-		if env := os.Getenv("MODFETCH_CONFIG"); env != "" {
-			*cfgPath = env
-		} else if h, err := os.UserHomeDir(); err == nil && h != "" {
-			*cfgPath = filepath.Join(h, ".config", "modfetch", "config.yml")
-		}
-	}
-	if _, err := os.Stat(*cfgPath); err != nil {
-		return fmt.Errorf("config file not found: %s", *cfgPath)
-	}
-	c, err := config.Load(*cfgPath)
+	c, _, err := loadConfig(*cfgPath)
 	if err != nil {
 		return err
 	}
@@ -313,19 +291,7 @@ func handleDownload(ctx context.Context, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *cfgPath == "" {
-		if env := os.Getenv("MODFETCH_CONFIG"); env != "" {
-			*cfgPath = env
-		} else {
-			if h, err := os.UserHomeDir(); err == nil && h != "" {
-				*cfgPath = filepath.Join(h, ".config", "modfetch", "config.yml")
-			}
-		}
-	}
-	if _, err := os.Stat(*cfgPath); err != nil {
-		return fmt.Errorf("config file not found: %s", *cfgPath)
-	}
-	c, err := config.Load(*cfgPath)
+	c, _, err := loadConfig(*cfgPath)
 	if err != nil {
 		return err
 	}
@@ -923,18 +889,10 @@ func handlePlace(ctx context.Context, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *cfgPath == "" {
-		if env := os.Getenv("MODFETCH_CONFIG"); env != "" {
-			*cfgPath = env
-		}
-	}
-	if *cfgPath == "" {
-		return errors.New("--config is required or set MODFETCH_CONFIG")
-	}
 	if *filePath == "" {
 		return errors.New("--path is required")
 	}
-	c, err := config.Load(*cfgPath)
+	c, _, err := loadConfig(*cfgPath)
 	if err != nil {
 		return err
 	}
@@ -977,19 +935,7 @@ func handleClean(ctx context.Context, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *cfgPath == "" {
-		if env := os.Getenv("MODFETCH_CONFIG"); env != "" {
-			*cfgPath = env
-		} else {
-			if h, err := os.UserHomeDir(); err == nil && h != "" {
-				*cfgPath = filepath.Join(h, ".config", "modfetch", "config.yml")
-			}
-		}
-	}
-	if _, err := os.Stat(*cfgPath); err != nil {
-		return fmt.Errorf("config file not found: %s", *cfgPath)
-	}
-	c, err := config.Load(*cfgPath)
+	c, _, err := loadConfig(*cfgPath)
 	if err != nil {
 		return err
 	}
@@ -1177,19 +1123,7 @@ func configOp(args []string, fn func(*config.Config, *logging.Logger) error) err
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *cfgPath == "" {
-		if env := os.Getenv("MODFETCH_CONFIG"); env != "" {
-			*cfgPath = env
-		} else {
-			if h, err := os.UserHomeDir(); err == nil && h != "" {
-				*cfgPath = filepath.Join(h, ".config", "modfetch", "config.yml")
-			}
-		}
-	}
-	if _, err := os.Stat(*cfgPath); err != nil {
-		return fmt.Errorf("config file not found: %s", *cfgPath)
-	}
-	c, err := config.Load(*cfgPath)
+	c, _, err := loadConfig(*cfgPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/modfetch/tui_cmd.go
+++ b/cmd/modfetch/tui_cmd.go
@@ -25,25 +25,18 @@ func handleTUI(ctx context.Context, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *cfgPath == "" {
-		if env := os.Getenv("MODFETCH_CONFIG"); env != "" {
-			*cfgPath = env
-		}
-	}
-	// If still empty, default to ~/.config/modfetch/config.yml
-	if *cfgPath == "" {
-		h, err := os.UserHomeDir()
-		if err != nil {
-			return errors.New("--config is required or set MODFETCH_CONFIG")
-		}
-		*cfgPath = filepath.Join(h, ".config", "modfetch", "config.yml")
+	resolvedCfgPath, err := resolveConfigPath(*cfgPath)
+	if err != nil {
+		return err
 	}
 	// Try to load config. If not found, offer to create via wizard with sensible defaults.
-	c, err := config.Load(*cfgPath)
+	c, err := config.Load(resolvedCfgPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// Create directory and run wizard
-			_ = os.MkdirAll(filepath.Dir(*cfgPath), 0o755)
+			if err := os.MkdirAll(filepath.Dir(resolvedCfgPath), 0o755); err != nil {
+				return err
+			}
 			defaults := &config.Config{Version: 1, General: config.General{DataRoot: "~/modfetch/data", DownloadRoot: "~/modfetch/downloads", PlacementMode: "symlink"}, Concurrency: config.Concurrency{ChunkSizeMB: 8, PerFileChunks: 4}}
 			wiz := cw.New(defaults)
 			p := tea.NewProgram(wiz)
@@ -63,12 +56,12 @@ func handleTUI(ctx context.Context, args []string) error {
 			if merr != nil {
 				return merr
 			}
-			if err := os.WriteFile(*cfgPath, b, 0o644); err != nil {
+			if err := os.WriteFile(resolvedCfgPath, b, 0o644); err != nil {
 				return err
 			}
-			fmt.Printf("wrote config to %s\n", *cfgPath)
+			fmt.Printf("wrote config to %s\n", resolvedCfgPath)
 			// Reload expanded config
-			c, err = config.Load(*cfgPath)
+			c, err = config.Load(resolvedCfgPath)
 			if err != nil {
 				return err
 			}

--- a/cmd/modfetch/verify.go
+++ b/cmd/modfetch/verify.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/jxwalker/modfetch/internal/config"
 	"github.com/jxwalker/modfetch/internal/logging"
 	"github.com/jxwalker/modfetch/internal/state"
 	"github.com/jxwalker/modfetch/internal/util"
@@ -42,27 +41,14 @@ func handleVerify(ctx context.Context, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *cfgPath == "" {
-		if env := os.Getenv("MODFETCH_CONFIG"); env != "" {
-			*cfgPath = env
-		} else {
-			if h, err := os.UserHomeDir(); err == nil && h != "" {
-				*cfgPath = filepath.Join(h, ".config", "modfetch", "config.yml")
-			}
-		}
-	}
-	if _, err := os.Stat(*cfgPath); err != nil {
-		return fmt.Errorf("config file not found: %s", *cfgPath)
-	}
-	c, err := config.Load(*cfgPath)
-	if err != nil {
-		return err
-	}
 	_ = logging.New(*logLevel, *jsonOut)
 	// If scanning an arbitrary directory, DB is not required; open only for state-backed modes.
 	var st *state.DB
 	if *scanDir == "" {
-		var err error
+		c, _, err := loadConfig(*cfgPath)
+		if err != nil {
+			return err
+		}
 		st, err = state.Open(c)
 		if err != nil {
 			return err

--- a/cmd/modfetch/verify_cmd_test.go
+++ b/cmd/modfetch/verify_cmd_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestVerifyScanDirDoesNotRequireConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("MODFETCH_CONFIG", "")
+
+	scanDir := filepath.Join(home, "models")
+	if err := os.MkdirAll(scanDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := handleVerify(context.Background(), []string{"--scan-dir", scanDir, "--safetensors-deep"})
+	if err != nil {
+		t.Fatalf("verify scan-dir without config: %v", err)
+	}
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,7 +69,8 @@ Performance optimizations
 Breaking changes to consider for v1.0
 - Config schema tidy-up
 - State DB schema simplification
-- Standardize CLI flags and naming
+- Standardize CLI flags and naming [WIP]
+  - Shared config path resolution across config-backed commands; `place` now honors the documented default config path [IMPL]
 
 Completed (from prior docs)
 - CivitAI model-aware default filenames and naming patterns (sources.*.naming.pattern) [IMPL]


### PR DESCRIPTION
## Summary
- add shared config path resolution for --config, MODFETCH_CONFIG, and the default ~/.config/modfetch/config.yml
- use the shared loader across config-backed CLI commands
- make place honor the documented default config path
- mark this v1.0 CLI flag standardization slice in the roadmap

## Tests
- go test ./cmd/modfetch -timeout 180s
- go test ./... -timeout 180s