### PR TITLE
Prepare release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+Added
+- S3-compatible storage destinations using local resumable staging plus SigV4 upload.
+- Archive extraction support for zip, tar, tar.gz, tgz, and optional 7z backends.
+- Duplicate reporting and `dedupe` link modes for verified duplicate artifacts.
+- Event-driven TUI state refresh with polling fallback.
+- Strict config validation mode and documented enum/range validation.
+- SQLite schema version baseline with explicit legacy v0-to-v1 migration.
+
+Changed
+- Centralized config path resolution and common CLI flag registration.
+- Synced shell completions with current commands and flags.
+- Improved chunked download verification, adaptive chunk sizing, and downloader HTTP client behavior.
+- Refined TUI state helpers, grouping/preferences, filter selection persistence, and progress reporting.
+
+Testing
+- Expanded resolver, state, placer, downloader, metrics, config, completion, S3, archive, and TUI test coverage.
+- Added migration, schema validation, completion, rate-limit, and race-suite coverage.
+
+Docs
+- Closed out the consolidated roadmap and marked old sprint/test status reports as historical.
+- Added database schema documentation and refreshed config, completion, batch, and CLI docs.
+
+## v0.6.1 — 2025-11-11
+
+Testing
+- Added real Hugging Face and CivitAI API integration tests with retry/backoff handling.
+- Expanded TUI navigation and inspector test coverage.
+- Added test guidance for manual TUI validation and external API behavior.
+
+Fixes
+- Fixed resolver path parsing, scanner version extraction, scanner format detection, state timestamp precision, and TUI test fixtures.
+- Improved test reliability for flaky external API calls.
+
 ## v0.5.2 — 2025-09-26
 
 Fixes
@@ -125,4 +158,3 @@ Assets
 ## v0.1.0 — 2025-08-20
 
 - Initial release: CLI download, verify, placement; hf:// and civitai:// resolvers; chunked + single-stream fallback
-

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The modfetch TUI provides a beautiful, full-featured interface for managing your
 
 ---
 
-## What's new in v0.6.0
+## What's new in v0.6.x
 - **Library View**: Browse all your downloaded models with rich metadata, search, and filters
   - View model details: type, quantization, size, source, tags, descriptions
   - Search by name, filter by type (LLM, LoRA, VAE, etc.) and source (HuggingFace, CivitAI, local)
@@ -132,6 +132,7 @@ The modfetch TUI provides a beautiful, full-featured interface for managing your
 - **Documentation**: Complete user guides for Library (docs/LIBRARY.md) and Scanner (docs/SCANNER.md)
 
 Previous releases:
+- v0.6.1: Testing reliability, real API integration coverage, and TUI test expansion
 - v0.5.2: Enhanced TUI with rich UI elements and vibrant colors
 - v0.5.1: Critical installer and TUI navigation fixes
 - v0.5.0: Comprehensive installation package with guided setup experience

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -22,7 +22,7 @@ curl -fsSL https://raw.githubusercontent.com/jxwalker/modfetch/main/scripts/inst
 ```
 
 ```
-✓ Downloaded modfetch v0.6.0
+✓ Downloaded modfetch v0.6.1
 ✓ Installed to /usr/local/bin/modfetch
 ✓ Ready to use!
 ```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -99,8 +99,8 @@ get_latest_version() {
         fi
         
         if [[ -z "$VERSION" ]]; then
-            warn "Could not fetch latest version, using v0.5.0 as fallback"
-            VERSION="v0.5.0"
+            warn "Could not fetch latest version, using v0.6.1 as fallback"
+            VERSION="v0.6.1"
         fi
     fi
     


### PR DESCRIPTION
## Summary
- fill CHANGELOG Unreleased with post-v0.6.1 roadmap work
- add missing v0.6.1 changelog entry from the published release notes
- update latest-version installer/docs references from stale v0.5.0/v0.6.0 values

## Validation
- git diff --check
- go test ./... -timeout 180s
- go test ./... -race -timeout 240s
- go vet ./...
- bash -n scripts/install.sh