### PR TITLE
[codex] Populate release notes from changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: dist
+      - name: Extract release notes
+        run: |
+          scripts/release-notes.sh "${GITHUB_REF_NAME}" > release_notes.md
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -96,5 +99,6 @@ jobs:
           name: ${{ github.ref_name }}
           draft: false
           prerelease: false
+          body_path: release_notes.md
           # Single glob to avoid double-matching .sha256 files which caused duplicate uploads
           files: dist/**/modfetch_*

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${1:-}"
+changelog="${2:-CHANGELOG.md}"
+
+if [[ -z "$tag" ]]; then
+    printf 'usage: %s <tag> [changelog]\n' "$0" >&2
+    exit 2
+fi
+
+if [[ ! -f "$changelog" ]]; then
+    printf 'changelog not found: %s\n' "$changelog" >&2
+    exit 2
+fi
+
+notes=$(
+    awk -v tag="$tag" '
+        $1 == "##" && $2 == tag {
+            found = 1
+            next
+        }
+        found && $0 ~ "^##[[:space:]]+" {
+            exit
+        }
+        found {
+            print
+        }
+        END {
+            if (!found) {
+                exit 42
+            }
+        }
+    ' "$changelog"
+) || {
+    status=$?
+    if [[ "$status" -eq 42 ]]; then
+        printf 'release notes for %s not found in %s\n' "$tag" "$changelog" >&2
+    fi
+    exit "$status"
+}
+
+notes=$(printf '%s\n' "$notes" | sed '/[^[:space:]]/,$!d')
+if ! grep -q '[^[:space:]]' <<<"$notes"; then
+    printf 'release notes for %s are empty in %s\n' "$tag" "$changelog" >&2
+    exit 42
+fi
+
+printf '%s\n' "$notes"


### PR DESCRIPTION
## Summary
- Add `scripts/release-notes.sh` to extract a tag section from `CHANGELOG.md`.
- Wire the release workflow to pass extracted notes to `softprops/action-gh-release` via `body_path`.
- Fail the release job clearly if changelog notes for the tag are missing or empty.

## Validation
- `scripts/release-notes.sh v0.6.3`
- `scripts/release-notes.sh v9.9.9` returns status 42 with a missing-notes error
- `bash -n scripts/release-notes.sh && bash -n scripts/install.sh`
- `git diff --check`
- `go test ./... -timeout 180s`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->