### PR TITLE
Centralize common CLI flags

### DIFF
--- a/cmd/modfetch/batch_cmd.go
+++ b/cmd/modfetch/batch_cmd.go
@@ -35,9 +35,7 @@ func handleBatch(ctx context.Context, args []string) error {
 
 func handleBatchImport(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("batch import", flag.ContinueOnError)
-	cfgPath := fs.String("config", "", "Path to YAML config file")
-	logLevel := fs.String("log-level", "info", "log level")
-	jsonOut := fs.Bool("json", false, "json logs")
+	common := addCommonConfigLogFlags(fs, "")
 	inPath := fs.String("input", "", "Text file with URLs (one per line). Supports optional key=value pairs after the URL: dest=... sha256=... type=... place=true mode=symlink")
 	outPath := fs.String("output", "", "Output batch YAML path (default: stdout)")
 	destDir := fs.String("dest-dir", "", "Destination directory override (default: config.general.download_root)")
@@ -53,11 +51,11 @@ func handleBatchImport(ctx context.Context, args []string) error {
 	if *inPath == "" {
 		return errors.New("--input is required")
 	}
-	c, _, err := loadConfig(*cfgPath)
+	c, _, err := loadConfig(*common.configPath)
 	if err != nil {
 		return err
 	}
-	log := logging.New(*logLevel, *jsonOut)
+	log := logging.New(*common.logLevel, *common.jsonOut)
 
 	f, err := os.Open(*inPath)
 	if err != nil {

--- a/cmd/modfetch/common_flags.go
+++ b/cmd/modfetch/common_flags.go
@@ -1,0 +1,24 @@
+package main
+
+import "flag"
+
+type commonConfigLogFlags struct {
+	configPath *string
+	logLevel   *string
+	jsonOut    *bool
+}
+
+func addCommonConfigLogFlags(fs *flag.FlagSet, jsonUsage string) commonConfigLogFlags {
+	if jsonUsage == "" {
+		jsonUsage = "json logs"
+	}
+	return commonConfigLogFlags{
+		configPath: fs.String("config", "", "Path to YAML config file"),
+		logLevel:   fs.String("log-level", "info", "log level"),
+		jsonOut:    fs.Bool("json", false, jsonUsage),
+	}
+}
+
+func addConfigPathFlag(fs *flag.FlagSet) *string {
+	return fs.String("config", "", "Path to YAML config file")
+}

--- a/cmd/modfetch/common_flags_test.go
+++ b/cmd/modfetch/common_flags_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestAddCommonConfigLogFlags(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	common := addCommonConfigLogFlags(fs, "")
+	if err := fs.Parse([]string{"--config", "/tmp/config.yml", "--log-level", "debug", "--json"}); err != nil {
+		t.Fatalf("parse common flags: %v", err)
+	}
+	if *common.configPath != "/tmp/config.yml" {
+		t.Fatalf("config path = %q", *common.configPath)
+	}
+	if *common.logLevel != "debug" {
+		t.Fatalf("log level = %q", *common.logLevel)
+	}
+	if !*common.jsonOut {
+		t.Fatal("expected json flag to be true")
+	}
+}
+
+func TestAddConfigPathFlag(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfgPath := addConfigPathFlag(fs)
+	if err := fs.Parse([]string{"--config", "/tmp/config.yml"}); err != nil {
+		t.Fatalf("parse config flag: %v", err)
+	}
+	if *cfgPath != "/tmp/config.yml" {
+		t.Fatalf("config path = %q", *cfgPath)
+	}
+}

--- a/cmd/modfetch/hostcaps.go
+++ b/cmd/modfetch/hostcaps.go
@@ -14,7 +14,7 @@ import (
 
 func handleHostCaps(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("hostcaps", flag.ContinueOnError)
-	cfgPath := fs.String("config", "", "Path to YAML config file")
+	cfgPath := addConfigPathFlag(fs)
 	list := fs.Bool("list", false, "List cached host capabilities")
 	clear := fs.String("clear", "", "Clear cache for a specific host")
 	clearAll := fs.Bool("clear-all", false, "Clear cache for all hosts")

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -120,21 +120,19 @@ Flags:
 
 func handleStatus(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("status", flag.ContinueOnError)
-	cfgPath := fs.String("config", "", "Path to YAML config file")
-	logLevel := fs.String("log-level", "info", "log level")
-	jsonOut := fs.Bool("json", false, "json logs")
+	common := addCommonConfigLogFlags(fs, "")
 	onlyErrors := fs.Bool("only-errors", false, "show only rows with error-like statuses (error, checksum_mismatch, verify_failed)")
 	summary := fs.Bool("summary", false, "print totals and error count")
 	duplicates := fs.Bool("duplicates", false, "show completed downloads with duplicate SHA256 content")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	c, _, err := loadConfig(*cfgPath)
+	c, _, err := loadConfig(*common.configPath)
 	if err != nil {
 		return err
 	}
 	_ = c // currently unused; reserved for future filters
-	log := logging.New(*logLevel, *jsonOut)
+	log := logging.New(*common.logLevel, *common.jsonOut)
 	st, err := state.Open(c)
 	if err != nil {
 		return err
@@ -146,7 +144,7 @@ func handleStatus(ctx context.Context, args []string) error {
 	}
 	if *duplicates {
 		groups := duplicateDownloadGroups(rows)
-		if *jsonOut {
+		if *common.jsonOut {
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
 			return enc.Encode(groups)
@@ -172,7 +170,7 @@ func handleStatus(ctx context.Context, args []string) error {
 		}
 		rows = filt
 	}
-	if *jsonOut {
+	if *common.jsonOut {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		if *summary {
@@ -204,19 +202,17 @@ type dedupeResult struct {
 
 func handleDedupe(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("dedupe", flag.ContinueOnError)
-	cfgPath := fs.String("config", "", "Path to YAML config file")
-	logLevel := fs.String("log-level", "info", "log level")
-	jsonOut := fs.Bool("json", false, "json logs")
+	common := addCommonConfigLogFlags(fs, "")
 	mode := fs.String("mode", "hardlink", "dedupe mode: hardlink|symlink")
 	dryRun := fs.Bool("dry-run", false, "show changes without modifying files")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	c, _, err := loadConfig(*cfgPath)
+	c, _, err := loadConfig(*common.configPath)
 	if err != nil {
 		return err
 	}
-	log := logging.New(*logLevel, *jsonOut)
+	log := logging.New(*common.logLevel, *common.jsonOut)
 	st, err := state.Open(c)
 	if err != nil {
 		return err
@@ -227,7 +223,7 @@ func handleDedupe(ctx context.Context, args []string) error {
 		return err
 	}
 	results := dedupeDuplicateGroups(duplicateDownloadGroups(rows), strings.ToLower(strings.TrimSpace(*mode)), *dryRun)
-	if *jsonOut {
+	if *common.jsonOut {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		return enc.Encode(results)
@@ -265,21 +261,19 @@ func handleConfig(ctx context.Context, args []string) error {
 
 func configValidate(args []string) error {
 	fs := flag.NewFlagSet("config validate", flag.ContinueOnError)
-	cfgPath := fs.String("config", "", "Path to YAML config file")
-	logLevel := fs.String("log-level", "info", "log level")
-	jsonOut := fs.Bool("json", false, "json logs")
+	common := addCommonConfigLogFlags(fs, "")
 	strict := fs.Bool("strict", false, "reject unknown config fields")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	resolvedCfgPath, err := resolveConfigPath(*cfgPath)
+	resolvedCfgPath, err := resolveConfigPath(*common.configPath)
 	if err != nil {
 		return err
 	}
 	if err := loadConfigForValidation(resolvedCfgPath, *strict); err != nil {
 		return err
 	}
-	log := logging.New(*logLevel, *jsonOut)
+	log := logging.New(*common.logLevel, *common.jsonOut)
 	log.Infof("config: valid")
 	return nil
 }
@@ -302,9 +296,7 @@ func loadConfigForValidation(path string, strict bool) error {
 
 func handleDownload(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("download", flag.ContinueOnError)
-	cfgPath := fs.String("config", "", "Path to YAML config file")
-	logLevel := fs.String("log-level", "info", "log level")
-	jsonOut := fs.Bool("json", false, "json logs")
+	common := addCommonConfigLogFlags(fs, "")
 	quiet := fs.Bool("quiet", false, "suppress progress and info logs (errors only)")
 	noResume := fs.Bool("no-resume", false, "do not resume; start fresh (delete any staged .part and chunk state)")
 	url := fs.String("url", "", "HTTP URL to download (direct) or resolver URI (e.g. hf://owner/repo/path)")
@@ -325,7 +317,7 @@ func handleDownload(ctx context.Context, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	c, _, err := loadConfig(*cfgPath)
+	c, _, err := loadConfig(*common.configPath)
 	if err != nil {
 		return err
 	}
@@ -340,10 +332,10 @@ func handleDownload(ctx context.Context, args []string) error {
 		return errors.New("s3 destinations cannot be combined with --extract or --place")
 	}
 	// quiet forces log level to error unless JSON is requested
-	if *quiet && !*jsonOut {
-		*logLevel = "error"
+	if *quiet && !*common.jsonOut {
+		*common.logLevel = "error"
 	}
-	log := logging.New(*logLevel, *jsonOut)
+	log := logging.New(*common.logLevel, *common.jsonOut)
 	st, err := state.Open(c)
 	if err != nil {
 		return err
@@ -799,7 +791,7 @@ func handleDownload(ctx context.Context, args []string) error {
 	// Prefer chunked downloader; it will fall back to single when needed
 	// Progress display (disabled for JSON or quiet)
 	var stopProg func()
-	if !*jsonOut && !*quiet {
+	if !*common.jsonOut && !*quiet {
 		candDest := strings.TrimSpace(*dest)
 		// Determine the resolver URI (could have been normalized above)
 		resolverURI := resolvedURL
@@ -886,7 +878,7 @@ func handleDownload(ctx context.Context, args []string) error {
 			"status":    "ok",
 			"extracted": extracted,
 		})
-	} else if !*jsonOut && !*quiet {
+	} else if !*common.jsonOut && !*quiet {
 		var rate string
 		if dur > 0 && size > 0 {
 			rate = humanize.Bytes(uint64(float64(size)/dur)) + "/s"
@@ -913,9 +905,7 @@ func handleDownload(ctx context.Context, args []string) error {
 
 func handlePlace(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("place", flag.ContinueOnError)
-	cfgPath := fs.String("config", "", "Path to YAML config file")
-	logLevel := fs.String("log-level", "info", "log level")
-	jsonOut := fs.Bool("json", false, "json logs")
+	common := addCommonConfigLogFlags(fs, "")
 	filePath := fs.String("path", "", "path to file to place")
 	artType := fs.String("type", "", "artifact type override (optional)")
 	mode := fs.String("mode", "", "placement mode override: symlink|hardlink|copy (optional)")
@@ -926,11 +916,11 @@ func handlePlace(ctx context.Context, args []string) error {
 	if *filePath == "" {
 		return errors.New("--path is required")
 	}
-	c, _, err := loadConfig(*cfgPath)
+	c, _, err := loadConfig(*common.configPath)
 	if err != nil {
 		return err
 	}
-	log := logging.New(*logLevel, *jsonOut)
+	log := logging.New(*common.logLevel, *common.jsonOut)
 	if *dryRun {
 		atype := *artType
 		if atype == "" {
@@ -958,9 +948,7 @@ func handlePlace(ctx context.Context, args []string) error {
 
 func handleClean(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("clean", flag.ContinueOnError)
-	cfgPath := fs.String("config", "", "Path to YAML config file")
-	logLevel := fs.String("log-level", "info", "log level")
-	jsonOut := fs.Bool("json", false, "json logs")
+	common := addCommonConfigLogFlags(fs, "")
 	days := fs.Int("days", 7, "remove .part files older than this many days (0 = remove all)")
 	dryRun := fs.Bool("dry-run", false, "show what would be removed, but do not delete")
 	destPath := fs.String("dest", "", "remove staged .part for this destination path (overrides days)")
@@ -969,11 +957,11 @@ func handleClean(ctx context.Context, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	c, _, err := loadConfig(*cfgPath)
+	c, _, err := loadConfig(*common.configPath)
 	if err != nil {
 		return err
 	}
-	log := logging.New(*logLevel, *jsonOut)
+	log := logging.New(*common.logLevel, *common.jsonOut)
 
 	removed := 0
 	skipped := 0
@@ -1104,7 +1092,7 @@ func handleClean(ctx context.Context, args []string) error {
 		}
 	}
 
-	if *jsonOut {
+	if *common.jsonOut {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		return enc.Encode(map[string]any{"removed": removed, "skipped": skipped, "sidecars_removed": sideRemoved, "errors": errs})
@@ -1151,17 +1139,15 @@ func resolveBatchDownloadCandidate(ctx context.Context, c *config.Config, uri st
 
 func configOp(args []string, fn func(*config.Config, *logging.Logger) error) error {
 	fs := flag.NewFlagSet("config", flag.ContinueOnError)
-	cfgPath := fs.String("config", "", "Path to YAML config file")
-	logLevel := fs.String("log-level", "info", "log level")
-	jsonOut := fs.Bool("json", false, "json logs")
+	common := addCommonConfigLogFlags(fs, "")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	c, _, err := loadConfig(*cfgPath)
+	c, _, err := loadConfig(*common.configPath)
 	if err != nil {
 		return err
 	}
-	log := logging.New(*logLevel, *jsonOut)
+	log := logging.New(*common.logLevel, *common.jsonOut)
 	return fn(c, log)
 }
 

--- a/cmd/modfetch/tui_cmd.go
+++ b/cmd/modfetch/tui_cmd.go
@@ -19,13 +19,11 @@ import (
 
 func handleTUI(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("tui", flag.ContinueOnError)
-	cfgPath := fs.String("config", "", "Path to YAML config file")
-	logLevel := fs.String("log-level", "info", "log level")
-	jsonOut := fs.Bool("json", false, "json logs (not used in TUI)")
+	common := addCommonConfigLogFlags(fs, "json logs (not used in TUI)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	resolvedCfgPath, err := resolveConfigPath(*cfgPath)
+	resolvedCfgPath, err := resolveConfigPath(*common.configPath)
 	if err != nil {
 		return err
 	}
@@ -69,7 +67,7 @@ func handleTUI(ctx context.Context, args []string) error {
 			return err
 		}
 	}
-	_ = logging.New(*logLevel, *jsonOut) // placeholder for future log routing
+	_ = logging.New(*common.logLevel, *common.jsonOut) // placeholder for future log routing
 	st, err := state.Open(c)
 	if err != nil {
 		return err

--- a/cmd/modfetch/verify.go
+++ b/cmd/modfetch/verify.go
@@ -25,7 +25,7 @@ import (
 //	--safetensors     additionally perform a minimal .safetensors structure check
 func handleVerify(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("verify", flag.ContinueOnError)
-	cfgPath := fs.String("config", "", "Path to YAML config file")
+	common := addCommonConfigLogFlags(fs, "")
 	pathFlag := fs.String("path", "", "Specific file to verify (optional)")
 	all := fs.Bool("all", false, "Verify all completed downloads")
 	checkST := fs.Bool("safetensors", false, "Sanity-check .safetensors structure")
@@ -36,16 +36,14 @@ func handleVerify(ctx context.Context, args []string) error {
 	onlyErrors := fs.Bool("only-errors", false, "Show only files with errors or non-verified status")
 	summary := fs.Bool("summary", false, "Print a summary of total scanned and error count")
 	fixSidecar := fs.Bool("fix-sidecar", false, "Rewrite .sha256 sidecar with actual hash for verified files")
-	logLevel := fs.String("log-level", "info", "log level")
-	jsonOut := fs.Bool("json", false, "json logs")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	_ = logging.New(*logLevel, *jsonOut)
+	_ = logging.New(*common.logLevel, *common.jsonOut)
 	// If scanning an arbitrary directory, DB is not required; open only for state-backed modes.
 	var st *state.DB
 	if *scanDir == "" {
-		c, _, err := loadConfig(*cfgPath)
+		c, _, err := loadConfig(*common.configPath)
 		if err != nil {
 			return err
 		}
@@ -141,7 +139,7 @@ func handleVerify(ctx context.Context, args []string) error {
 		return errors.New("use --scan-dir or --path or --all")
 	}
 
-	if *jsonOut {
+	if *common.jsonOut {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		return enc.Encode(report)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -76,6 +76,7 @@ Breaking changes to consider for v1.0
 - Standardize CLI flags and naming [WIP]
   - Shared config path resolution across config-backed commands; `place` now honors the documented default config path [IMPL]
   - Shell completions are aligned with current commands and flags, including `hostcaps`, strict config validation, quantization selection, and dry-run variants [IMPL]
+  - Common `--config`, `--log-level`, and `--json` flag registration is centralized for config-backed commands [IMPL]
 
 Completed (from prior docs)
 - CivitAI model-aware default filenames and naming patterns (sources.*.naming.pattern) [IMPL]


### PR DESCRIPTION
## Summary
- add helpers for shared --config, --log-level, and --json flag registration
- use the helpers across config-backed command handlers
- keep hostcaps on config/json only while sharing config flag registration
- add focused tests for common flag helper parsing
- update roadmap traceability

## Tests
- go test ./cmd/modfetch -timeout 180s
- go test ./... -count=1 -timeout 180s