### PR TITLE
[codex] Fix Hugging Face shorthand aliases

### DIFF
--- a/docs/RESOLVERS.md
+++ b/docs/RESOLVERS.md
@@ -3,7 +3,7 @@
 This guide documents the resolver URI formats and configurable naming patterns.
 
 Supported schemes
-- Hugging Face: `hf://{owner}/{repo}/{path}?rev=main`
+- Hugging Face: `hf://{repo-alias}[/{file}]?rev=main` or `hf://{owner}/{repo}[/{path}]?rev=main`
 - CivitAI: `civitai://model/{id}[?version=ID][&file=substring]`
 
 Configurable naming patterns
@@ -92,4 +92,3 @@ Notes
 - Tokens must be provided via environment variables. Do not hardcode secrets in YAML.
 - The chunked downloader uses these headers for HEAD and ranged GET requests.
 - For testing only, an internal override is available to swap the CivitAI API base URL.
-

--- a/internal/resolver/huggingface.go
+++ b/internal/resolver/huggingface.go
@@ -68,6 +68,32 @@ var preferredQuantizations = []string{
 	"Q3_K_L", "Q3_K_S", "Q2_K", "bf16", "fp32", "F32",
 }
 
+var hfAliasFileExtensions = map[string]struct{}{
+	".bin":         {},
+	".ckpt":        {},
+	".gguf":        {},
+	".json":        {},
+	".md":          {},
+	".model":       {},
+	".onnx":        {},
+	".pkl":         {},
+	".pt":          {},
+	".pth":         {},
+	".safetensors": {},
+	".txt":         {},
+	".yaml":        {},
+	".yml":         {},
+}
+
+var hfAliasFileNames = map[string]struct{}{
+	".gitattributes": {},
+	".gitignore":     {},
+	"dockerfile":     {},
+	"license":        {},
+	"notice":         {},
+	"readme":         {},
+}
+
 // Accepts URIs of the form:
 //
 //	hf://{owner}/{repo}/{path}?rev=main&quant={quantization}
@@ -76,6 +102,53 @@ var preferredQuantizations = []string{
 // If quant is specified, selects that specific quantization variant.
 // If path points to a directory or is omitted, will list and detect quantizations.
 func (h *HuggingFace) CanHandle(u string) bool { return strings.HasPrefix(u, "hf://") }
+
+func parseHFPath(rawPath string) (owner, repo, repoID, filePath string, err error) {
+	parts := splitHFPath(rawPath)
+	if len(parts) == 0 {
+		return "", "", "", "", errors.New("hf uri must be hf://repo[/file] or hf://owner/repo[/path]")
+	}
+	if len(parts) == 1 {
+		repo = parts[0]
+		return "", repo, repo, "", nil
+	}
+
+	owner = parts[0]
+	repo = parts[1]
+	repoID = owner + "/" + repo
+	if len(parts) > 2 {
+		filePath = path.Join(parts[2:]...)
+	}
+	return owner, repo, repoID, filePath, nil
+}
+
+func aliasFilePath(rawPath string) (repo, filePath string, ok bool) {
+	parts := splitHFPath(rawPath)
+	if len(parts) != 2 || !looksLikeHFAliasFile(parts[1]) {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func looksLikeHFAliasFile(segment string) bool {
+	base := strings.ToLower(path.Base(strings.TrimSpace(segment)))
+	if _, ok := hfAliasFileNames[base]; ok {
+		return true
+	}
+	_, ok := hfAliasFileExtensions[path.Ext(base)]
+	return ok
+}
+
+func splitHFPath(rawPath string) []string {
+	rawParts := strings.Split(rawPath, "/")
+	parts := make([]string, 0, len(rawParts))
+	for _, part := range rawParts {
+		if part = strings.TrimSpace(part); part != "" {
+			parts = append(parts, part)
+		}
+	}
+	return parts
+}
 
 // listRepoFiles fetches the file tree from HuggingFace API.
 func (h *HuggingFace) listRepoFiles(ctx context.Context, repoID, rev string, headers map[string]string) ([]hfRepoFile, error) {
@@ -240,21 +313,9 @@ func (h *HuggingFace) Resolve(ctx context.Context, uri string, cfg *config.Confi
 	} else {
 		rawPath = s
 	}
-	parts := strings.Split(rawPath, "/")
-	if len(parts) < 2 {
-		return nil, errors.New("hf uri must be hf://owner/repo or hf://owner/repo/path")
-	}
-	var owner, repo string
-	var filePath string
-	if len(parts) == 2 {
-		// hf://owner/repo - need to list files
-		owner = parts[0]
-		repo = parts[1]
-		filePath = ""
-	} else {
-		owner = parts[0]
-		repo = parts[1]
-		filePath = path.Join(parts[2:]...)
+	owner, repo, repoID, filePath, err := parseHFPath(rawPath)
+	if err != nil {
+		return nil, err
 	}
 
 	// Parse query parameters
@@ -267,9 +328,6 @@ func (h *HuggingFace) Resolve(ctx context.Context, uri string, cfg *config.Confi
 		}
 		requestedQuant = q.Get("quant")
 	}
-
-	// Construct repo ID
-	repoID := owner + "/" + repo
 
 	// Prepare headers (auth)
 	headers := map[string]string{}
@@ -286,27 +344,15 @@ func (h *HuggingFace) Resolve(ctx context.Context, uri string, cfg *config.Confi
 
 	// If specific file path given and no quant requested, use direct resolution (backward compatible)
 	if filePath != "" && !needsQuantDetection {
-		base := hfBaseURL + "/" + repoID
-		resURL := base + "/resolve/" + url.PathEscape(rev) + "/" + strings.ReplaceAll(filePath, "+", "%2B")
-
-		fileName := path.Base(filePath)
-		suggested := h.computeSuggestedFilename(cfg, owner, repo, filePath, rev, fileName, "")
-
-		return &Resolved{
-			URL:               resURL,
-			Headers:           headers,
-			FileName:          fileName,
-			SuggestedFilename: suggested,
-			RepoOwner:         owner,
-			RepoName:          repo,
-			RepoPath:          filePath,
-			Rev:               rev,
-		}, nil
+		return h.resolveDirectFile(repoID, owner, repo, filePath, rev, headers, cfg), nil
 	}
 
 	// List files and detect quantizations
 	files, err := h.listRepoFiles(ctx, repoID, rev, headers)
 	if err != nil {
+		if aliasRepo, aliasPath, ok := aliasFilePath(rawPath); ok {
+			return h.resolveDirectFile(aliasRepo, "", aliasRepo, aliasPath, rev, headers, cfg), nil
+		}
 		return nil, fmt.Errorf("list repo files: %w", err)
 	}
 
@@ -347,6 +393,25 @@ func (h *HuggingFace) Resolve(ctx context.Context, uri string, cfg *config.Confi
 		AvailableQuantizations: allQuants,
 		SelectedQuantization:   selected.Name,
 	}, nil
+}
+
+func (h *HuggingFace) resolveDirectFile(repoID, owner, repo, filePath, rev string, headers map[string]string, cfg *config.Config) *Resolved {
+	base := hfBaseURL + "/" + repoID
+	resURL := base + "/resolve/" + url.PathEscape(rev) + "/" + strings.ReplaceAll(filePath, "+", "%2B")
+
+	fileName := path.Base(filePath)
+	suggested := h.computeSuggestedFilename(cfg, owner, repo, filePath, rev, fileName, "")
+
+	return &Resolved{
+		URL:               resURL,
+		Headers:           headers,
+		FileName:          fileName,
+		SuggestedFilename: suggested,
+		RepoOwner:         owner,
+		RepoName:          repo,
+		RepoPath:          filePath,
+		Rev:               rev,
+	}
 }
 
 // computeSuggestedFilename computes the suggested filename using naming pattern.

--- a/internal/resolver/huggingface_unit_test.go
+++ b/internal/resolver/huggingface_unit_test.go
@@ -125,6 +125,176 @@ func TestHuggingFaceResolveWithLocalTreeAndNamingPattern(t *testing.T) {
 	}
 }
 
+func TestHuggingFaceResolveSingleSegmentRepoAliasWithLocalTree(t *testing.T) {
+	oldBase := hfBaseURL
+	defer func() { hfBaseURL = oldBase }()
+
+	var handlerErr atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/models/gpt2/tree/main" {
+			handlerErr.Store(fmt.Sprintf("unexpected path: %s", r.URL.Path))
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		files := []hfRepoFile{
+			{Path: "pytorch_model.bin", Type: "file", Size: 42},
+		}
+		if err := json.NewEncoder(w).Encode(files); err != nil {
+			handlerErr.Store(fmt.Sprintf("encode files: %v", err))
+			return
+		}
+	}))
+	defer server.Close()
+	hfBaseURL = server.URL
+
+	res, err := (&HuggingFace{}).Resolve(context.Background(), "hf://gpt2", nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if v := handlerErr.Load(); v != nil {
+		t.Fatal(v)
+	}
+	if res.URL != server.URL+"/gpt2/resolve/main/pytorch_model.bin" {
+		t.Fatalf("unexpected resolve URL: %s", res.URL)
+	}
+	if res.RepoOwner != "" || res.RepoName != "gpt2" || res.RepoPath != "pytorch_model.bin" {
+		t.Fatalf("unexpected repo metadata: %+v", res)
+	}
+}
+
+func TestHuggingFacePathParsingPrefersNamespacedRepos(t *testing.T) {
+	tests := []struct {
+		name         string
+		rawPath      string
+		wantOwner    string
+		wantRepo     string
+		wantRepoID   string
+		wantFilePath string
+	}{
+		{
+			name:       "namespaced repo with dotted name",
+			rawPath:    "owner/model.v1",
+			wantOwner:  "owner",
+			wantRepo:   "model.v1",
+			wantRepoID: "owner/model.v1",
+		},
+		{
+			name:         "namespaced repo file path",
+			rawPath:      "owner/model.v1/README.md",
+			wantOwner:    "owner",
+			wantRepo:     "model.v1",
+			wantRepoID:   "owner/model.v1",
+			wantFilePath: "README.md",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			owner, repo, repoID, filePath, err := parseHFPath(tc.rawPath)
+			if err != nil {
+				t.Fatalf("parseHFPath: %v", err)
+			}
+			if owner != tc.wantOwner || repo != tc.wantRepo || repoID != tc.wantRepoID || filePath != tc.wantFilePath {
+				t.Fatalf("unexpected parse: owner=%q repo=%q repoID=%q filePath=%q", owner, repo, repoID, filePath)
+			}
+		})
+	}
+}
+
+func TestHuggingFaceResolveDottedNamespacedRepo(t *testing.T) {
+	oldBase := hfBaseURL
+	defer func() { hfBaseURL = oldBase }()
+
+	var handlerErr atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/models/acme/model.v1/tree/main" {
+			handlerErr.Store(fmt.Sprintf("unexpected path: %s", r.URL.Path))
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		files := []hfRepoFile{
+			{Path: "model.Q4_K_M.gguf", Type: "file", Size: 42},
+		}
+		if err := json.NewEncoder(w).Encode(files); err != nil {
+			handlerErr.Store(fmt.Sprintf("encode files: %v", err))
+			return
+		}
+	}))
+	defer server.Close()
+	hfBaseURL = server.URL
+
+	res, err := (&HuggingFace{}).Resolve(context.Background(), "hf://acme/model.v1?rev=main", nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if v := handlerErr.Load(); v != nil {
+		t.Fatal(v)
+	}
+	if res.URL != server.URL+"/acme/model.v1/resolve/main/model.Q4_K_M.gguf" {
+		t.Fatalf("unexpected resolve URL: %s", res.URL)
+	}
+	if res.RepoOwner != "acme" || res.RepoName != "model.v1" || res.RepoPath != "model.Q4_K_M.gguf" {
+		t.Fatalf("unexpected repo metadata: %+v", res)
+	}
+}
+
+func TestHuggingFaceAliasFileFallback(t *testing.T) {
+	oldBase := hfBaseURL
+	defer func() { hfBaseURL = oldBase }()
+
+	var sawCanonicalAttempt atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/models/gpt2/README.md/tree/main" {
+			sawCanonicalAttempt.Store(true)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "unexpected path", http.StatusNotFound)
+	}))
+	defer server.Close()
+	hfBaseURL = server.URL
+
+	res, err := (&HuggingFace{}).Resolve(context.Background(), "hf://gpt2/README.md?rev=main", nil)
+	if err != nil {
+		t.Fatalf("Resolve direct file alias: %v", err)
+	}
+	if !sawCanonicalAttempt.Load() {
+		t.Fatal("expected canonical owner/repo tree lookup before alias fallback")
+	}
+	if res.URL != server.URL+"/gpt2/resolve/main/README.md" {
+		t.Fatalf("unexpected resolve URL: %s", res.URL)
+	}
+	if res.RepoOwner != "" || res.RepoName != "gpt2" || res.RepoPath != "README.md" {
+		t.Fatalf("unexpected repo metadata: %+v", res)
+	}
+}
+
+func TestHuggingFaceAliasFileFallbackSupportsExtensionlessFiles(t *testing.T) {
+	oldBase := hfBaseURL
+	defer func() { hfBaseURL = oldBase }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/models/gpt2/LICENSE/tree/main" {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+	hfBaseURL = server.URL
+
+	res, err := (&HuggingFace{}).Resolve(context.Background(), "hf://gpt2/LICENSE?rev=main", nil)
+	if err != nil {
+		t.Fatalf("Resolve direct file alias: %v", err)
+	}
+	if res.URL != server.URL+"/gpt2/resolve/main/LICENSE" {
+		t.Fatalf("unexpected resolve URL: %s", res.URL)
+	}
+	if res.RepoOwner != "" || res.RepoName != "gpt2" || res.RepoPath != "LICENSE" {
+		t.Fatalf("unexpected repo metadata: %+v", res)
+	}
+}
+
 func TestHuggingFaceResolveLocalTreeErrors(t *testing.T) {
 	oldBase := hfBaseURL
 	defer func() { hfBaseURL = oldBase }()
@@ -158,5 +328,30 @@ func TestHuggingFaceDirectFileResolutionAndSuggestedFilename(t *testing.T) {
 	}
 	if res.SuggestedFilename != "acme_tiny_dev_model-v1.gguf" {
 		t.Fatalf("unexpected suggested filename: %q", res.SuggestedFilename)
+	}
+}
+
+func TestHuggingFaceDirectFileResolutionForSingleSegmentRepoAlias(t *testing.T) {
+	oldBase := hfBaseURL
+	defer func() { hfBaseURL = oldBase }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+	hfBaseURL = server.URL
+
+	res, err := (&HuggingFace{}).Resolve(context.Background(), "hf://gpt2/README.md?rev=main", nil)
+	if err != nil {
+		t.Fatalf("Resolve direct file: %v", err)
+	}
+	if res.URL != server.URL+"/gpt2/resolve/main/README.md" {
+		t.Fatalf("unexpected resolve URL: %s", res.URL)
+	}
+	if res.RepoOwner != "" || res.RepoName != "gpt2" || res.RepoPath != "README.md" {
+		t.Fatalf("unexpected repo metadata: %+v", res)
+	}
+	if res.FileName != "README.md" || res.SuggestedFilename != "README.md" {
+		t.Fatalf("unexpected file naming: %+v", res)
 	}
 }


### PR DESCRIPTION
## Summary
- Support Hugging Face single-segment repo aliases such as `hf://gpt2` and direct alias files such as `hf://gpt2/README.md?rev=main`.
- Preserve existing `hf://owner/repo` and `hf://owner/repo/path` parsing for namespaced repositories.
- Align resolver docs with the supported alias form.

## Validation
- `go test ./internal/resolver -run 'TestHuggingFace' -count=1`
- `git diff --check`
- `go test ./... -timeout 180s`
- `go vet ./...`
- `go test ./... -race -timeout 240s`
- Built a temp binary and downloaded/verified public `hf://gpt2/README.md?rev=main` successfully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/jxwalker/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->