### PR TITLE
Prepare v0.6.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v0.6.2 — 2026-04-26
+
 Added
 - S3-compatible storage destinations using local resumable staging plus SigV4 upload.
 - Archive extraction support for zip, tar, tar.gz, tgz, and optional 7z backends.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The modfetch TUI provides a beautiful, full-featured interface for managing your
 - **Documentation**: Complete user guides for Library (docs/LIBRARY.md) and Scanner (docs/SCANNER.md)
 
 Previous releases:
+- v0.6.2: Roadmap, storage, archives, schema, CLI, shell completions, and test coverage
 - v0.6.1: Testing reliability, real API integration coverage, and TUI test expansion
 - v0.5.2: Enhanced TUI with rich UI elements and vibrant colors
 - v0.5.1: Critical installer and TUI navigation fixes

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -22,9 +22,9 @@ curl -fsSL https://raw.githubusercontent.com/jxwalker/modfetch/main/scripts/inst
 ```
 
 ```
-✓ Downloaded modfetch v0.6.1
-✓ Installed to /usr/local/bin/modfetch
-✓ Ready to use!
+✓ Downloaded modfetch binary
+✓ Installed modfetch to /usr/local/bin/modfetch
+✓ Version check passed
 ```
 
 ### Option B: Build from Source

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -99,8 +99,8 @@ get_latest_version() {
         fi
         
         if [[ -z "$VERSION" ]]; then
-            warn "Could not fetch latest version, using v0.6.1 as fallback"
-            VERSION="v0.6.1"
+            warn "Could not fetch latest version, using v0.6.2 as fallback"
+            VERSION="v0.6.2"
         fi
     fi
     


### PR DESCRIPTION
## Summary
- move current Unreleased changelog notes under v0.6.2 dated 2026-04-26
- add v0.6.2 to the README release summary
- update installer fallback and quickstart latest-version examples to v0.6.2

## Validation
- git diff --check
- go test ./... -timeout 180s
- go test ./... -race -timeout 240s
- go vet ./...
- bash -n scripts/install.sh

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/jxwalker/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->