### PR TITLE
Validate documented config schema values

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -16,7 +16,7 @@ Quick start: interactive wizard
 - `general`
   - `data_root`: State DB, logs, metrics root
   - `download_root`: Where partial and finished downloads are staged before placement
-  - `placement_mode`: `symlink` | `hardlink` | `copy`
+  - `placement_mode`: `symlink` | `hardlink` | `copy` (optional for configs that do not use placement; provide `--mode` when placing if omitted)
   - `quarantine`: true|false (quarantine until checksum verified)
   - `allow_overwrite`: true|false
   - `stage_partials`: true|false (default true). When true, .part files are written under `download_root/.parts` (or `partials_root` if set) and moved atomically on completion.
@@ -32,7 +32,7 @@ Quick start: interactive wizard
   - `upload_sha256_file`: when true, upload the generated `.sha256` sidecar next to the object.
   - Use an explicit destination like `--dest s3://bucket/path/model.gguf`; modfetch downloads to a resumable local staging path under `data_root/s3-staging`, verifies locally, uploads the artifact, and records the final `s3://` URI in state.
 - `network`
-  - `timeout_seconds`, `max_redirects`, `tls_verify`, `user_agent`
+  - `timeout_seconds`, `max_redirects`, `tls_verify`, `user_agent` (`timeout_seconds` and `max_redirects` must be >= 0; `max_redirects: 0` uses the default limit)
   - `global_bandwidth_bytes_per_second`: optional process-wide bandwidth cap in bytes/second; 0 or omitted means unlimited.
   - `per_download_bandwidth_bytes_per_second`: optional per-download bandwidth cap in bytes/second; 0 or omitted means unlimited.
   - `dns_cache_ttl_seconds`: optional DNS cache TTL in seconds for repeated hosts; 0 or omitted disables caching.
@@ -59,7 +59,7 @@ Quick start: interactive wizard
   - `require_sha256`, `accept_md5_sha1_if_provided`
   - `safetensors_deep_verify_after_download`: when true, perform deep coverage/length verification of .safetensors files immediately after download; fail the command if invalid
 - `ui`
-  - `refresh_hz`, `column_mode`, `compact`, `theme`
+  - `refresh_hz`, `column_mode`, `compact`, `theme` (`refresh_hz` must be >= 0; `column_mode` may be omitted or set to `dest`, `url`, or `host`)
 
 See `assets/sample-config/config.example.yml` for a full example.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,6 +69,7 @@ Performance optimizations
 Breaking changes to consider for v1.0
 - Config schema tidy-up [WIP]
   - `modfetch config validate --strict` rejects unknown YAML fields before strict validation becomes a v1.0 default candidate [IMPL]
+  - Documented enum/range values are validated for placement mode, network timeout/redirect settings, and TUI column mode [IMPL]
 - State DB schema simplification [WIP]
   - State DB bootstrap is centralized and stamps SQLite `user_version` as the v1.0 migration baseline [IMPL]
 - Standardize CLI flags and naming [WIP]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -271,6 +271,19 @@ func (c *Config) Validate() error {
 	if c.General.DownloadRoot == "" {
 		return errors.New("general.download_root is required")
 	}
+	placementMode := stringsLower(strings.TrimSpace(c.General.PlacementMode))
+	switch placementMode {
+	case "", "symlink", "hardlink", "copy":
+		c.General.PlacementMode = placementMode
+	default:
+		return fmt.Errorf("general.placement_mode invalid: %s", c.General.PlacementMode)
+	}
+	if c.Network.TimeoutSeconds < 0 {
+		return fmt.Errorf("network.timeout_seconds must be >= 0")
+	}
+	if c.Network.MaxRedirects < 0 {
+		return fmt.Errorf("network.max_redirects must be >= 0")
+	}
 	if c.Resolver.CacheTTLHours < 0 {
 		return fmt.Errorf("resolver.cache_ttl_hours must be >= 0")
 	}
@@ -334,6 +347,13 @@ func (c *Config) Validate() error {
 	}
 	if c.UI.RefreshHz < 0 {
 		return fmt.Errorf("ui.refresh_hz must be >= 0")
+	}
+	columnMode := stringsLower(strings.TrimSpace(c.UI.ColumnMode))
+	switch columnMode {
+	case "", "dest", "url", "host":
+		c.UI.ColumnMode = columnMode
+	default:
+		return fmt.Errorf("ui.column_mode invalid: %s", c.UI.ColumnMode)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -84,6 +84,96 @@ func TestValidateRejectsNegativeDNSCacheTTL(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsInvalidDocumentedSchemaValues(t *testing.T) {
+	base := Config{
+		Version: 1,
+		General: General{
+			DataRoot:     t.TempDir(),
+			DownloadRoot: t.TempDir(),
+		},
+	}
+
+	tests := []struct {
+		name string
+		edit func(*Config)
+		want string
+	}{
+		{
+			name: "placement mode",
+			edit: func(c *Config) { c.General.PlacementMode = "move" },
+			want: "general.placement_mode invalid",
+		},
+		{
+			name: "network timeout",
+			edit: func(c *Config) { c.Network.TimeoutSeconds = -1 },
+			want: "network.timeout_seconds must be >= 0",
+		},
+		{
+			name: "network redirects",
+			edit: func(c *Config) { c.Network.MaxRedirects = -1 },
+			want: "network.max_redirects must be >= 0",
+		},
+		{
+			name: "ui column mode",
+			edit: func(c *Config) { c.UI.ColumnMode = "filename" },
+			want: "ui.column_mode invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := base
+			tt.edit(&c)
+			err := c.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q validation error, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestValidateAcceptsDocumentedSchemaValues(t *testing.T) {
+	for _, placementMode := range []string{"", "symlink", "hardlink", "copy"} {
+		for _, columnMode := range []string{"", "dest", "url", "host"} {
+			t.Run(placementMode+"/"+columnMode, func(t *testing.T) {
+				c := Config{
+					Version: 1,
+					General: General{
+						DataRoot:      t.TempDir(),
+						DownloadRoot:  t.TempDir(),
+						PlacementMode: placementMode,
+					},
+					UI: UIOptions{ColumnMode: columnMode},
+				}
+				if err := c.Validate(); err != nil {
+					t.Fatalf("expected documented values to validate, got %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestValidateNormalizesDocumentedSchemaValues(t *testing.T) {
+	c := Config{
+		Version: 1,
+		General: General{
+			DataRoot:      t.TempDir(),
+			DownloadRoot:  t.TempDir(),
+			PlacementMode: " HardLink ",
+		},
+		UI: UIOptions{ColumnMode: " URL "},
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("expected mixed-case documented values to validate, got %v", err)
+	}
+	if c.General.PlacementMode != "hardlink" {
+		t.Fatalf("expected normalized placement mode, got %q", c.General.PlacementMode)
+	}
+	if c.UI.ColumnMode != "url" {
+		t.Fatalf("expected normalized column mode, got %q", c.UI.ColumnMode)
+	}
+}
+
 func TestValidateS3RequiresCredentialsWhenEndpointConfigured(t *testing.T) {
 	t.Setenv("MODFETCH_TEST_S3_ACCESS", "")
 	t.Setenv("MODFETCH_TEST_S3_SECRET", "")

--- a/internal/downloader/httpclient.go
+++ b/internal/downloader/httpclient.go
@@ -30,10 +30,14 @@ type cachingDialer struct {
 
 func newHTTPClient(cfg *config.Config) *http.Client {
 	timeoutSeconds := 0
+	maxRedirects := 10
 	perHost := 10
 	tlsVerify := true
 	if cfg != nil {
 		timeoutSeconds = cfg.Network.TimeoutSeconds
+		if cfg.Network.MaxRedirects > 0 {
+			maxRedirects = cfg.Network.MaxRedirects
+		}
 		tlsVerify = cfg.Network.TLSVerify
 		if cfg.Concurrency.PerHostRequests > 0 {
 			perHost = cfg.Concurrency.PerHostRequests
@@ -76,6 +80,9 @@ func newHTTPClient(cfg *config.Config) *http.Client {
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) == 0 {
 			return nil
+		}
+		if len(via) > maxRedirects {
+			return fmt.Errorf("stopped after %d redirects", maxRedirects)
 		}
 		prev := via[len(via)-1]
 		if ua := prev.Header.Get("User-Agent"); ua != "" {

--- a/internal/downloader/httpclient_test.go
+++ b/internal/downloader/httpclient_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/jxwalker/modfetch/internal/config"
@@ -42,6 +44,29 @@ func TestNewHTTPClientHonorsTLSVerify(t *testing.T) {
 	}
 	if tr.TLSClientConfig == nil || !tr.TLSClientConfig.InsecureSkipVerify {
 		t.Fatal("expected TLS verification to be disabled")
+	}
+}
+
+func TestNewHTTPClientHonorsMaxRedirects(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/start":
+			http.Redirect(w, r, "/one", http.StatusFound)
+		case "/one":
+			http.Redirect(w, r, "/two", http.StatusFound)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := newHTTPClient(&config.Config{Network: config.Network{MaxRedirects: 1}})
+	resp, err := client.Get(server.URL + "/start")
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "stopped after 1 redirects") {
+		t.Fatalf("expected redirect limit error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- validate documented enum/range config values for placement mode, network timeout/redirects, and TUI column mode
- cover valid and invalid schema values with config tests
- update config docs and roadmap traceability

## Tests
- go test ./internal/config -timeout 180s
- go test ./... -count=1 -timeout 180s