### PR TITLE
[codex] Add library catalog import and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,10 @@ modfetch place --path /path/to/model.safetensors
 
 # Batch downloads
 modfetch download --batch jobs.yml --place
+
+# Back up or migrate your model library catalog
+modfetch library export --output modfetch-catalog.json
+modfetch library import --input modfetch-catalog.json --dry-run
 ```
 
 ### Detailed Examples

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -34,7 +34,7 @@ _modfetch_completions()
 {
     local cur prev words cword
     _init_completion || return
-    local cmds="config download place verify status tui batch dedupe clean hostcaps version help completion"
+    local cmds="config download place verify status tui library batch dedupe clean hostcaps version help completion"
     if [[ ${cword} -eq 1 ]]; then
         COMPREPLY=( $(compgen -W "${cmds}" -- "$cur") )
         return
@@ -66,6 +66,18 @@ _modfetch_completions()
             COMPREPLY=( $(compgen -W "--config --log-level --json --only-errors --summary --duplicates" -- "$cur") ) ;;
         tui)
             COMPREPLY=( $(compgen -W "--config --log-level --json" -- "$cur") ) ;;
+        library)
+            if [[ ${cword} -eq 2 ]]; then
+                COMPREPLY=( $(compgen -W "export import" -- "$cur") )
+                return
+            fi
+            case ${words[2]} in
+                export)
+                    COMPREPLY=( $(compgen -W "--config --log-level --json --format --output" -- "$cur") ) ;;
+                import)
+                    COMPREPLY=( $(compgen -W "--config --log-level --json --input --dry-run" -- "$cur") ) ;;
+                *) ;;
+            esac ;;
         clean)
             COMPREPLY=( $(compgen -W "--config --log-level --json --days --dry-run --dest --include-next-to-dest --sidecars" -- "$cur") ) ;;
         batch)
@@ -92,7 +104,7 @@ const zshCompletion = `#compdef modfetch
 # zsh completion for modfetch (basic)
 _modfetch() {
   local -a cmds
-  cmds=(config download place verify status tui batch dedupe clean hostcaps version help completion)
+  cmds=(config download place verify status tui library batch dedupe clean hostcaps version help completion)
   if (( CURRENT == 2 )); then
     _describe 'command' cmds
     return
@@ -133,6 +145,20 @@ _modfetch() {
     tui)
       _arguments '*:options:(--config --log-level --json)'
       ;;
+    library)
+      if (( CURRENT == 3 )); then
+        _arguments '*:subcommands:(export import)'
+      else
+        case $words[3] in
+          export)
+            _arguments '*:options:(--config --log-level --json --format --output)'
+            ;;
+          import)
+            _arguments '*:options:(--config --log-level --json --input --dry-run)'
+            ;;
+        esac
+      fi
+      ;;
     clean)
       _arguments '*:options:(--config --log-level --json --days --dry-run --dest --include-next-to-dest --sidecars)'
       ;;
@@ -169,6 +195,7 @@ complete -c modfetch -n "__fish_seen_subcommand_from status" -l only-errors -d "
 complete -c modfetch -n "__fish_seen_subcommand_from status" -l summary -d "Print totals and errors"
 complete -c modfetch -n "__fish_seen_subcommand_from status" -l duplicates -d "Show duplicate completed downloads"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "tui" -d "dashboard"
+complete -c modfetch -f -n "__fish_use_subcommand" -a "library" -d "library catalog"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "batch" -d "batch operations"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "version" -d "print version"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "help" -d "show help"
@@ -182,7 +209,7 @@ complete -c modfetch -n "__fish_seen_subcommand_from clean" -l include-next-to-d
 complete -c modfetch -n "__fish_seen_subcommand_from clean" -l sidecars -d "Remove orphan .sha256"
 
 # Common flags
-for cmd in download place verify status tui dedupe clean
+for cmd in download place verify status tui library dedupe clean
   complete -c modfetch -n "__fish_seen_subcommand_from $cmd" -l config -d "Path to config"
   complete -c modfetch -n "__fish_seen_subcommand_from $cmd" -l log-level -d "Log level"
   complete -c modfetch -n "__fish_seen_subcommand_from $cmd" -l json -d "JSON output"
@@ -215,6 +242,12 @@ complete -c modfetch -n "__fish_seen_subcommand_from download" -l extract -d "Ex
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l extract-dir -d "Extraction directory"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l quant -d "HuggingFace quantization to download"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l list-quants -d "List HuggingFace quantizations"
+complete -c modfetch -n "__fish_seen_subcommand_from library" -a "export" -d "Export model catalog"
+complete -c modfetch -n "__fish_seen_subcommand_from library" -a "import" -d "Import model catalog"
+complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from export" -l format -d "Catalog format"
+complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from export" -l output -d "Output catalog path"
+complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from import" -l input -d "Input catalog path"
+complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from import" -l dry-run -d "Report changes without writing"
 complete -c modfetch -n "__fish_seen_subcommand_from dedupe" -l mode -d "hardlink|symlink"
 complete -c modfetch -n "__fish_seen_subcommand_from dedupe" -l dry-run -d "Show dedupe changes without modifying files"
 # batch import flags

--- a/cmd/modfetch/library_cmd.go
+++ b/cmd/modfetch/library_cmd.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/jxwalker/modfetch/internal/catalog"
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+func handleLibrary(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return errors.New("library subcommand required: export or import")
+	}
+	switch args[0] {
+	case "export":
+		return handleLibraryExport(ctx, args[1:])
+	case "import":
+		return handleLibraryImport(ctx, args[1:])
+	default:
+		return fmt.Errorf("unknown library subcommand: %s", args[0])
+	}
+}
+
+func handleLibraryExport(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("library export", flag.ContinueOnError)
+	common := addCommonConfigLogFlags(fs, "")
+	format := fs.String("format", "json", "catalog format: json")
+	output := fs.String("output", "-", "output path, or - for stdout")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if *format != "json" {
+		return fmt.Errorf("unsupported export format %q", *format)
+	}
+	db, err := openLibraryDB(*common.configPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	w, closeFn, err := outputWriter(*output)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+	return catalog.Export(db, w)
+}
+
+func handleLibraryImport(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("library import", flag.ContinueOnError)
+	common := addCommonConfigLogFlags(fs, "print import result as JSON")
+	input := fs.String("input", "", "catalog JSON path, or - for stdin")
+	dryRun := fs.Bool("dry-run", false, "report changes without writing to the library")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if *input == "" {
+		return errors.New("library import requires --input")
+	}
+	db, err := openLibraryDB(*common.configPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	r, closeFn, err := inputReader(*input)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+	result, err := catalog.Import(db, r, catalog.ImportOptions{DryRun: *dryRun})
+	if err != nil {
+		return err
+	}
+	if *common.jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+	fmt.Printf("Import summary: creates=%d updates=%d skips=%d conflicts=%d dry_run=%t\n",
+		result.Creates, result.Updates, result.Skips, result.Conflicts, result.DryRun)
+	for _, entry := range result.Entries {
+		if entry.Reason != "" {
+			fmt.Printf("%s %s (%s)\n", entry.Action, entry.DownloadURL, entry.Reason)
+		} else {
+			fmt.Printf("%s %s\n", entry.Action, entry.DownloadURL)
+		}
+	}
+	if result.Conflicts > 0 {
+		return fmt.Errorf("catalog import has %d conflict(s)", result.Conflicts)
+	}
+	return nil
+}
+
+func openLibraryDB(configPath string) (*state.DB, error) {
+	cfg, _, err := loadConfig(configPath)
+	if err != nil {
+		return nil, err
+	}
+	return state.Open(cfg)
+}
+
+func outputWriter(path string) (io.Writer, func(), error) {
+	if path == "" || path == "-" {
+		return os.Stdout, func() {}, nil
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return f, func() { _ = f.Close() }, nil
+}
+
+func inputReader(path string) (io.Reader, func(), error) {
+	if path == "-" {
+		return os.Stdin, func() {}, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return f, func() { _ = f.Close() }, nil
+}

--- a/cmd/modfetch/library_cmd.go
+++ b/cmd/modfetch/library_cmd.go
@@ -87,7 +87,13 @@ func handleLibraryImport(ctx context.Context, args []string) error {
 	if *common.jsonOut {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(result)
+		if err := enc.Encode(result); err != nil {
+			return err
+		}
+		if result.Conflicts > 0 {
+			return fmt.Errorf("catalog import has %d conflict(s)", result.Conflicts)
+		}
+		return nil
 	}
 	fmt.Printf("Import summary: creates=%d updates=%d skips=%d conflicts=%d dry_run=%t\n",
 		result.Creates, result.Updates, result.Skips, result.Conflicts, result.DryRun)

--- a/cmd/modfetch/library_cmd_test.go
+++ b/cmd/modfetch/library_cmd_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/config"
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+func TestHandleLibraryExportImport(t *testing.T) {
+	dir := t.TempDir()
+	sourceCfg := writeLibraryConfig(t, filepath.Join(dir, "source"))
+	source, err := state.Open(&config.Config{General: config.General{
+		DataRoot:     filepath.Join(dir, "source", "data"),
+		DownloadRoot: filepath.Join(dir, "source", "downloads"),
+	}})
+	if err != nil {
+		t.Fatalf("open source db: %v", err)
+	}
+	if err := source.UpsertMetadata(&state.ModelMetadata{
+		DownloadURL: "https://example.com/model.gguf",
+		Dest:        filepath.Join(dir, "source", "downloads", "model.gguf"),
+		ModelName:   "CLI Model",
+		Source:      "direct",
+		Favorite:    true,
+	}); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	if err := source.Close(); err != nil {
+		t.Fatalf("close source db: %v", err)
+	}
+
+	catalogPath := filepath.Join(dir, "catalog.json")
+	if err := handleLibrary(context.Background(), []string{"export", "--config", sourceCfg, "--output", catalogPath}); err != nil {
+		t.Fatalf("library export: %v", err)
+	}
+	if _, err := os.Stat(catalogPath); err != nil {
+		t.Fatalf("expected catalog output: %v", err)
+	}
+
+	targetCfg := writeLibraryConfig(t, filepath.Join(dir, "target"))
+	if err := handleLibrary(context.Background(), []string{"import", "--config", targetCfg, "--input", catalogPath, "--dry-run"}); err != nil {
+		t.Fatalf("library import dry-run: %v", err)
+	}
+	if err := handleLibrary(context.Background(), []string{"import", "--config", targetCfg, "--input", catalogPath}); err != nil {
+		t.Fatalf("library import: %v", err)
+	}
+
+	target, err := state.Open(&config.Config{General: config.General{
+		DataRoot:     filepath.Join(dir, "target", "data"),
+		DownloadRoot: filepath.Join(dir, "target", "downloads"),
+	}})
+	if err != nil {
+		t.Fatalf("open target db: %v", err)
+	}
+	defer func() { _ = target.Close() }()
+	meta, err := target.GetMetadata("https://example.com/model.gguf")
+	if err != nil {
+		t.Fatalf("get imported metadata: %v", err)
+	}
+	if meta.ModelName != "CLI Model" || !meta.Favorite {
+		t.Fatalf("unexpected imported metadata: %+v", meta)
+	}
+}
+
+func writeLibraryConfig(t *testing.T, root string) string {
+	t.Helper()
+	cfgPath := filepath.Join(root, "config.yml")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "version: 1\n" +
+		"general:\n" +
+		"  data_root: " + filepath.Join(root, "data") + "\n" +
+		"  download_root: " + filepath.Join(root, "downloads") + "\n"
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return cfgPath
+}

--- a/cmd/modfetch/library_cmd_test.go
+++ b/cmd/modfetch/library_cmd_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jxwalker/modfetch/internal/config"
@@ -63,6 +65,52 @@ func TestHandleLibraryExportImport(t *testing.T) {
 	}
 	if meta.ModelName != "CLI Model" || !meta.Favorite {
 		t.Fatalf("unexpected imported metadata: %+v", meta)
+	}
+}
+
+func TestHandleLibraryImportJSONReturnsErrorOnConflicts(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeLibraryConfig(t, filepath.Join(dir, "cfg"))
+	db, err := state.Open(&config.Config{General: config.General{
+		DataRoot:     filepath.Join(dir, "cfg", "data"),
+		DownloadRoot: filepath.Join(dir, "cfg", "downloads"),
+	}})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.UpsertMetadata(&state.ModelMetadata{
+		DownloadURL: "https://example.com/existing.gguf",
+		Dest:        "/models/shared.gguf",
+		ModelName:   "Existing",
+	}); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"app":             "modfetch",
+		"catalog_version": 1,
+		"models": []map[string]any{{
+			"metadata": map[string]any{
+				"download_url": "https://example.com/incoming.gguf",
+				"dest":         "/models/shared.gguf",
+				"model_name":   "Incoming",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalogPath := filepath.Join(dir, "conflict.json")
+	if err := os.WriteFile(catalogPath, payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err = handleLibrary(context.Background(), []string{"import", "--config", cfgPath, "--input", catalogPath, "--json"})
+	if err == nil || !strings.Contains(err.Error(), "conflict") {
+		t.Fatalf("expected JSON import conflict error, got %v", err)
 	}
 }
 

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -79,6 +79,8 @@ func run(ctx context.Context, args []string) error {
 		return handleDedupe(ctx, args[1:])
 	case "batch":
 		return handleBatch(ctx, args[1:])
+	case "library":
+		return handleLibrary(ctx, args[1:])
 	case "help", "-h", "--help":
 		usage()
 		return nil
@@ -103,6 +105,8 @@ Commands:
   place             Place a file into configured app directories
   verify            Verify SHA256 of a file or all completed downloads
   tui               Open the interactive terminal dashboard
+  library export    Export model library catalog as JSON
+  library import    Import model library catalog JSON
   batch import      Import URLs from a text file and produce a YAML batch
   version           Print version
   help              Show this help

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -13,6 +13,7 @@ Complete command-line reference for modfetch. For the visual TUI interface, see 
   - [clean](#clean)
   - [config](#config)
   - [tui](#tui)
+  - [library](#library)
 - [URL Formats](#url-formats)
 - [Examples](#examples)
 - [Scripting](#scripting)
@@ -33,6 +34,7 @@ modfetch download --url URL       # Download a file
 modfetch verify --all              # Verify all downloads
 modfetch place --path FILE         # Place model into app
 modfetch clean --days 7            # Clean old partials
+modfetch library export --output catalog.json
 modfetch config validate           # Validate config
 modfetch tui                       # Launch visual TUI
 ```
@@ -148,6 +150,31 @@ Show rows from the download state database.
 - `--summary` - Print totals
 - `--duplicates` - Group completed downloads by matching SHA256 content
 - `--json` - Emit machine-readable JSON
+
+### library
+
+Export or import the model library catalog for backup and machine migration.
+
+```bash
+# Export metadata, favorites, source URLs, destination paths, and checksums
+modfetch library export --format json --output modfetch-catalog.json
+
+# Preview an import without writing to the state database
+modfetch library import --input modfetch-catalog.json --dry-run
+
+# Import catalog entries and print a machine-readable summary
+modfetch library import --input modfetch-catalog.json --json
+```
+
+Exported catalogs include a schema version and one entry per model metadata row.
+When a matching download row exists, the catalog also carries expected and
+actual SHA256 values, file size, status, source URL, and destination path.
+
+Import is idempotent:
+- existing identical entries are reported as `skip`
+- new entries are reported as `create`
+- changed entries with the same source URL are reported as `update`
+- destination collisions with a different source URL are reported as `conflict`
 
 ### dedupe
 

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -12,6 +12,7 @@ The Model Library feature in modfetch provides a centralized view of all your do
 - [Filtering and Search](#filtering-and-search)
 - [Model Details](#model-details)
 - [Directory Scanning](#directory-scanning)
+- [Catalog Backup and Migration](#catalog-backup-and-migration)
 - [Metadata Sources](#metadata-sources)
 
 ## Overview
@@ -331,6 +332,27 @@ Scan complete: 15 new, 27 skipped, 0 errors
 ```
 
 The library view automatically refreshes to show newly discovered models.
+
+## Catalog Backup and Migration
+
+Use the CLI catalog commands to back up or move your library index without
+copying the SQLite state database directly.
+
+```bash
+modfetch library export --format json --output modfetch-catalog.json
+modfetch library import --input modfetch-catalog.json --dry-run
+modfetch library import --input modfetch-catalog.json
+```
+
+The JSON catalog includes:
+- schema version metadata
+- model metadata and user fields such as favorites, notes, and ratings
+- source URLs and destination paths
+- checksum, size, and status data when a matching download row exists
+
+Import dry-run reports the planned `create`, `update`, `skip`, and `conflict`
+counts without writing. Re-importing the same catalog is idempotent and reports
+unchanged entries as skips.
 
 ## Metadata Sources
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,7 +33,7 @@ rewrite.
 
 ## v0.7.0 Implementation Plan
 
-### 1. Package Distribution [NEXT]
+### 1. Package Distribution [DONE]
 
 Outcome: users can install through a maintained package channel instead of only
 the curl installer or manual release binaries.
@@ -41,7 +41,8 @@ the curl installer or manual release binaries.
 - [DONE] Homebrew tap formula for macOS and Linuxbrew.
 - [DONE] Document the package install path in README and docs/INSTALLATION.md.
 - [DONE] Add release checklist coverage, so formula updates are part of tagging.
-- [TODO] Decide whether an AUR package is in scope for v0.7.0 or v0.7.x.
+- [DONE] Decide whether an AUR package is in scope for v0.7.0 or v0.7.x:
+  defer to v0.7.x after Homebrew usage settles.
 
 Acceptance checks:
 - Formula installs the latest GitHub Release artifact and verifies checksum.
@@ -49,17 +50,17 @@ Acceptance checks:
   the tap exists.
 - `docs/RELEASE.md` includes the tap update and validation steps.
 
-### 2. Library Catalog Export and Import [TODO]
+### 2. Library Catalog Export and Import [DONE]
 
 Outcome: users can move or back up their model library index without manually
 copying SQLite state.
 
-- [TODO] Add `library export --format json` for model metadata, favorites,
+- [DONE] Add `library export --format json` for model metadata, favorites,
   source URLs, checksums, and placement hints.
-- [TODO] Add `library import` with dry-run, conflict reporting, and idempotent
+- [DONE] Add `library import` with dry-run, conflict reporting, and idempotent
   updates.
-- [TODO] Include schema version metadata in exported catalogs.
-- [TODO] Document backup/restore and machine migration workflows.
+- [DONE] Include schema version metadata in exported catalogs.
+- [DONE] Document backup/restore and machine migration workflows.
 
 Acceptance checks:
 - Export/import round trip preserves model identity, favorite status, source,

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -193,18 +194,32 @@ func importOne(db *state.DB, downloadsByKey map[string]state.DownloadRow, metada
 		res.Action = "update"
 	}
 
+	row, hasDownload := importDownloadRow(downloadsByKey, entry)
 	if opts.DryRun {
+		applyImportMaps(downloadsByKey, metadataByURL, metadataByDest, meta, row, hasDownload)
 		return res
 	}
-	if err := db.UpsertMetadata(&meta); err != nil {
+	err := db.WithTx(func(tx *sql.Tx) error {
+		if err := db.UpsertMetadataTx(tx, &meta); err != nil {
+			return fmt.Errorf("upsert metadata: %w", err)
+		}
+		if hasDownload {
+			if err := db.UpsertDownloadTx(tx, row); err != nil {
+				return fmt.Errorf("upsert download: %w", err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
 		res.Action = "conflict"
-		res.Reason = fmt.Sprintf("upsert metadata: %v", err)
+		res.Reason = err.Error()
 		return res
 	}
-	metadataByURL[meta.DownloadURL] = meta
-	if meta.Dest != "" {
-		metadataByDest[meta.Dest] = meta
-	}
+	applyImportMaps(downloadsByKey, metadataByURL, metadataByDest, meta, row, hasDownload)
+	return res
+}
+
+func importDownloadRow(downloadsByKey map[string]state.DownloadRow, entry CatalogEntry) (state.DownloadRow, bool) {
 	if entry.Download != nil && entry.Download.URL != "" && entry.Download.Dest != "" {
 		row := state.DownloadRow{
 			URL:            entry.Download.URL,
@@ -221,14 +236,19 @@ func importOne(db *state.DB, downloadsByKey map[string]state.DownloadRow, metada
 				row.Status = "imported"
 			}
 		}
-		if err := db.UpsertDownload(row); err != nil {
-			res.Action = "conflict"
-			res.Reason = fmt.Sprintf("upsert download: %v", err)
-			return res
-		}
+		return row, true
+	}
+	return state.DownloadRow{}, false
+}
+
+func applyImportMaps(downloadsByKey map[string]state.DownloadRow, metadataByURL, metadataByDest map[string]state.ModelMetadata, meta state.ModelMetadata, row state.DownloadRow, hasDownload bool) {
+	metadataByURL[meta.DownloadURL] = meta
+	if meta.Dest != "" {
+		metadataByDest[meta.Dest] = meta
+	}
+	if hasDownload {
 		downloadsByKey[downloadKey(row.URL, row.Dest)] = row
 	}
-	return res
 }
 
 func snapshotDownload(row state.DownloadRow) *DownloadSnapshot {

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -270,7 +270,7 @@ func snapshotDownload(row state.DownloadRow) *DownloadSnapshot {
 }
 
 func downloadEqual(downloadsByKey map[string]state.DownloadRow, entry CatalogEntry) bool {
-	if entry.Download == nil {
+	if entry.Download == nil || entry.Download.URL == "" || entry.Download.Dest == "" {
 		return true
 	}
 	row, ok := downloadsByKey[downloadKey(entry.Download.URL, entry.Download.Dest)]

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -1,7 +1,6 @@
 package catalog
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -78,20 +77,14 @@ func Build(db *state.DB) (*Catalog, error) {
 		return nil, fmt.Errorf("list downloads: %w", err)
 	}
 	byURLDest := map[string]state.DownloadRow{}
-	byURL := map[string]state.DownloadRow{}
 	for _, row := range downloads {
 		byURLDest[downloadKey(row.URL, row.Dest)] = row
-		if _, ok := byURL[row.URL]; !ok {
-			byURL[row.URL] = row
-		}
 	}
 
 	entries := make([]CatalogEntry, 0, len(metadataRows))
 	for _, meta := range metadataRows {
 		entry := CatalogEntry{Metadata: meta}
 		if row, ok := byURLDest[downloadKey(meta.DownloadURL, meta.Dest)]; ok {
-			entry.Download = snapshotDownload(row)
-		} else if row, ok := byURL[meta.DownloadURL]; ok {
 			entry.Download = snapshotDownload(row)
 		}
 		entries = append(entries, entry)
@@ -130,10 +123,22 @@ func Import(db *state.DB, r io.Reader, opts ImportOptions) (*ImportResult, error
 	for _, row := range existingDownloads {
 		downloadsByKey[downloadKey(row.URL, row.Dest)] = row
 	}
+	existingMetadata, err := db.ListMetadata(state.MetadataFilters{})
+	if err != nil {
+		return nil, fmt.Errorf("list metadata: %w", err)
+	}
+	metadataByURL := map[string]state.ModelMetadata{}
+	metadataByDest := map[string]state.ModelMetadata{}
+	for _, meta := range existingMetadata {
+		metadataByURL[meta.DownloadURL] = meta
+		if meta.Dest != "" {
+			metadataByDest[meta.Dest] = meta
+		}
+	}
 
 	result := &ImportResult{DryRun: opts.DryRun}
 	for _, entry := range cat.Models {
-		action := importOne(db, downloadsByKey, entry, opts)
+		action := importOne(db, downloadsByKey, metadataByURL, metadataByDest, entry, opts)
 		result.Entries = append(result.Entries, action)
 		switch action.Action {
 		case "create":
@@ -149,7 +154,7 @@ func Import(db *state.DB, r io.Reader, opts ImportOptions) (*ImportResult, error
 	return result, nil
 }
 
-func importOne(db *state.DB, downloadsByKey map[string]state.DownloadRow, entry CatalogEntry, opts ImportOptions) ImportEntryResult {
+func importOne(db *state.DB, downloadsByKey map[string]state.DownloadRow, metadataByURL, metadataByDest map[string]state.ModelMetadata, entry CatalogEntry, opts ImportOptions) ImportEntryResult {
 	meta := entry.Metadata
 	res := ImportEntryResult{DownloadURL: meta.DownloadURL, Dest: meta.Dest}
 	if meta.DownloadURL == "" {
@@ -157,29 +162,31 @@ func importOne(db *state.DB, downloadsByKey map[string]state.DownloadRow, entry 
 		res.Reason = "metadata download_url is required"
 		return res
 	}
-	if meta.Dest != "" {
-		byDest, err := db.GetMetadataByDest(meta.Dest)
-		if err != nil {
+	if entry.Download != nil {
+		if entry.Download.URL != "" && entry.Download.URL != meta.DownloadURL {
 			res.Action = "conflict"
-			res.Reason = fmt.Sprintf("lookup destination: %v", err)
+			res.Reason = fmt.Sprintf("download snapshot URL %s does not match metadata URL", entry.Download.URL)
 			return res
 		}
-		if byDest != nil && byDest.DownloadURL != meta.DownloadURL {
+		if meta.Dest != "" && entry.Download.Dest != "" && entry.Download.Dest != meta.Dest {
+			res.Action = "conflict"
+			res.Reason = fmt.Sprintf("download snapshot destination %s does not match metadata destination", entry.Download.Dest)
+			return res
+		}
+	}
+	if meta.Dest != "" {
+		byDest, ok := metadataByDest[meta.Dest]
+		if ok && byDest.DownloadURL != meta.DownloadURL {
 			res.Action = "conflict"
 			res.Reason = fmt.Sprintf("destination already belongs to %s", byDest.DownloadURL)
 			return res
 		}
 	}
 
-	existing, err := db.GetMetadata(meta.DownloadURL)
-	if err != nil && err != sql.ErrNoRows {
-		res.Action = "conflict"
-		res.Reason = fmt.Sprintf("lookup metadata: %v", err)
-		return res
-	}
-	if err == sql.ErrNoRows {
+	existing, found := metadataByURL[meta.DownloadURL]
+	if !found {
 		res.Action = "create"
-	} else if metadataEqual(*existing, meta) && downloadEqual(downloadsByKey, entry) {
+	} else if metadataEqual(existing, meta) && downloadEqual(downloadsByKey, entry) {
 		res.Action = "skip"
 		return res
 	} else {
@@ -194,6 +201,10 @@ func importOne(db *state.DB, downloadsByKey map[string]state.DownloadRow, entry 
 		res.Reason = fmt.Sprintf("upsert metadata: %v", err)
 		return res
 	}
+	metadataByURL[meta.DownloadURL] = meta
+	if meta.Dest != "" {
+		metadataByDest[meta.Dest] = meta
+	}
 	if entry.Download != nil && entry.Download.URL != "" && entry.Download.Dest != "" {
 		row := state.DownloadRow{
 			URL:            entry.Download.URL,
@@ -204,7 +215,11 @@ func importOne(db *state.DB, downloadsByKey map[string]state.DownloadRow, entry 
 			Status:         entry.Download.Status,
 		}
 		if row.Status == "" {
-			row.Status = "imported"
+			if existingRow, ok := downloadsByKey[downloadKey(row.URL, row.Dest)]; ok {
+				row.Status = existingRow.Status
+			} else {
+				row.Status = "imported"
+			}
 		}
 		if err := db.UpsertDownload(row); err != nil {
 			res.Action = "conflict"
@@ -235,10 +250,11 @@ func downloadEqual(downloadsByKey map[string]state.DownloadRow, entry CatalogEnt
 	if !ok {
 		return false
 	}
+	statusMatches := entry.Download.Status == "" || row.Status == entry.Download.Status
 	return row.ExpectedSHA256 == entry.Download.ExpectedSHA256 &&
 		row.ActualSHA256 == entry.Download.ActualSHA256 &&
 		row.Size == entry.Download.Size &&
-		row.Status == entry.Download.Status
+		statusMatches
 }
 
 func metadataEqual(a, b state.ModelMetadata) bool {

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -1,0 +1,253 @@
+package catalog
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"time"
+
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+const Version = 1
+
+type Catalog struct {
+	App                string         `json:"app"`
+	CatalogVersion     int            `json:"catalog_version"`
+	StateSchemaVersion int            `json:"state_schema_version"`
+	ExportedAt         time.Time      `json:"exported_at"`
+	Models             []CatalogEntry `json:"models"`
+}
+
+type CatalogEntry struct {
+	Metadata state.ModelMetadata `json:"metadata"`
+	Download *DownloadSnapshot   `json:"download,omitempty"`
+}
+
+type DownloadSnapshot struct {
+	URL            string `json:"url"`
+	Dest           string `json:"dest"`
+	ExpectedSHA256 string `json:"expected_sha256,omitempty"`
+	ActualSHA256   string `json:"actual_sha256,omitempty"`
+	Size           int64  `json:"size,omitempty"`
+	Status         string `json:"status,omitempty"`
+}
+
+type ImportOptions struct {
+	DryRun bool
+}
+
+type ImportResult struct {
+	DryRun    bool                `json:"dry_run"`
+	Creates   int                 `json:"creates"`
+	Updates   int                 `json:"updates"`
+	Skips     int                 `json:"skips"`
+	Conflicts int                 `json:"conflicts"`
+	Entries   []ImportEntryResult `json:"entries"`
+}
+
+type ImportEntryResult struct {
+	DownloadURL string `json:"download_url"`
+	Dest        string `json:"dest,omitempty"`
+	Action      string `json:"action"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+func Export(db *state.DB, w io.Writer) error {
+	cat, err := Build(db)
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(cat)
+}
+
+func Build(db *state.DB) (*Catalog, error) {
+	if db == nil {
+		return nil, fmt.Errorf("nil db")
+	}
+	metadataRows, err := db.ListMetadata(state.MetadataFilters{OrderBy: "name"})
+	if err != nil {
+		return nil, fmt.Errorf("list metadata: %w", err)
+	}
+	downloads, err := db.ListDownloads()
+	if err != nil {
+		return nil, fmt.Errorf("list downloads: %w", err)
+	}
+	byURLDest := map[string]state.DownloadRow{}
+	byURL := map[string]state.DownloadRow{}
+	for _, row := range downloads {
+		byURLDest[downloadKey(row.URL, row.Dest)] = row
+		if _, ok := byURL[row.URL]; !ok {
+			byURL[row.URL] = row
+		}
+	}
+
+	entries := make([]CatalogEntry, 0, len(metadataRows))
+	for _, meta := range metadataRows {
+		entry := CatalogEntry{Metadata: meta}
+		if row, ok := byURLDest[downloadKey(meta.DownloadURL, meta.Dest)]; ok {
+			entry.Download = snapshotDownload(row)
+		} else if row, ok := byURL[meta.DownloadURL]; ok {
+			entry.Download = snapshotDownload(row)
+		}
+		entries = append(entries, entry)
+	}
+
+	return &Catalog{
+		App:                "modfetch",
+		CatalogVersion:     Version,
+		StateSchemaVersion: state.SchemaVersion,
+		ExportedAt:         time.Now().UTC(),
+		Models:             entries,
+	}, nil
+}
+
+func Import(db *state.DB, r io.Reader, opts ImportOptions) (*ImportResult, error) {
+	if db == nil {
+		return nil, fmt.Errorf("nil db")
+	}
+	var cat Catalog
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(&cat); err != nil {
+		return nil, fmt.Errorf("decode catalog: %w", err)
+	}
+	if cat.App != "" && cat.App != "modfetch" {
+		return nil, fmt.Errorf("unsupported catalog app %q", cat.App)
+	}
+	if cat.CatalogVersion > Version {
+		return nil, fmt.Errorf("catalog version %d is newer than supported version %d", cat.CatalogVersion, Version)
+	}
+
+	existingDownloads, err := db.ListDownloads()
+	if err != nil {
+		return nil, fmt.Errorf("list downloads: %w", err)
+	}
+	downloadsByKey := map[string]state.DownloadRow{}
+	for _, row := range existingDownloads {
+		downloadsByKey[downloadKey(row.URL, row.Dest)] = row
+	}
+
+	result := &ImportResult{DryRun: opts.DryRun}
+	for _, entry := range cat.Models {
+		action := importOne(db, downloadsByKey, entry, opts)
+		result.Entries = append(result.Entries, action)
+		switch action.Action {
+		case "create":
+			result.Creates++
+		case "update":
+			result.Updates++
+		case "skip":
+			result.Skips++
+		case "conflict":
+			result.Conflicts++
+		}
+	}
+	return result, nil
+}
+
+func importOne(db *state.DB, downloadsByKey map[string]state.DownloadRow, entry CatalogEntry, opts ImportOptions) ImportEntryResult {
+	meta := entry.Metadata
+	res := ImportEntryResult{DownloadURL: meta.DownloadURL, Dest: meta.Dest}
+	if meta.DownloadURL == "" {
+		res.Action = "conflict"
+		res.Reason = "metadata download_url is required"
+		return res
+	}
+	if meta.Dest != "" {
+		byDest, err := db.GetMetadataByDest(meta.Dest)
+		if err != nil {
+			res.Action = "conflict"
+			res.Reason = fmt.Sprintf("lookup destination: %v", err)
+			return res
+		}
+		if byDest != nil && byDest.DownloadURL != meta.DownloadURL {
+			res.Action = "conflict"
+			res.Reason = fmt.Sprintf("destination already belongs to %s", byDest.DownloadURL)
+			return res
+		}
+	}
+
+	existing, err := db.GetMetadata(meta.DownloadURL)
+	if err != nil && err != sql.ErrNoRows {
+		res.Action = "conflict"
+		res.Reason = fmt.Sprintf("lookup metadata: %v", err)
+		return res
+	}
+	if err == sql.ErrNoRows {
+		res.Action = "create"
+	} else if metadataEqual(*existing, meta) && downloadEqual(downloadsByKey, entry) {
+		res.Action = "skip"
+		return res
+	} else {
+		res.Action = "update"
+	}
+
+	if opts.DryRun {
+		return res
+	}
+	if err := db.UpsertMetadata(&meta); err != nil {
+		res.Action = "conflict"
+		res.Reason = fmt.Sprintf("upsert metadata: %v", err)
+		return res
+	}
+	if entry.Download != nil && entry.Download.URL != "" && entry.Download.Dest != "" {
+		row := state.DownloadRow{
+			URL:            entry.Download.URL,
+			Dest:           entry.Download.Dest,
+			ExpectedSHA256: entry.Download.ExpectedSHA256,
+			ActualSHA256:   entry.Download.ActualSHA256,
+			Size:           entry.Download.Size,
+			Status:         entry.Download.Status,
+		}
+		if row.Status == "" {
+			row.Status = "imported"
+		}
+		if err := db.UpsertDownload(row); err != nil {
+			res.Action = "conflict"
+			res.Reason = fmt.Sprintf("upsert download: %v", err)
+			return res
+		}
+		downloadsByKey[downloadKey(row.URL, row.Dest)] = row
+	}
+	return res
+}
+
+func snapshotDownload(row state.DownloadRow) *DownloadSnapshot {
+	return &DownloadSnapshot{
+		URL:            row.URL,
+		Dest:           row.Dest,
+		ExpectedSHA256: row.ExpectedSHA256,
+		ActualSHA256:   row.ActualSHA256,
+		Size:           row.Size,
+		Status:         row.Status,
+	}
+}
+
+func downloadEqual(downloadsByKey map[string]state.DownloadRow, entry CatalogEntry) bool {
+	if entry.Download == nil {
+		return true
+	}
+	row, ok := downloadsByKey[downloadKey(entry.Download.URL, entry.Download.Dest)]
+	if !ok {
+		return false
+	}
+	return row.ExpectedSHA256 == entry.Download.ExpectedSHA256 &&
+		row.ActualSHA256 == entry.Download.ActualSHA256 &&
+		row.Size == entry.Download.Size &&
+		row.Status == entry.Download.Status
+}
+
+func metadataEqual(a, b state.ModelMetadata) bool {
+	a.ID, b.ID = 0, 0
+	a.CreatedAt, b.CreatedAt = time.Time{}, time.Time{}
+	a.UpdatedAt, b.UpdatedAt = time.Time{}, time.Time{}
+	return reflect.DeepEqual(a, b)
+}
+
+func downloadKey(url, dest string) string {
+	return url + "\x00" + dest
+}

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -169,6 +169,10 @@ func importOne(db *state.DB, downloadsByKey map[string]state.DownloadRow, metada
 			res.Reason = fmt.Sprintf("download snapshot URL %s does not match metadata URL", entry.Download.URL)
 			return res
 		}
+		if meta.Dest == "" && entry.Download.Dest != "" {
+			meta.Dest = entry.Download.Dest
+			res.Dest = meta.Dest
+		}
 		if meta.Dest != "" && entry.Download.Dest != "" && entry.Download.Dest != meta.Dest {
 			res.Action = "conflict"
 			res.Reason = fmt.Sprintf("download snapshot destination %s does not match metadata destination", entry.Download.Dest)
@@ -242,6 +246,9 @@ func importDownloadRow(downloadsByKey map[string]state.DownloadRow, entry Catalo
 }
 
 func applyImportMaps(downloadsByKey map[string]state.DownloadRow, metadataByURL, metadataByDest map[string]state.ModelMetadata, meta state.ModelMetadata, row state.DownloadRow, hasDownload bool) {
+	if existing, ok := metadataByURL[meta.DownloadURL]; ok && existing.Dest != "" && existing.Dest != meta.Dest {
+		delete(metadataByDest, existing.Dest)
+	}
 	metadataByURL[meta.DownloadURL] = meta
 	if meta.Dest != "" {
 		metadataByDest[meta.Dest] = meta

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -1,0 +1,168 @@
+package catalog
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+func TestExportImportRoundTripPreservesLibraryCatalog(t *testing.T) {
+	source := testDB(t)
+	destPath := filepath.Join(t.TempDir(), "llama.gguf")
+	meta := state.ModelMetadata{
+		DownloadURL:   "https://example.com/llama.gguf",
+		Dest:          destPath,
+		ModelName:     "Llama Test",
+		ModelID:       "org/llama-test",
+		Source:        "huggingface",
+		ModelType:     "LLM",
+		Tags:          []string{"llama", "gguf"},
+		Quantization:  "Q4_K_M",
+		FileSize:      42,
+		FileFormat:    ".gguf",
+		UserNotes:     "portable favorite",
+		UserRating:    5,
+		Favorite:      true,
+		HomepageURL:   "https://example.com/llama",
+		ThumbnailURL:  "https://example.com/llama.png",
+		DownloadCount: 7,
+		TimesUsed:     3,
+	}
+	if err := source.UpsertMetadata(&meta); err != nil {
+		t.Fatalf("upsert metadata: %v", err)
+	}
+	if err := source.UpsertDownload(state.DownloadRow{
+		URL:            meta.DownloadURL,
+		Dest:           meta.Dest,
+		ExpectedSHA256: "expected",
+		ActualSHA256:   "actual",
+		Size:           meta.FileSize,
+		Status:         "completed",
+	}); err != nil {
+		t.Fatalf("upsert download: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := Export(source, &buf); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	var exported Catalog
+	if err := json.Unmarshal(buf.Bytes(), &exported); err != nil {
+		t.Fatalf("decode export: %v", err)
+	}
+	if exported.CatalogVersion != Version || len(exported.Models) != 1 {
+		t.Fatalf("unexpected exported catalog: %+v", exported)
+	}
+	if exported.Models[0].Download == nil || exported.Models[0].Download.ActualSHA256 != "actual" {
+		t.Fatalf("expected checksum snapshot in export, got %+v", exported.Models[0].Download)
+	}
+
+	target := testDB(t)
+	result, err := Import(target, bytes.NewReader(buf.Bytes()), ImportOptions{})
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if result.Creates != 1 || result.Updates != 0 || result.Skips != 0 || result.Conflicts != 0 {
+		t.Fatalf("unexpected import result: %+v", result)
+	}
+
+	imported, err := target.GetMetadata(meta.DownloadURL)
+	if err != nil {
+		t.Fatalf("get imported metadata: %v", err)
+	}
+	if imported.ModelName != meta.ModelName || !imported.Favorite || imported.UserNotes != meta.UserNotes {
+		t.Fatalf("metadata was not preserved: %+v", imported)
+	}
+	downloads, err := target.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(downloads) != 1 || downloads[0].ActualSHA256 != "actual" || downloads[0].ExpectedSHA256 != "expected" {
+		t.Fatalf("download checksum was not preserved: %+v", downloads)
+	}
+
+	second, err := Import(target, bytes.NewReader(buf.Bytes()), ImportOptions{})
+	if err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+	if second.Skips != 1 || second.Creates != 0 || second.Updates != 0 || second.Conflicts != 0 {
+		t.Fatalf("expected idempotent skip, got %+v", second)
+	}
+}
+
+func TestImportDryRunReportsCreatesWithoutWriting(t *testing.T) {
+	db := testDB(t)
+	cat := Catalog{
+		App:            "modfetch",
+		CatalogVersion: Version,
+		Models: []CatalogEntry{{
+			Metadata: state.ModelMetadata{
+				DownloadURL: "https://example.com/model.safetensors",
+				Dest:        "/models/model.safetensors",
+				ModelName:   "Dry Run Model",
+			},
+		}},
+	}
+	payload := encodeCatalog(t, cat)
+	result, err := Import(db, bytes.NewReader(payload), ImportOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("dry-run import: %v", err)
+	}
+	if !result.DryRun || result.Creates != 1 {
+		t.Fatalf("unexpected dry-run result: %+v", result)
+	}
+	if _, err := db.GetMetadata("https://example.com/model.safetensors"); err == nil {
+		t.Fatal("dry-run import wrote metadata")
+	}
+}
+
+func TestImportReportsDestinationConflict(t *testing.T) {
+	db := testDB(t)
+	if err := db.UpsertMetadata(&state.ModelMetadata{
+		DownloadURL: "https://example.com/existing.gguf",
+		Dest:        "/models/shared.gguf",
+		ModelName:   "Existing",
+	}); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	cat := Catalog{
+		App:            "modfetch",
+		CatalogVersion: Version,
+		Models: []CatalogEntry{{
+			Metadata: state.ModelMetadata{
+				DownloadURL: "https://example.com/incoming.gguf",
+				Dest:        "/models/shared.gguf",
+				ModelName:   "Incoming",
+			},
+		}},
+	}
+	result, err := Import(db, bytes.NewReader(encodeCatalog(t, cat)), ImportOptions{})
+	if err != nil {
+		t.Fatalf("import conflict catalog: %v", err)
+	}
+	if result.Conflicts != 1 || result.Entries[0].Action != "conflict" {
+		t.Fatalf("expected destination conflict, got %+v", result)
+	}
+}
+
+func encodeCatalog(t *testing.T, cat Catalog) []byte {
+	t.Helper()
+	payload, err := json.Marshal(cat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+func testDB(t *testing.T) *state.DB {
+	t.Helper()
+	db, err := state.NewDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -209,6 +209,77 @@ func TestImportRejectsMismatchedDownloadSnapshot(t *testing.T) {
 	}
 }
 
+func TestImportNormalizesSnapshotOnlyDestination(t *testing.T) {
+	db := testDB(t)
+	cat := Catalog{
+		App:            "modfetch",
+		CatalogVersion: Version,
+		Models: []CatalogEntry{{
+			Metadata: state.ModelMetadata{
+				DownloadURL: "https://example.com/model.gguf",
+				ModelName:   "Model",
+			},
+			Download: &DownloadSnapshot{
+				URL:    "https://example.com/model.gguf",
+				Dest:   "/models/model.gguf",
+				Status: "completed",
+			},
+		}},
+	}
+	result, err := Import(db, bytes.NewReader(encodeCatalog(t, cat)), ImportOptions{})
+	if err != nil {
+		t.Fatalf("import snapshot-only dest catalog: %v", err)
+	}
+	if result.Creates != 1 || result.Conflicts != 0 {
+		t.Fatalf("expected create without conflict, got %+v", result)
+	}
+	meta, err := db.GetMetadata("https://example.com/model.gguf")
+	if err != nil {
+		t.Fatalf("get metadata: %v", err)
+	}
+	if meta.Dest != "/models/model.gguf" {
+		t.Fatalf("expected metadata destination to be normalized, got %q", meta.Dest)
+	}
+}
+
+func TestImportDryRunMovedDestinationFreesOldPath(t *testing.T) {
+	db := testDB(t)
+	if err := db.UpsertMetadata(&state.ModelMetadata{
+		DownloadURL: "https://example.com/moved.gguf",
+		Dest:        "/models/old.gguf",
+		ModelName:   "Moved",
+	}); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	cat := Catalog{
+		App:            "modfetch",
+		CatalogVersion: Version,
+		Models: []CatalogEntry{
+			{
+				Metadata: state.ModelMetadata{
+					DownloadURL: "https://example.com/moved.gguf",
+					Dest:        "/models/new.gguf",
+					ModelName:   "Moved",
+				},
+			},
+			{
+				Metadata: state.ModelMetadata{
+					DownloadURL: "https://example.com/replacement.gguf",
+					Dest:        "/models/old.gguf",
+					ModelName:   "Replacement",
+				},
+			},
+		},
+	}
+	result, err := Import(db, bytes.NewReader(encodeCatalog(t, cat)), ImportOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("dry-run import moved destination catalog: %v", err)
+	}
+	if result.Updates != 1 || result.Creates != 1 || result.Conflicts != 0 {
+		t.Fatalf("expected move to free old destination in dry-run, got %+v", result)
+	}
+}
+
 func TestImportEmptySnapshotStatusPreservesExistingDownloadStatus(t *testing.T) {
 	db := testDB(t)
 	meta := state.ModelMetadata{

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -119,6 +119,40 @@ func TestImportDryRunReportsCreatesWithoutWriting(t *testing.T) {
 	}
 }
 
+func TestImportDryRunSimulatesEarlierEntries(t *testing.T) {
+	db := testDB(t)
+	cat := Catalog{
+		App:            "modfetch",
+		CatalogVersion: Version,
+		Models: []CatalogEntry{
+			{
+				Metadata: state.ModelMetadata{
+					DownloadURL: "https://example.com/first.gguf",
+					Dest:        "/models/shared.gguf",
+					ModelName:   "First",
+				},
+			},
+			{
+				Metadata: state.ModelMetadata{
+					DownloadURL: "https://example.com/second.gguf",
+					Dest:        "/models/shared.gguf",
+					ModelName:   "Second",
+				},
+			},
+		},
+	}
+	result, err := Import(db, bytes.NewReader(encodeCatalog(t, cat)), ImportOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("dry-run import: %v", err)
+	}
+	if result.Creates != 1 || result.Conflicts != 1 {
+		t.Fatalf("expected dry-run to simulate destination conflict, got %+v", result)
+	}
+	if _, err := db.GetMetadata("https://example.com/first.gguf"); err == nil {
+		t.Fatal("dry-run import wrote metadata")
+	}
+}
+
 func TestImportReportsDestinationConflict(t *testing.T) {
 	db := testDB(t)
 	if err := db.UpsertMetadata(&state.ModelMetadata{

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -327,6 +327,43 @@ func TestImportEmptySnapshotStatusPreservesExistingDownloadStatus(t *testing.T) 
 	}
 }
 
+func TestImportIncompleteDownloadSnapshotIsIgnoredForIdempotency(t *testing.T) {
+	db := testDB(t)
+	meta := state.ModelMetadata{
+		DownloadURL: "https://example.com/model.gguf",
+		Dest:        "/models/model.gguf",
+		ModelName:   "Model",
+	}
+	if err := db.UpsertMetadata(&meta); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	if err := db.UpsertDownload(state.DownloadRow{
+		URL:    meta.DownloadURL,
+		Dest:   meta.Dest,
+		Size:   10,
+		Status: "completed",
+	}); err != nil {
+		t.Fatalf("seed download: %v", err)
+	}
+	cat := Catalog{
+		App:            "modfetch",
+		CatalogVersion: Version,
+		Models: []CatalogEntry{{
+			Metadata: meta,
+			Download: &DownloadSnapshot{
+				URL: meta.DownloadURL,
+			},
+		}},
+	}
+	result, err := Import(db, bytes.NewReader(encodeCatalog(t, cat)), ImportOptions{})
+	if err != nil {
+		t.Fatalf("import incomplete download catalog: %v", err)
+	}
+	if result.Skips != 1 || result.Creates != 0 || result.Updates != 0 || result.Conflicts != 0 {
+		t.Fatalf("expected incomplete snapshot to be ignored for idempotency, got %+v", result)
+	}
+}
+
 func encodeCatalog(t *testing.T, cat Catalog) []byte {
 	t.Helper()
 	payload, err := json.Marshal(cat)

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -148,6 +148,80 @@ func TestImportReportsDestinationConflict(t *testing.T) {
 	}
 }
 
+func TestImportRejectsMismatchedDownloadSnapshot(t *testing.T) {
+	db := testDB(t)
+	cat := Catalog{
+		App:            "modfetch",
+		CatalogVersion: Version,
+		Models: []CatalogEntry{{
+			Metadata: state.ModelMetadata{
+				DownloadURL: "https://example.com/model.gguf",
+				Dest:        "/models/model.gguf",
+				ModelName:   "Model",
+			},
+			Download: &DownloadSnapshot{
+				URL:    "https://example.com/other.gguf",
+				Dest:   "/models/model.gguf",
+				Status: "completed",
+			},
+		}},
+	}
+	result, err := Import(db, bytes.NewReader(encodeCatalog(t, cat)), ImportOptions{})
+	if err != nil {
+		t.Fatalf("import mismatch catalog: %v", err)
+	}
+	if result.Conflicts != 1 || result.Entries[0].Action != "conflict" {
+		t.Fatalf("expected snapshot mismatch conflict, got %+v", result)
+	}
+}
+
+func TestImportEmptySnapshotStatusPreservesExistingDownloadStatus(t *testing.T) {
+	db := testDB(t)
+	meta := state.ModelMetadata{
+		DownloadURL: "https://example.com/model.gguf",
+		Dest:        "/models/model.gguf",
+		ModelName:   "Model",
+	}
+	if err := db.UpsertMetadata(&meta); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	if err := db.UpsertDownload(state.DownloadRow{
+		URL:    meta.DownloadURL,
+		Dest:   meta.Dest,
+		Size:   10,
+		Status: "completed",
+	}); err != nil {
+		t.Fatalf("seed download: %v", err)
+	}
+	meta.ModelName = "Model Updated"
+	cat := Catalog{
+		App:            "modfetch",
+		CatalogVersion: Version,
+		Models: []CatalogEntry{{
+			Metadata: meta,
+			Download: &DownloadSnapshot{
+				URL:  meta.DownloadURL,
+				Dest: meta.Dest,
+				Size: 10,
+			},
+		}},
+	}
+	result, err := Import(db, bytes.NewReader(encodeCatalog(t, cat)), ImportOptions{})
+	if err != nil {
+		t.Fatalf("import empty-status catalog: %v", err)
+	}
+	if result.Updates != 1 {
+		t.Fatalf("expected update, got %+v", result)
+	}
+	rows, err := db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Status != "completed" {
+		t.Fatalf("expected existing status to be preserved, got %+v", rows)
+	}
+}
+
 func encodeCatalog(t *testing.T, cat Catalog) []byte {
 	t.Helper()
 	payload, err := json.Marshal(cat)

--- a/internal/state/metadata.go
+++ b/internal/state/metadata.go
@@ -8,6 +8,10 @@ import (
 	"time"
 )
 
+type metadataExecer interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+}
+
 // ModelMetadata stores rich metadata about downloaded models
 type ModelMetadata struct {
 	ID int64 `json:"id"`
@@ -146,6 +150,18 @@ func (db *DB) InitMetadataTable() error {
 
 // UpsertMetadata inserts or updates model metadata
 func (db *DB) UpsertMetadata(meta *ModelMetadata) error {
+	err := upsertMetadata(db.SQL, meta)
+	if err == nil {
+		db.NotifyChange()
+	}
+	return err
+}
+
+func (db *DB) UpsertMetadataTx(tx *sql.Tx, meta *ModelMetadata) error {
+	return upsertMetadata(tx, meta)
+}
+
+func upsertMetadata(exec metadataExecer, meta *ModelMetadata) error {
 	if meta.DownloadURL == "" {
 		return fmt.Errorf("download_url is required")
 	}
@@ -208,7 +224,7 @@ func (db *DB) UpsertMetadata(meta *ModelMetadata) error {
 		user_rating=excluded.user_rating,
 		favorite=excluded.favorite`
 
-	_, err = db.SQL.Exec(stmt,
+	_, err = exec.Exec(stmt,
 		meta.DownloadURL, meta.Dest, meta.ModelName, meta.ModelID, meta.Version, meta.Source,
 		meta.Description, meta.Author, meta.AuthorURL, meta.License, string(tagsJSON),
 		meta.ModelType, meta.BaseModel, meta.Architecture, meta.ParameterCount, meta.Quantization,
@@ -218,10 +234,6 @@ func (db *DB) UpsertMetadata(meta *ModelMetadata) error {
 		meta.CreatedAt.Unix(), meta.UpdatedAt.Unix(),
 		meta.UserNotes, meta.UserRating, meta.Favorite,
 	)
-	if err == nil {
-		db.NotifyChange()
-	}
-
 	return err
 }
 


### PR DESCRIPTION
## Summary
- add `modfetch library export/import` for JSON model-library catalogs
- preserve metadata, favorites, destination/source hints, and download checksums in exports
- add import dry-run, create/update/skip/conflict reporting, idempotent re-imports, and destination conflict checks
- document backup/migration workflows and mark the roadmap slice done

## Tests
- git diff --check
- GOCACHE="$PWD/.cache/go-build" GOMODCACHE="$PWD/.cache/gomod" go test ./internal/catalog ./cmd/modfetch
- GOCACHE="$PWD/.cache/go-build" GOMODCACHE="$PWD/.cache/gomod" go test ./...
- GOCACHE="$PWD/.cache/go-build" GOMODCACHE="$PWD/.cache/gomod" make build
- ./bin/modfetch help | rg -n "library export|library import"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->