### PR TITLE
Make state schema migration explicit

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -71,4 +71,9 @@ Indexes:
 
 ## Migration notes
 
-Version `1` preserves the current table layout. Future v1.x migrations should advance `PRAGMA user_version` and keep compatibility shims explicit rather than relying on silent best-effort `ALTER TABLE` calls.
+Version `1` preserves the current table layout. Databases with `PRAGMA user_version = 0`
+are migrated through an explicit v0-to-v1 step that adds the legacy `downloads`
+columns introduced before the schema version baseline: `actual_sha256`,
+`retries`, and `last_error`. Future v1.x migrations should advance
+`PRAGMA user_version` and keep compatibility shims explicit rather than relying
+on silent best-effort `ALTER TABLE` calls.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -72,6 +72,7 @@ Breaking changes to consider for v1.0
   - Documented enum/range values are validated for placement mode, network timeout/redirect settings, and TUI column mode [IMPL]
 - State DB schema simplification [WIP]
   - State DB bootstrap is centralized and stamps SQLite `user_version` as the v1.0 migration baseline [IMPL]
+  - Legacy version-0 download schemas migrate through an explicit v0-to-v1 path for missing compatibility columns [IMPL]
 - Standardize CLI flags and naming [WIP]
   - Shared config path resolution across config-backed commands; `place` now honors the documented default config path [IMPL]
   - Shell completions are aligned with current commands and flags, including `hostcaps`, strict config validation, quantization selection, and dry-run variants [IMPL]

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -139,10 +139,10 @@ func openAtPath(path string) (*DB, error) {
 			_ = sqldb.Close()
 		}
 	}()
-	if err := rejectNewerSchemaVersion(sqldb); err != nil {
+	if err := initSchema(sqldb); err != nil {
 		return nil, err
 	}
-	if err := initSchema(sqldb); err != nil {
+	if err := migrateSchema(sqldb); err != nil {
 		return nil, err
 	}
 	db := &DB{SQL: sqldb, Path: path}
@@ -156,9 +156,6 @@ func openAtPath(path string) (*DB, error) {
 		return nil, err
 	}
 	if err := db.InitMetadataTable(); err != nil {
-		return nil, err
-	}
-	if err := ensureSchemaVersion(sqldb); err != nil {
 		return nil, err
 	}
 	ready = true
@@ -192,54 +189,88 @@ func initSchema(db *sql.DB) error {
 			return err
 		}
 	}
-	// Try to add new columns in case of existing DB without them
-	if err := addColumnIfNotExists(db, `ALTER TABLE downloads ADD COLUMN actual_sha256 TEXT`); err != nil {
+	return nil
+}
+
+func migrateSchema(db *sql.DB) error {
+	var current int
+	if err := db.QueryRow(`PRAGMA user_version`).Scan(&current); err != nil {
 		return err
 	}
-	if err := addColumnIfNotExists(db, `ALTER TABLE downloads ADD COLUMN retries INTEGER DEFAULT 0`); err != nil {
-		return err
+	if current > SchemaVersion {
+		return fmt.Errorf("database schema version %d is newer than supported version %d", current, SchemaVersion)
 	}
-	if err := addColumnIfNotExists(db, `ALTER TABLE downloads ADD COLUMN last_error TEXT`); err != nil {
-		return err
+	for current < SchemaVersion {
+		switch current {
+		case 0:
+			if err := migrateSchema0To1(db); err != nil {
+				return err
+			}
+			current = 1
+		default:
+			return fmt.Errorf("unsupported database schema version: %d", current)
+		}
 	}
 	return nil
 }
 
-func addColumnIfNotExists(db *sql.DB, stmt string) error {
-	_, err := db.Exec(stmt)
-	if err == nil {
-		return nil
+func migrateSchema0To1(db *sql.DB) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
 	}
-	if strings.Contains(strings.ToLower(err.Error()), "duplicate column name") {
-		return nil
+	existingColumns, err := downloadColumns(tx)
+	if err != nil {
+		return err
 	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	columns := []struct {
+		name       string
+		definition string
+	}{
+		{name: "actual_sha256", definition: "actual_sha256 TEXT"},
+		{name: "retries", definition: "retries INTEGER DEFAULT 0"},
+		{name: "last_error", definition: "last_error TEXT"},
+	}
+	for _, col := range columns {
+		if existingColumns[col.name] {
+			continue
+		}
+		if _, err := tx.Exec(`ALTER TABLE downloads ADD COLUMN ` + col.definition); err != nil {
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
+	_, err = db.Exec(`PRAGMA user_version = 1`)
 	return err
 }
 
-func rejectNewerSchemaVersion(db *sql.DB) error {
-	var current int
-	if err := db.QueryRow(`PRAGMA user_version`).Scan(&current); err != nil {
-		return err
+func downloadColumns(tx *sql.Tx) (map[string]bool, error) {
+	rows, err := tx.Query(`PRAGMA table_info(downloads)`)
+	if err != nil {
+		return nil, err
 	}
-	if current > SchemaVersion {
-		return fmt.Errorf("database schema version %d is newer than supported version %d", current, SchemaVersion)
+	defer func() { _ = rows.Close() }()
+	columns := map[string]bool{}
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull, pk int
+		var defaultValue sql.NullString
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return nil, err
+		}
+		columns[name] = true
 	}
-	return nil
-}
-
-func ensureSchemaVersion(db *sql.DB) error {
-	var current int
-	if err := db.QueryRow(`PRAGMA user_version`).Scan(&current); err != nil {
-		return err
-	}
-	if current > SchemaVersion {
-		return fmt.Errorf("database schema version %d is newer than supported version %d", current, SchemaVersion)
-	}
-	if current < SchemaVersion {
-		_, err := db.Exec(fmt.Sprintf(`PRAGMA user_version = %d`, SchemaVersion))
-		return err
-	}
-	return nil
+	return columns, rows.Err()
 }
 
 func (db *DB) prepareStatements() error {

--- a/internal/state/state_coverage_test.go
+++ b/internal/state/state_coverage_test.go
@@ -104,6 +104,107 @@ func TestNewDBRejectsNewerSchemaVersion(t *testing.T) {
 	}
 }
 
+func TestNewDBMigratesLegacyVersionZeroDownloadsSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	raw, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = raw.Exec(`CREATE TABLE downloads (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		url TEXT NOT NULL,
+		dest TEXT NOT NULL,
+		expected_sha256 TEXT,
+		etag TEXT,
+		last_modified TEXT,
+		size INTEGER,
+		status TEXT,
+		created_at INTEGER NOT NULL,
+		updated_at INTEGER NOT NULL,
+		UNIQUE(url, dest)
+	);
+	INSERT INTO downloads(url, dest, expected_sha256, etag, last_modified, size, status, created_at, updated_at)
+	VALUES('https://example.com/legacy.bin', '/tmp/legacy.bin', 'expected', 'etag', 'lastmod', 42, 'complete', 1, 2);`)
+	if err != nil {
+		_ = raw.Close()
+		t.Fatal(err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := NewDB(path)
+	if err != nil {
+		t.Fatalf("open migrated db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var version int
+	if err := db.SQL.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
+		t.Fatalf("query user_version: %v", err)
+	}
+	if version != SchemaVersion {
+		t.Fatalf("schema version = %d; want %d", version, SchemaVersion)
+	}
+	for _, column := range []string{"actual_sha256", "retries", "last_error"} {
+		ok, err := downloadsTableHasColumn(db.SQL, column)
+		if err != nil {
+			t.Fatalf("check column %s: %v", column, err)
+		}
+		if !ok {
+			t.Fatalf("expected migrated downloads.%s column", column)
+		}
+	}
+
+	rows, err := db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list migrated downloads: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected one legacy row, got %d", len(rows))
+	}
+	if rows[0].ActualSHA256 != "" || rows[0].Retries != 0 || rows[0].LastError != "" {
+		t.Fatalf("expected migrated defaults, got %+v", rows[0])
+	}
+
+	rows[0].ActualSHA256 = "actual"
+	rows[0].LastError = "kept"
+	if err := db.UpsertDownload(rows[0]); err != nil {
+		t.Fatalf("upsert migrated row: %v", err)
+	}
+	if err := db.IncDownloadRetries(rows[0].URL, rows[0].Dest, 3); err != nil {
+		t.Fatalf("increment migrated retries: %v", err)
+	}
+	rows, err = db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list after migrated upsert: %v", err)
+	}
+	if rows[0].ActualSHA256 != "actual" || rows[0].Retries != 3 || rows[0].LastError != "kept" {
+		t.Fatalf("expected migrated columns to be writable, got %+v", rows[0])
+	}
+}
+
+func downloadsTableHasColumn(db *sql.DB, column string) (bool, error) {
+	rows, err := db.Query(`PRAGMA table_info(downloads)`)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull, pk int
+		var defaultValue sql.NullString
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
 func TestDownloadStatusRetriesAndDelete(t *testing.T) {
 	db := testDownloadDB(t)
 	row := DownloadRow{URL: "https://example.com/a", Dest: "/tmp/a.bin", Status: "pending"}


### PR DESCRIPTION
## Summary
- replace best-effort download column ALTER calls with an explicit v0-to-v1 schema migration
- preserve fresh database bootstrap while stamping PRAGMA user_version through the migration path
- add a legacy version-0 downloads schema test that verifies migrated columns, defaults, and writeability
- document the explicit migration in database docs and roadmap

## Tests
- go test ./internal/state -timeout 180s
- go test ./... -count=1 -timeout 180s