### PR TITLE
[codex] Prepare v0.6.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v0.6.3 — 2026-04-27
+
+Fixes
+- Fixed Hugging Face shorthand alias downloads such as `hf://gpt2/README.md?rev=main`.
+- Preserved canonical namespaced repo parsing for dotted repository names such as `hf://acme/model.v1`.
+
+Docs
+- Clarified Hugging Face resolver forms for repo-only and optional-path URIs.
+
 ## v0.6.2 — 2026-04-26
 
 Added

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The modfetch TUI provides a beautiful, full-featured interface for managing your
 - **Documentation**: Complete user guides for Library (docs/LIBRARY.md) and Scanner (docs/SCANNER.md)
 
 Previous releases:
+- v0.6.3: Hugging Face shorthand alias fixes and resolver docs clarification
 - v0.6.2: Roadmap, storage, archives, schema, CLI, shell completions, and test coverage
 - v0.6.1: Testing reliability, real API integration coverage, and TUI test expansion
 - v0.5.2: Enhanced TUI with rich UI elements and vibrant colors

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -100,8 +100,8 @@ get_latest_version() {
         fi
         
         if [[ -z "$VERSION" ]]; then
-            warn "Could not fetch latest version, using v0.6.2 as fallback"
-            VERSION="v0.6.2"
+            warn "Could not fetch latest version, using v0.6.3 as fallback"
+            VERSION="v0.6.3"
         fi
     fi
     


### PR DESCRIPTION
## Summary
- Prepare `v0.6.3` release notes for the Hugging Face shorthand alias fix merged in #129.
- Add `v0.6.3` to the README release list.
- Update the installer fallback version to `v0.6.3`.

## Validation
- `bash -n scripts/install.sh`
- `git diff --check`
- `go test ./... -timeout 180s`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/jxwalker/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->