### PR TITLE
[codex] Add state schema baseline

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -1,0 +1,74 @@
+# Database schema
+
+modfetch stores local state in SQLite at `general.data_root/state.db`.
+
+## Schema version
+
+The database uses SQLite `PRAGMA user_version` as the migration baseline. The current schema version is `1`.
+
+## Tables
+
+### downloads
+
+Tracks download attempts and final artifacts. The logical key is `(url, dest)`.
+
+Key columns:
+- `url`, `dest`
+- `expected_sha256`, `actual_sha256`
+- `etag`, `last_modified`, `size`
+- `status`, `retries`, `last_error`
+- `created_at`, `updated_at`
+
+Indexes:
+- `idx_downloads_status`
+- `idx_downloads_dest`
+- `idx_downloads_updated_at`
+
+### chunks
+
+Tracks resumable chunk plans and per-chunk verification state. The logical key is `(url, dest, idx)`.
+
+Key columns:
+- `url`, `dest`, `idx`
+- `start`, `end`, `size`
+- `sha256`, `status`, `updated_at`
+
+Indexes:
+- `idx_chunks_url_dest`
+
+### host_caps
+
+Caches host capability probes so repeated downloads do not rediscover HEAD/range support on every run.
+
+Key columns:
+- `host`
+- `head_ok`, `accept_ranges`
+- `updated_at`
+
+### model_metadata
+
+Stores library metadata for downloaded or scanned models. The logical key is `download_url`.
+
+Key columns:
+- `download_url`, `dest`
+- `model_name`, `model_id`, `version`, `source`
+- `description`, `author`, `license`, `tags`
+- `model_type`, `base_model`, `architecture`, `parameter_count`, `quantization`
+- `file_size`, `file_format`
+- `download_count`, `last_used`, `times_used`
+- `homepage_url`, `repo_url`, `documentation_url`, `author_url`, `thumbnail_url`
+- `user_notes`, `user_rating`, `favorite`
+- `created_at`, `updated_at`
+
+Indexes:
+- `idx_metadata_source`
+- `idx_metadata_type`
+- `idx_metadata_favorite`
+- `idx_metadata_last_used`
+- `idx_metadata_updated_at`
+- `idx_metadata_dest`
+- `idx_metadata_model_name`
+
+## Migration notes
+
+Version `1` preserves the current table layout. Future v1.x migrations should advance `PRAGMA user_version` and keep compatibility shims explicit rather than relying on silent best-effort `ALTER TABLE` calls.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,7 +69,8 @@ Performance optimizations
 Breaking changes to consider for v1.0
 - Config schema tidy-up [WIP]
   - `modfetch config validate --strict` rejects unknown YAML fields before strict validation becomes a v1.0 default candidate [IMPL]
-- State DB schema simplification
+- State DB schema simplification [WIP]
+  - State DB bootstrap is centralized and stamps SQLite `user_version` as the v1.0 migration baseline [IMPL]
 - Standardize CLI flags and naming [WIP]
   - Shared config path resolution across config-backed commands; `place` now honors the documented default config path [IMPL]
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -14,6 +14,8 @@ import (
 	"github.com/jxwalker/modfetch/internal/config"
 )
 
+const SchemaVersion = 1
+
 type DB struct {
 	SQL  *sql.DB
 	Path string
@@ -117,35 +119,27 @@ func Open(cfg *config.Config) (*DB, error) {
 		return nil, err
 	}
 	path := filepath.Join(cfg.General.DataRoot, "state.db")
-	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout=5000&_pragma=journal_mode(WAL)&_fk=1", path)
-	sqldb, err := sql.Open("sqlite", dsn)
-	if err != nil {
-		return nil, err
-	}
-	if err := initSchema(sqldb); err != nil {
-		return nil, err
-	}
-	db := &DB{SQL: sqldb, Path: path}
-	if err := db.prepareStatements(); err != nil {
-		return nil, err
-	}
-	if err := db.InitChunksTable(); err != nil {
-		return nil, err
-	}
-	if err := db.InitHostCapsTable(); err != nil {
-		return nil, err
-	}
-	if err := db.InitMetadataTable(); err != nil {
-		return nil, err
-	}
-	return db, nil
+	return openAtPath(path)
 }
 
 // NewDB opens a database at the specified path (for testing)
 func NewDB(path string) (*DB, error) {
+	return openAtPath(path)
+}
+
+func openAtPath(path string) (*DB, error) {
 	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout=5000&_pragma=journal_mode(WAL)&_fk=1", path)
 	sqldb, err := sql.Open("sqlite", dsn)
 	if err != nil {
+		return nil, err
+	}
+	ready := false
+	defer func() {
+		if !ready {
+			_ = sqldb.Close()
+		}
+	}()
+	if err := rejectNewerSchemaVersion(sqldb); err != nil {
 		return nil, err
 	}
 	if err := initSchema(sqldb); err != nil {
@@ -164,6 +158,10 @@ func NewDB(path string) (*DB, error) {
 	if err := db.InitMetadataTable(); err != nil {
 		return nil, err
 	}
+	if err := ensureSchemaVersion(sqldb); err != nil {
+		return nil, err
+	}
+	ready = true
 	return db, nil
 }
 
@@ -195,9 +193,52 @@ func initSchema(db *sql.DB) error {
 		}
 	}
 	// Try to add new columns in case of existing DB without them
-	_, _ = db.Exec(`ALTER TABLE downloads ADD COLUMN actual_sha256 TEXT`)
-	_, _ = db.Exec(`ALTER TABLE downloads ADD COLUMN retries INTEGER DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE downloads ADD COLUMN last_error TEXT`)
+	if err := addColumnIfNotExists(db, `ALTER TABLE downloads ADD COLUMN actual_sha256 TEXT`); err != nil {
+		return err
+	}
+	if err := addColumnIfNotExists(db, `ALTER TABLE downloads ADD COLUMN retries INTEGER DEFAULT 0`); err != nil {
+		return err
+	}
+	if err := addColumnIfNotExists(db, `ALTER TABLE downloads ADD COLUMN last_error TEXT`); err != nil {
+		return err
+	}
+	return nil
+}
+
+func addColumnIfNotExists(db *sql.DB, stmt string) error {
+	_, err := db.Exec(stmt)
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "duplicate column name") {
+		return nil
+	}
+	return err
+}
+
+func rejectNewerSchemaVersion(db *sql.DB) error {
+	var current int
+	if err := db.QueryRow(`PRAGMA user_version`).Scan(&current); err != nil {
+		return err
+	}
+	if current > SchemaVersion {
+		return fmt.Errorf("database schema version %d is newer than supported version %d", current, SchemaVersion)
+	}
+	return nil
+}
+
+func ensureSchemaVersion(db *sql.DB) error {
+	var current int
+	if err := db.QueryRow(`PRAGMA user_version`).Scan(&current); err != nil {
+		return err
+	}
+	if current > SchemaVersion {
+		return fmt.Errorf("database schema version %d is newer than supported version %d", current, SchemaVersion)
+	}
+	if current < SchemaVersion {
+		_, err := db.Exec(fmt.Sprintf(`PRAGMA user_version = %d`, SchemaVersion))
+		return err
+	}
 	return nil
 }
 

--- a/internal/state/state_coverage_test.go
+++ b/internal/state/state_coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -65,6 +66,41 @@ func TestChunkLifecycleTxAndDirectUpdates(t *testing.T) {
 	}
 	if len(chunks) != 0 {
 		t.Fatalf("expected chunks deleted, got %+v", chunks)
+	}
+}
+
+func TestNewDBInitializesSchemaVersion(t *testing.T) {
+	db := testDownloadDB(t)
+	var got int
+	if err := db.SQL.QueryRow(`PRAGMA user_version`).Scan(&got); err != nil {
+		t.Fatalf("query user_version: %v", err)
+	}
+	if got != SchemaVersion {
+		t.Fatalf("schema version = %d; want %d", got, SchemaVersion)
+	}
+}
+
+func TestNewDBRejectsNewerSchemaVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	raw, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(`PRAGMA user_version = 999`); err != nil {
+		_ = raw.Close()
+		t.Fatal(err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := NewDB(path)
+	if err == nil {
+		_ = db.Close()
+		t.Fatal("expected newer schema version to be rejected")
+	}
+	if !strings.Contains(err.Error(), "newer than supported") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- centralize state DB opening/bootstrap for Open and NewDB
- stamp SQLite PRAGMA user_version as the current schema migration baseline
- document the current state database tables and update the v1.0 roadmap item

## Tests
- go test ./internal/state -timeout 180s
- go test ./... -timeout 180s