### PR TITLE
[codex] Add strict config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ modfetch download --batch jobs.yml --place
 - Validate config:
   
   modfetch config validate --config /path/to/config.yml
+  modfetch config validate --config /path/to/config.yml --strict
   
 - Download with live progress (speed, ETA):
   

--- a/cmd/modfetch/config_validate_test.go
+++ b/cmd/modfetch/config_validate_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConfigValidateStrictRejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yml")
+	cfg := "version: 1\n" +
+		"general:\n" +
+		"  data_root: " + filepath.Join(dir, "data") + "\n" +
+		"  download_root: " + filepath.Join(dir, "downloads") + "\n" +
+		"  download_rooot: typo\n"
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := handleConfig(context.Background(), []string{"validate", "--config", cfgPath}); err != nil {
+		t.Fatalf("non-strict validate should pass, got %v", err)
+	}
+	err := handleConfig(context.Background(), []string{"validate", "--config", cfgPath, "--strict"})
+	if err == nil || !strings.Contains(err.Error(), "download_rooot") {
+		t.Fatalf("expected strict unknown-field error, got %v", err)
+	}
+}

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -249,10 +249,7 @@ func handleConfig(ctx context.Context, args []string) error {
 	sub := args[0]
 	switch sub {
 	case "validate":
-		return configOp(args[1:], func(c *config.Config, log *logging.Logger) error {
-			log.Infof("config: valid")
-			return nil
-		})
+		return configValidate(args[1:])
 	case "print":
 		return configOp(args[1:], func(c *config.Config, log *logging.Logger) error {
 			enc := json.NewEncoder(os.Stdout)
@@ -264,6 +261,43 @@ func handleConfig(ctx context.Context, args []string) error {
 	default:
 		return fmt.Errorf("unknown config subcommand: %s", sub)
 	}
+}
+
+func configValidate(args []string) error {
+	fs := flag.NewFlagSet("config validate", flag.ContinueOnError)
+	cfgPath := fs.String("config", "", "Path to YAML config file")
+	logLevel := fs.String("log-level", "info", "log level")
+	jsonOut := fs.Bool("json", false, "json logs")
+	strict := fs.Bool("strict", false, "reject unknown config fields")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	resolvedCfgPath, err := resolveConfigPath(*cfgPath)
+	if err != nil {
+		return err
+	}
+	if err := loadConfigForValidation(resolvedCfgPath, *strict); err != nil {
+		return err
+	}
+	log := logging.New(*logLevel, *jsonOut)
+	log.Infof("config: valid")
+	return nil
+}
+
+func loadConfigForValidation(path string, strict bool) error {
+	var err error
+	if strict {
+		_, err = config.LoadStrict(path)
+	} else {
+		_, err = config.Load(path)
+	}
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("config file not found: %s", path)
+		}
+		return err
+	}
+	return nil
 }
 
 func handleDownload(ctx context.Context, args []string) error {

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -348,7 +348,7 @@ Configuration management commands.
 
 **1. Validate config:**
 ```bash
-modfetch config validate [--config PATH]
+modfetch config validate [--config PATH] [--strict]
 ```
 
 **2. Generate config wizard:**
@@ -361,6 +361,9 @@ modfetch config wizard --out PATH
 ```bash
 # Validate config
 modfetch config validate --config ~/modfetch/config.yml
+
+# Validate config and reject unknown YAML fields
+modfetch config validate --config ~/modfetch/config.yml --strict
 
 # Interactive config wizard
 modfetch config wizard --out ~/.config/modfetch/config.yml

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -63,6 +63,16 @@ Quick start: interactive wizard
 
 See `assets/sample-config/config.example.yml` for a full example.
 
+## Strict validation
+
+Use strict validation to catch misspelled or unsupported YAML fields:
+
+```bash
+modfetch config validate --config ~/modfetch/config.yml --strict
+```
+
+Strict validation is intended as a v1.0 readiness check. Regular validation remains backward-compatible and continues to ignore unknown YAML fields for now.
+
 ## Tokens / environment variables
 - Set in environment, not in YAML:
   - `HF_TOKEN`: Hugging Face token (Bearer), used when sources.huggingface.enabled is true

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -67,7 +67,8 @@ Performance optimizations
 - Adaptive chunk size based on configured throughput and file size [IMPL]
 
 Breaking changes to consider for v1.0
-- Config schema tidy-up
+- Config schema tidy-up [WIP]
+  - `modfetch config validate --strict` rejects unknown YAML fields before strict validation becomes a v1.0 default candidate [IMPL]
 - State DB schema simplification
 - Standardize CLI flags and naming [WIP]
   - Shared config path resolution across config-backed commands; `place` now honors the documented default config path [IMPL]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -189,6 +190,15 @@ type UIOptions struct {
 
 // Load reads, parses, expands, and validates a YAML config file.
 func Load(path string) (*Config, error) {
+	return load(path, false)
+}
+
+// LoadStrict reads, parses, expands, and validates a YAML config file while rejecting unknown schema fields.
+func LoadStrict(path string) (*Config, error) {
+	return load(path, true)
+}
+
+func load(path string, strict bool) (*Config, error) {
 	if path == "" {
 		return nil, errors.New("config path is empty")
 	}
@@ -203,7 +213,13 @@ func Load(path string) (*Config, error) {
 	// Expand ${ENV} placeholders before unmarshalling
 	b = []byte(os.ExpandEnv(string(b)))
 	var c Config
-	if err := yaml.Unmarshal(b, &c); err != nil {
+	if strict {
+		dec := yaml.NewDecoder(bytes.NewReader(b))
+		dec.KnownFields(true)
+		if err := dec.Decode(&c); err != nil {
+			return nil, err
+		}
+	} else if err := yaml.Unmarshal(b, &c); err != nil {
 		return nil, err
 	}
 	if err := c.expandPaths(); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -16,6 +18,33 @@ func TestLoadSampleConfig(t *testing.T) {
 	}
 	if c.General.DataRoot == "" || c.General.DownloadRoot == "" {
 		t.Fatalf("expected non-empty general paths")
+	}
+}
+
+func TestLoadStrictSampleConfig(t *testing.T) {
+	path := "../../assets/sample-config/config.example.yml"
+	if _, err := LoadStrict(path); err != nil {
+		t.Fatalf("LoadStrict returned error for sample config: %v", err)
+	}
+}
+
+func TestLoadStrictRejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+	cfg := "version: 1\n" +
+		"general:\n" +
+		"  data_root: " + filepath.Join(dir, "data") + "\n" +
+		"  download_root: " + filepath.Join(dir, "downloads") + "\n" +
+		"  download_rooot: typo\n"
+	if err := os.WriteFile(path, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(path); err != nil {
+		t.Fatalf("non-strict Load should ignore unknown fields, got %v", err)
+	}
+	_, err := LoadStrict(path)
+	if err == nil || !strings.Contains(err.Error(), "download_rooot") {
+		t.Fatalf("expected strict unknown-field error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add internal config.LoadStrict using YAML known-field validation
- add modfetch config validate --strict for v1.0 schema readiness checks
- document strict validation and mark the config schema tidy-up roadmap slice

## Tests
- go test ./internal/config ./cmd/modfetch -timeout 180s
- go test ./... -timeout 180s