### PR TITLE
[codex] Add TUI library filters and bulk actions

### DIFF
--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -143,8 +143,17 @@ The library automatically paginates when you have more models than fit on screen
 | `5` or `L` | Switch to Library tab |
 | `Enter` | View model details |
 | `Esc` | Back to list / Exit detail view |
-| `f` | Toggle favorite on selected model |
+| `Space` | Select or deselect the highlighted model |
+| `A` | Select all visible models |
+| `X` | Clear library selection |
+| `f` | Favorite or unfavorite selected models |
 | `/` | Activate search |
+| `F` | Open filter menu |
+| `r` or `y` | Retry selected downloads |
+| `V` | Verify selected files |
+| `p` | Place selected files |
+| `E` | Export selected catalog entries |
+| `D` | Delete staged data after confirmation |
 | `S` | Scan directories for models |
 | `↑` `↓` `j` `k` | Navigate model list |
 | `g` `G` | Jump to first/last model |
@@ -183,7 +192,7 @@ Model Library • Search: "llama"
 
 ### Filtering by Type
 
-Filter models by type using the internal filter state (future enhancement will add UI controls):
+Press `F`, choose `Type`, and press `Enter` to cycle through known model types:
 
 **Supported types:**
 - `LLM` - Large language models (.gguf, .ggml files)
@@ -196,7 +205,7 @@ Filter models by type using the internal filter state (future enhancement will a
 
 ### Filtering by Source
 
-Filter models by source:
+Press `F`, choose `Source`, and press `Enter` to cycle through known sources:
 
 **Supported sources:**
 - `huggingface` - Models from HuggingFace Hub
@@ -212,7 +221,26 @@ Mark important models as favorites:
 2. Press `f` to toggle favorite status
 3. Favorite models show a ★ indicator
 
-Filter to show only favorites by enabling the favorites filter (future UI enhancement).
+Filter to show only favorites by pressing `F`, choosing `Favorites`, and pressing `Enter`.
+
+### Bulk Actions
+
+Use `Space` to select individual rows, `A` to select all visible rows, and `X`
+to clear the selection. When no rows are selected, library actions apply to the
+highlighted row.
+
+- `r` or `y`: retry the selected models' download URLs.
+- `V`: verify selected files and refresh checksum/status state.
+- `p`: place selected files using configured placement rules.
+- `f`: favorite the selection if any selected model is not favorite; otherwise
+  unfavorite the selection.
+- `E`: export selected entries to `library-selected-catalog.json` under the data
+  root.
+- `D`: delete staged download rows/chunks, and files under the download root,
+  after a confirmation summary. Library metadata is kept.
+
+Selections are tracked by model identity, so a selected model remains selected
+when filters temporarily hide it and later reveal it again.
 
 ## Model Details
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -67,17 +67,17 @@ Acceptance checks:
   destination, checksum, and core metadata.
 - Import dry-run reports creates, updates, skips, and conflicts without writes.
 
-### 3. TUI Bulk Operations and Filter Menu [TODO]
+### 3. TUI Bulk Operations and Filter Menu [DONE]
 
 Outcome: common library maintenance tasks are possible from the TUI without
 dropping to separate CLI commands.
 
-- [TODO] Implement the documented `F` filter menu for library type/source,
+- [DONE] Implement the documented `F` filter menu for library type/source,
   favorite status, and text search.
-- [TODO] Add multi-select bulk actions for retry, delete staged data, verify,
+- [DONE] Add multi-select bulk actions for retry, delete staged data, verify,
   place, favorite/unfavorite, and export selected catalog entries.
-- [TODO] Show bulk-action confirmation summaries before destructive actions.
-- [TODO] Add tests for selection persistence across filters and tabs.
+- [DONE] Show bulk-action confirmation summaries before destructive actions.
+- [DONE] Add tests for selection persistence across filters and tabs.
 
 Acceptance checks:
 - Selection state remains stable when filters change.

--- a/docs/TUI_GUIDE.md
+++ b/docs/TUI_GUIDE.md
@@ -106,11 +106,19 @@ help overlay.
 
 - `j`/`k` or arrow keys - Navigate model list
 - `/` - Search models by name
+- `F` - Open the filter menu for search, model type, source, and favorites
+- `Space` - Select or deselect the highlighted model
+- `A` - Select all visible library models
+- `X` - Clear library selection
 - `Enter` - View model details
 - `Esc` - Return to list from detail view
-- `f` - Toggle favorite on selected model
+- `f` - Favorite or unfavorite the current selection
+- `r` or `y` - Retry selected library downloads
+- `V` - Verify selected files and update checksum/status state
+- `p` - Place selected files using configured placement rules
+- `E` - Export selected models to `library-selected-catalog.json`
+- `D` - Delete selected staged download data after confirmation
 - `S` - Scan directories for new models
-- `F` - Toggle filter menu (future)
 
 ### Settings Tab Keys
 
@@ -145,6 +153,12 @@ Default naming
 - Press / to filter by substring (e.g., part of the filename or URL)
 - Press g to toggle grouping by status
 - Sorting works with or without grouping
+
+Library filtering:
+- Press `F` on the Library tab to open the filter menu.
+- Use `j`/`k` or arrow keys to choose Search, Type, Source, Favorites, or Clear filters.
+- Press `Enter` to edit search, cycle type/source values, toggle favorites, or clear all filters.
+- Library selections are tracked by model identity, so selected rows remain selected when filters hide and later reveal them.
 
 ## Speed and ETA
 
@@ -214,4 +228,3 @@ For animated SVGs/GIFs, consider tools like svg-term or agg (requires additional
 - Quiet logs are for the CLI; the TUI always shows live state
 - For large batches, consider using batch YAML with `modfetch download --batch jobs.yml` alongside the TUI
 - Export MODFETCH_CONFIG for convenience so TUI and CLI share defaults
-

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -90,7 +90,7 @@ func (m *Model) renderCommandsBar() string {
 
 func (m *Model) renderLibraryCommandsBar() string {
 	// Library tab commands reference
-	return m.th.footer.Render("j/k navigate • Enter details • Esc back • / search • S scan directories • f favorite • H toasts • ? help • q quit")
+	return m.th.footer.Render("j/k navigate • Space select • A all • X clear • F filters • f favorite • r retry • V verify • p place • E export • D delete staged • ? help • q quit")
 }
 
 func (m *Model) renderSettingsCommandsBar() string {
@@ -119,9 +119,10 @@ func (m *Model) renderHelp() string {
 	sb.WriteString("\n")
 	sb.WriteString(m.th.head.Render("Library Tab (5/L)") + "\n")
 	sb.WriteString("Nav: j/k up/down • Enter view details • Esc back to list\n")
-	sb.WriteString("Search: / to enter; Enter to apply; Esc to clear\n")
+	sb.WriteString("Search/filter: / search • F filter menu for search, type, source, favorites\n")
+	sb.WriteString("Select: Space toggle • A select visible • X clear selection\n")
 	sb.WriteString("Scan: S scan configured directories for existing models\n")
-	sb.WriteString("Favorite: f toggle favorite on selected model\n")
+	sb.WriteString("Bulk actions: r retry • V verify files • p place • f favorite/unfavorite • E export catalog • D delete staged data\n")
 	sb.WriteString("\n")
 	sb.WriteString(m.th.head.Render("Settings Tab (6/M)") + "\n")
 	sb.WriteString("View current configuration including paths, tokens, and preferences\n")

--- a/internal/tui/library_actions.go
+++ b/internal/tui/library_actions.go
@@ -1,0 +1,423 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jxwalker/modfetch/internal/catalog"
+	"github.com/jxwalker/modfetch/internal/placer"
+	"github.com/jxwalker/modfetch/internal/state"
+	"github.com/jxwalker/modfetch/internal/util"
+)
+
+func libraryKey(meta state.ModelMetadata) string {
+	if strings.TrimSpace(meta.DownloadURL) != "" {
+		return meta.DownloadURL
+	}
+	return meta.Dest
+}
+
+func (m *Model) currentLibraryKey() string {
+	if m.librarySelected >= 0 && m.librarySelected < len(m.libraryRows) {
+		return libraryKey(m.libraryRows[m.librarySelected])
+	}
+	return ""
+}
+
+func (m *Model) restoreLibrarySelection(key string) {
+	if len(m.libraryRows) == 0 {
+		m.librarySelected = 0
+		return
+	}
+	if key != "" {
+		for i, row := range m.libraryRows {
+			if libraryKey(row) == key {
+				m.librarySelected = i
+				return
+			}
+		}
+	}
+	if key == "" && m.librarySelected >= len(m.libraryRows) {
+		m.librarySelected = 0
+		return
+	}
+	if m.librarySelected < 0 {
+		m.librarySelected = 0
+	}
+	if m.librarySelected >= len(m.libraryRows) {
+		m.librarySelected = len(m.libraryRows) - 1
+	}
+}
+
+func (m *Model) selectedLibraryRows() []state.ModelMetadata {
+	if len(m.librarySelectedKeys) == 0 {
+		if m.librarySelected >= 0 && m.librarySelected < len(m.libraryRows) {
+			return []state.ModelMetadata{m.libraryRows[m.librarySelected]}
+		}
+		return nil
+	}
+	rows := make([]state.ModelMetadata, 0, len(m.librarySelectedKeys))
+	for _, row := range m.libraryRows {
+		if m.librarySelectedKeys[libraryKey(row)] {
+			rows = append(rows, row)
+		}
+	}
+	return rows
+}
+
+func (m *Model) applyLibraryFilters(rows []state.ModelMetadata) []state.ModelMetadata {
+	filtered := rows[:0]
+	for _, row := range rows {
+		if m.libraryFilterType != "" && row.ModelType != m.libraryFilterType {
+			continue
+		}
+		if m.libraryFilterSource != "" && row.Source != m.libraryFilterSource {
+			continue
+		}
+		if m.libraryShowFavorites && !row.Favorite {
+			continue
+		}
+		filtered = append(filtered, row)
+	}
+	return filtered
+}
+
+func (m *Model) updateLibraryFilterMenu(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	s := msg.String()
+	selectedKey := m.currentLibraryKey()
+	if m.libraryFilterEditing {
+		switch s {
+		case "enter", "ctrl+j":
+			m.libraryFilterEditing = false
+			m.librarySearch = strings.TrimSpace(m.librarySearchInput.Value())
+			m.refreshLibraryData()
+			m.restoreLibrarySelection(selectedKey)
+			return m, nil
+		case "esc":
+			m.libraryFilterEditing = false
+			m.librarySearchInput.SetValue(m.librarySearch)
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.librarySearchInput, cmd = m.librarySearchInput.Update(msg)
+		return m, cmd
+	}
+
+	switch s {
+	case "esc", "F":
+		m.libraryFilterMenu = false
+		return m, nil
+	case "j", "down":
+		if m.libraryFilterIndex < 4 {
+			m.libraryFilterIndex++
+		}
+		return m, nil
+	case "k", "up":
+		if m.libraryFilterIndex > 0 {
+			m.libraryFilterIndex--
+		}
+		return m, nil
+	case "enter", "ctrl+j", " ":
+		switch m.libraryFilterIndex {
+		case 0:
+			m.libraryFilterEditing = true
+			m.librarySearchInput.SetValue(m.librarySearch)
+			m.librarySearchInput.Focus()
+		case 1:
+			m.libraryFilterType = nextValue(m.libraryFilterType, m.libraryFilterValues("type"))
+			m.refreshLibraryData()
+			m.restoreLibrarySelection(selectedKey)
+		case 2:
+			m.libraryFilterSource = nextValue(m.libraryFilterSource, m.libraryFilterValues("source"))
+			m.refreshLibraryData()
+			m.restoreLibrarySelection(selectedKey)
+		case 3:
+			m.libraryShowFavorites = !m.libraryShowFavorites
+			m.refreshLibraryData()
+			m.restoreLibrarySelection(selectedKey)
+		case 4:
+			m.librarySearch = ""
+			m.librarySearchInput.SetValue("")
+			m.libraryFilterType = ""
+			m.libraryFilterSource = ""
+			m.libraryShowFavorites = false
+			m.refreshLibraryData()
+			m.restoreLibrarySelection(selectedKey)
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m *Model) updateLibraryConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "n", "N":
+		m.libraryConfirm = nil
+		return m, nil
+	case "y", "Y", "enter", "ctrl+j":
+		action := m.libraryConfirm
+		m.libraryConfirm = nil
+		if action != nil && action.action == "delete-staged" {
+			return m, m.deleteLibraryStagedCmd(action.rows)
+		}
+	}
+	return m, nil
+}
+
+func (m *Model) libraryFilterValues(field string) []string {
+	if m.st == nil {
+		return nil
+	}
+	rows, err := m.st.ListMetadata(state.MetadataFilters{OrderBy: "name", Limit: 1000})
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	for _, row := range rows {
+		var v string
+		switch field {
+		case "type":
+			v = row.ModelType
+		case "source":
+			v = row.Source
+		}
+		v = strings.TrimSpace(v)
+		if v != "" {
+			seen[v] = true
+		}
+	}
+	values := make([]string, 0, len(seen)+1)
+	values = append(values, "")
+	for v := range seen {
+		values = append(values, v)
+	}
+	sort.Strings(values[1:])
+	return values
+}
+
+func nextValue(current string, values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	for i, value := range values {
+		if value == current {
+			return values[(i+1)%len(values)]
+		}
+	}
+	return values[0]
+}
+
+func (m *Model) retryLibraryRows(rows []state.ModelMetadata) tea.Cmd {
+	if m.st == nil {
+		return nil
+	}
+	cmds := make([]tea.Cmd, 0, len(rows))
+	for _, row := range rows {
+		if strings.TrimSpace(row.DownloadURL) == "" || strings.TrimSpace(row.Dest) == "" {
+			continue
+		}
+		_ = m.st.UpsertDownload(state.DownloadRow{URL: row.DownloadURL, Dest: row.Dest, Status: "pending"})
+		cmds = append(cmds, m.startDownloadCmd(row.DownloadURL, row.Dest, false, row.ModelType))
+	}
+	if len(cmds) > 0 {
+		m.addToast(fmt.Sprintf("retrying %d library item(s)", len(cmds)))
+	}
+	return tea.Batch(cmds...)
+}
+
+func (m *Model) toggleFavoriteLibraryRows(rows []state.ModelMetadata) tea.Cmd {
+	if len(rows) == 0 || m.st == nil {
+		return nil
+	}
+	makeFavorite := false
+	for _, row := range rows {
+		if !row.Favorite {
+			makeFavorite = true
+			break
+		}
+	}
+	count := 0
+	for _, row := range rows {
+		row.Favorite = makeFavorite
+		if err := m.st.UpsertMetadata(&row); err == nil {
+			count++
+		}
+	}
+	if count > 0 {
+		if makeFavorite {
+			m.addToast(fmt.Sprintf("favorited %d", count))
+		} else {
+			m.addToast(fmt.Sprintf("unfavorited %d", count))
+		}
+	}
+	m.libraryNeedsRefresh = true
+	m.refreshLibraryData()
+	return nil
+}
+
+func (m *Model) placeLibraryRowsCmd(rows []state.ModelMetadata) tea.Cmd {
+	return func() tea.Msg {
+		if m.cfg == nil {
+			return libraryBulkMsg{action: "place", err: fmt.Errorf("missing config")}
+		}
+		count := 0
+		for _, row := range rows {
+			if strings.TrimSpace(row.Dest) == "" {
+				continue
+			}
+			if _, err := os.Stat(row.Dest); err != nil {
+				return libraryBulkMsg{action: "place", count: count, err: err}
+			}
+			if _, err := placer.Place(m.cfg, row.Dest, "", ""); err != nil {
+				return libraryBulkMsg{action: "place", count: count, err: err}
+			}
+			count++
+		}
+		return libraryBulkMsg{action: "place", count: count}
+	}
+}
+
+func (m *Model) verifyLibraryRowsCmd(rows []state.ModelMetadata) tea.Cmd {
+	return func() tea.Msg {
+		if m.st == nil {
+			return libraryBulkMsg{action: "verify", err: fmt.Errorf("missing database")}
+		}
+		downloadRows, _ := m.st.ListDownloads()
+		downloads := map[string]state.DownloadRow{}
+		for _, row := range downloadRows {
+			downloads[keyFor(row)] = row
+		}
+		count := 0
+		for _, meta := range rows {
+			if strings.TrimSpace(meta.Dest) == "" {
+				continue
+			}
+			sum, err := util.HashFileSHA256(meta.Dest)
+			key := meta.DownloadURL + "|" + meta.Dest
+			row := downloads[key]
+			row.URL = meta.DownloadURL
+			row.Dest = meta.Dest
+			if err != nil {
+				row.Status = "verify_failed"
+				row.LastError = err.Error()
+				_ = m.st.UpsertDownload(row)
+				return libraryBulkMsg{action: "verify", count: count, err: err}
+			}
+			want := strings.TrimSpace(row.ExpectedSHA256)
+			if want == "" {
+				want = strings.TrimSpace(row.ActualSHA256)
+			}
+			if want != "" && !strings.EqualFold(want, sum) {
+				row.ActualSHA256 = sum
+				row.Status = "verify_failed"
+				row.LastError = "checksum mismatch"
+				_ = m.st.UpsertDownload(row)
+				return libraryBulkMsg{action: "verify", count: count, err: fmt.Errorf("checksum mismatch for %s", meta.Dest)}
+			}
+			row.ActualSHA256 = sum
+			row.Status = "completed"
+			row.LastError = ""
+			_ = m.st.UpsertDownload(row)
+			count++
+		}
+		return libraryBulkMsg{action: "verify", count: count}
+	}
+}
+
+func (m *Model) exportLibraryRowsCmd(rows []state.ModelMetadata) tea.Cmd {
+	return func() tea.Msg {
+		if m.st == nil {
+			return libraryBulkMsg{action: "export", err: fmt.Errorf("missing database")}
+		}
+		cat, err := catalog.Build(m.st)
+		if err != nil {
+			return libraryBulkMsg{action: "export", err: err}
+		}
+		selected := map[string]bool{}
+		for _, row := range rows {
+			selected[libraryKey(row)] = true
+		}
+		entries := cat.Models[:0]
+		for _, entry := range cat.Models {
+			if selected[libraryKey(entry.Metadata)] {
+				entries = append(entries, entry)
+			}
+		}
+		cat.Models = entries
+		path := m.libraryExportPath()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return libraryBulkMsg{action: "export", err: err}
+		}
+		f, err := os.Create(path)
+		if err != nil {
+			return libraryBulkMsg{action: "export", err: err}
+		}
+		defer func() { _ = f.Close() }()
+		enc := json.NewEncoder(f)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(cat); err != nil {
+			return libraryBulkMsg{action: "export", err: err}
+		}
+		return libraryBulkMsg{action: "export", count: len(entries), path: path}
+	}
+}
+
+func (m *Model) deleteLibraryStagedCmd(rows []state.ModelMetadata) tea.Cmd {
+	return func() tea.Msg {
+		if m.st == nil {
+			return libraryBulkMsg{action: "delete staged", err: fmt.Errorf("missing database")}
+		}
+		count := 0
+		for _, row := range rows {
+			if strings.TrimSpace(row.DownloadURL) != "" && strings.TrimSpace(row.Dest) != "" {
+				if err := m.st.DeleteDownloadAndChunks(row.DownloadURL, row.Dest); err == nil {
+					count++
+				}
+			}
+			if m.isStagedLibraryPath(row.Dest) {
+				_ = os.Remove(row.Dest)
+			}
+			delete(m.librarySelectedKeys, libraryKey(row))
+		}
+		return libraryBulkMsg{action: "delete staged", count: count}
+	}
+}
+
+func (m *Model) libraryExportPath() string {
+	if m.cfg == nil {
+		return filepath.Join(os.TempDir(), "modfetch-library-selected-catalog.json")
+	}
+	root := strings.TrimSpace(m.cfg.General.DataRoot)
+	if root == "" {
+		root = filepath.Dir(m.uiStatePath())
+	}
+	return filepath.Join(root, "library-selected-catalog.json")
+}
+
+func (m *Model) isStagedLibraryPath(path string) bool {
+	if m.cfg == nil {
+		return false
+	}
+	root := strings.TrimSpace(m.cfg.General.DownloadRoot)
+	if root == "" || strings.TrimSpace(path) == "" {
+		return false
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(absRoot, absPath)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (!strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && rel != "..")
+}

--- a/internal/tui/library_actions.go
+++ b/internal/tui/library_actions.go
@@ -90,6 +90,18 @@ func (m *Model) applyLibraryFilters(rows []state.ModelMetadata) []state.ModelMet
 	return filtered
 }
 
+const libraryRowLimit = 1000
+
+func normalizeLibraryRows(rows []state.ModelMetadata) []state.ModelMetadata {
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rows[i].UpdatedAt.After(rows[j].UpdatedAt)
+	})
+	if len(rows) > libraryRowLimit {
+		return rows[:libraryRowLimit]
+	}
+	return rows
+}
+
 func (m *Model) updateLibraryFilterMenu(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	s := msg.String()
 	selectedKey := m.currentLibraryKey()
@@ -273,16 +285,21 @@ func (m *Model) toggleFavoriteLibraryRowsCmd(rows []state.ModelMetadata) tea.Cmd
 			break
 		}
 	}
+	clearKeys := !makeFavorite && m.libraryShowFavorites
 	return func() tea.Msg {
 		count := 0
+		keys := make([]string, 0, len(rows))
 		for _, row := range rows {
 			row.Favorite = makeFavorite
 			if err := m.st.UpsertMetadata(&row); err != nil {
-				return libraryBulkMsg{action: favoriteActionName(makeFavorite), count: count, err: err}
+				return libraryBulkMsg{action: favoriteActionName(makeFavorite), count: count, keys: keys, err: err}
+			}
+			if clearKeys {
+				keys = append(keys, libraryKey(row))
 			}
 			count++
 		}
-		return libraryBulkMsg{action: favoriteActionName(makeFavorite), count: count}
+		return libraryBulkMsg{action: favoriteActionName(makeFavorite), count: count, keys: keys}
 	}
 }
 
@@ -432,6 +449,7 @@ func (m *Model) deleteLibraryStagedCmd(rows []state.ModelMetadata) tea.Cmd {
 			return libraryBulkMsg{action: "delete staged", err: fmt.Errorf("missing database")}
 		}
 		count := 0
+		keys := make([]string, 0, len(rows))
 		var firstErr error
 		for _, row := range rows {
 			if !m.isStagedLibraryPath(row.Dest) {
@@ -456,10 +474,10 @@ func (m *Model) deleteLibraryStagedCmd(rows []state.ModelMetadata) tea.Cmd {
 				deleted = true
 			}
 			if deleted {
-				delete(m.librarySelectedKeys, libraryKey(row))
+				keys = append(keys, libraryKey(row))
 			}
 		}
-		return libraryBulkMsg{action: "delete staged", count: count, err: firstErr}
+		return libraryBulkMsg{action: "delete staged", count: count, keys: keys, err: firstErr}
 	}
 }
 

--- a/internal/tui/library_actions.go
+++ b/internal/tui/library_actions.go
@@ -19,10 +19,16 @@ import (
 )
 
 func libraryKey(meta state.ModelMetadata) string {
-	if strings.TrimSpace(meta.DownloadURL) != "" {
-		return meta.DownloadURL
+	url := strings.TrimSpace(meta.DownloadURL)
+	dest := strings.TrimSpace(meta.Dest)
+	switch {
+	case url != "" && dest != "":
+		return url + "|" + dest
+	case url != "":
+		return url
+	default:
+		return dest
 	}
-	return meta.Dest
 }
 
 func (m *Model) currentLibraryKey() string {
@@ -104,14 +110,12 @@ func normalizeLibraryRows(rows []state.ModelMetadata) []state.ModelMetadata {
 
 func (m *Model) updateLibraryFilterMenu(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	s := msg.String()
-	selectedKey := m.currentLibraryKey()
 	if m.libraryFilterEditing {
 		switch s {
 		case "enter", "ctrl+j":
 			m.libraryFilterEditing = false
 			m.librarySearch = strings.TrimSpace(m.librarySearchInput.Value())
 			m.refreshLibraryData()
-			m.restoreLibrarySelection(selectedKey)
 			return m, nil
 		case "esc":
 			m.libraryFilterEditing = false
@@ -146,15 +150,12 @@ func (m *Model) updateLibraryFilterMenu(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case 1:
 			m.libraryFilterType = nextValue(m.libraryFilterType, m.libraryFilterValues("type"))
 			m.refreshLibraryData()
-			m.restoreLibrarySelection(selectedKey)
 		case 2:
 			m.libraryFilterSource = nextValue(m.libraryFilterSource, m.libraryFilterValues("source"))
 			m.refreshLibraryData()
-			m.restoreLibrarySelection(selectedKey)
 		case 3:
 			m.libraryShowFavorites = !m.libraryShowFavorites
 			m.refreshLibraryData()
-			m.restoreLibrarySelection(selectedKey)
 		case 4:
 			m.librarySearch = ""
 			m.librarySearchInput.SetValue("")
@@ -162,7 +163,6 @@ func (m *Model) updateLibraryFilterMenu(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.libraryFilterSource = ""
 			m.libraryShowFavorites = false
 			m.refreshLibraryData()
-			m.restoreLibrarySelection(selectedKey)
 		}
 		return m, nil
 	}
@@ -246,7 +246,7 @@ func (m *Model) retryLibraryRows(rows []state.ModelMetadata) tea.Cmd {
 		ctx, cancel := context.WithCancel(context.Background())
 		m.running[key] = cancel
 		m.retrying[key] = now
-		cmds = append(cmds, m.retryLibraryRowCmd(ctx, row))
+		cmds = append(cmds, m.retryLibraryRowCmd(ctx, row, key))
 	}
 	if len(cmds) > 0 {
 		m.addToast(fmt.Sprintf("retrying %d library item(s)", len(cmds)))
@@ -257,10 +257,10 @@ func (m *Model) retryLibraryRows(rows []state.ModelMetadata) tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
-func (m *Model) retryLibraryRowCmd(ctx context.Context, row state.ModelMetadata) tea.Cmd {
+func (m *Model) retryLibraryRowCmd(ctx context.Context, row state.ModelMetadata, key string) tea.Cmd {
 	return func() tea.Msg {
 		if err := m.st.UpsertDownload(state.DownloadRow{URL: row.DownloadURL, Dest: row.Dest, Status: "pending"}); err != nil {
-			return libraryBulkMsg{action: "retry", err: err}
+			return libraryBulkMsg{action: "retry", runningKeys: []string{key}, err: err}
 		}
 		return m.startDownloadCmdCtx(ctx, row.DownloadURL, row.Dest, false, row.ModelType)()
 	}

--- a/internal/tui/library_actions.go
+++ b/internal/tui/library_actions.go
@@ -1,12 +1,15 @@
 package tui
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	neturl "net/url"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jxwalker/modfetch/internal/catalog"
@@ -170,15 +173,8 @@ func (m *Model) updateLibraryConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) libraryFilterValues(field string) []string {
-	if m.st == nil {
-		return nil
-	}
-	rows, err := m.st.ListMetadata(state.MetadataFilters{OrderBy: "name", Limit: 1000})
-	if err != nil {
-		return nil
-	}
 	seen := map[string]bool{}
-	for _, row := range rows {
+	for _, row := range m.libraryRows {
 		var v string
 		switch field {
 		case "type":
@@ -217,20 +213,56 @@ func (m *Model) retryLibraryRows(rows []state.ModelMetadata) tea.Cmd {
 		return nil
 	}
 	cmds := make([]tea.Cmd, 0, len(rows))
+	skipped := 0
+	now := time.Now()
 	for _, row := range rows {
 		if strings.TrimSpace(row.DownloadURL) == "" || strings.TrimSpace(row.Dest) == "" {
 			continue
 		}
-		_ = m.st.UpsertDownload(state.DownloadRow{URL: row.DownloadURL, Dest: row.Dest, Status: "pending"})
-		cmds = append(cmds, m.startDownloadCmd(row.DownloadURL, row.Dest, false, row.ModelType))
+		if !retryableLibraryURL(row.DownloadURL) {
+			skipped++
+			continue
+		}
+		key := row.DownloadURL + "|" + row.Dest
+		if _, ok := m.running[key]; ok {
+			continue
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		m.running[key] = cancel
+		m.retrying[key] = now
+		cmds = append(cmds, m.retryLibraryRowCmd(ctx, row))
 	}
 	if len(cmds) > 0 {
 		m.addToast(fmt.Sprintf("retrying %d library item(s)", len(cmds)))
 	}
+	if skipped > 0 {
+		m.addToast(fmt.Sprintf("skipped %d local item(s); only remote downloads can retry", skipped))
+	}
 	return tea.Batch(cmds...)
 }
 
-func (m *Model) toggleFavoriteLibraryRows(rows []state.ModelMetadata) tea.Cmd {
+func (m *Model) retryLibraryRowCmd(ctx context.Context, row state.ModelMetadata) tea.Cmd {
+	return func() tea.Msg {
+		if err := m.st.UpsertDownload(state.DownloadRow{URL: row.DownloadURL, Dest: row.Dest, Status: "pending"}); err != nil {
+			return libraryBulkMsg{action: "retry", err: err}
+		}
+		return m.startDownloadCmdCtx(ctx, row.DownloadURL, row.Dest, false, row.ModelType)()
+	}
+}
+
+func retryableLibraryURL(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if strings.HasPrefix(raw, "hf://") || strings.HasPrefix(raw, "civitai://") {
+		return true
+	}
+	u, err := neturl.Parse(raw)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == "http" || u.Scheme == "https"
+}
+
+func (m *Model) toggleFavoriteLibraryRowsCmd(rows []state.ModelMetadata) tea.Cmd {
 	if len(rows) == 0 || m.st == nil {
 		return nil
 	}
@@ -241,23 +273,24 @@ func (m *Model) toggleFavoriteLibraryRows(rows []state.ModelMetadata) tea.Cmd {
 			break
 		}
 	}
-	count := 0
-	for _, row := range rows {
-		row.Favorite = makeFavorite
-		if err := m.st.UpsertMetadata(&row); err == nil {
+	return func() tea.Msg {
+		count := 0
+		for _, row := range rows {
+			row.Favorite = makeFavorite
+			if err := m.st.UpsertMetadata(&row); err != nil {
+				return libraryBulkMsg{action: favoriteActionName(makeFavorite), count: count, err: err}
+			}
 			count++
 		}
+		return libraryBulkMsg{action: favoriteActionName(makeFavorite), count: count}
 	}
-	if count > 0 {
-		if makeFavorite {
-			m.addToast(fmt.Sprintf("favorited %d", count))
-		} else {
-			m.addToast(fmt.Sprintf("unfavorited %d", count))
-		}
+}
+
+func favoriteActionName(makeFavorite bool) string {
+	if makeFavorite {
+		return "favorite"
 	}
-	m.libraryNeedsRefresh = true
-	m.refreshLibraryData()
-	return nil
+	return "unfavorite"
 }
 
 func (m *Model) placeLibraryRowsCmd(rows []state.ModelMetadata) tea.Cmd {
@@ -266,19 +299,26 @@ func (m *Model) placeLibraryRowsCmd(rows []state.ModelMetadata) tea.Cmd {
 			return libraryBulkMsg{action: "place", err: fmt.Errorf("missing config")}
 		}
 		count := 0
+		var firstErr error
 		for _, row := range rows {
 			if strings.TrimSpace(row.Dest) == "" {
 				continue
 			}
 			if _, err := os.Stat(row.Dest); err != nil {
-				return libraryBulkMsg{action: "place", count: count, err: err}
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
 			}
 			if _, err := placer.Place(m.cfg, row.Dest, "", ""); err != nil {
-				return libraryBulkMsg{action: "place", count: count, err: err}
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
 			}
 			count++
 		}
-		return libraryBulkMsg{action: "place", count: count}
+		return libraryBulkMsg{action: "place", count: count, err: firstErr}
 	}
 }
 
@@ -287,12 +327,16 @@ func (m *Model) verifyLibraryRowsCmd(rows []state.ModelMetadata) tea.Cmd {
 		if m.st == nil {
 			return libraryBulkMsg{action: "verify", err: fmt.Errorf("missing database")}
 		}
-		downloadRows, _ := m.st.ListDownloads()
+		downloadRows, err := m.st.ListDownloads()
+		if err != nil {
+			return libraryBulkMsg{action: "verify", err: err}
+		}
 		downloads := map[string]state.DownloadRow{}
 		for _, row := range downloadRows {
 			downloads[keyFor(row)] = row
 		}
 		count := 0
+		var firstErr error
 		for _, meta := range rows {
 			if strings.TrimSpace(meta.Dest) == "" {
 				continue
@@ -305,8 +349,13 @@ func (m *Model) verifyLibraryRowsCmd(rows []state.ModelMetadata) tea.Cmd {
 			if err != nil {
 				row.Status = "verify_failed"
 				row.LastError = err.Error()
-				_ = m.st.UpsertDownload(row)
-				return libraryBulkMsg{action: "verify", count: count, err: err}
+				if upsertErr := m.st.UpsertDownload(row); upsertErr != nil && firstErr == nil {
+					firstErr = upsertErr
+				}
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
 			}
 			want := strings.TrimSpace(row.ExpectedSHA256)
 			if want == "" {
@@ -316,16 +365,26 @@ func (m *Model) verifyLibraryRowsCmd(rows []state.ModelMetadata) tea.Cmd {
 				row.ActualSHA256 = sum
 				row.Status = "verify_failed"
 				row.LastError = "checksum mismatch"
-				_ = m.st.UpsertDownload(row)
-				return libraryBulkMsg{action: "verify", count: count, err: fmt.Errorf("checksum mismatch for %s", meta.Dest)}
+				if upsertErr := m.st.UpsertDownload(row); upsertErr != nil && firstErr == nil {
+					firstErr = upsertErr
+				}
+				if firstErr == nil {
+					firstErr = fmt.Errorf("checksum mismatch for %s", meta.Dest)
+				}
+				continue
 			}
 			row.ActualSHA256 = sum
 			row.Status = "completed"
 			row.LastError = ""
-			_ = m.st.UpsertDownload(row)
+			if err := m.st.UpsertDownload(row); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
 			count++
 		}
-		return libraryBulkMsg{action: "verify", count: count}
+		return libraryBulkMsg{action: "verify", count: count, err: firstErr}
 	}
 }
 
@@ -373,18 +432,34 @@ func (m *Model) deleteLibraryStagedCmd(rows []state.ModelMetadata) tea.Cmd {
 			return libraryBulkMsg{action: "delete staged", err: fmt.Errorf("missing database")}
 		}
 		count := 0
+		var firstErr error
 		for _, row := range rows {
+			if !m.isStagedLibraryPath(row.Dest) {
+				continue
+			}
+			deleted := false
 			if strings.TrimSpace(row.DownloadURL) != "" && strings.TrimSpace(row.Dest) != "" {
-				if err := m.st.DeleteDownloadAndChunks(row.DownloadURL, row.Dest); err == nil {
+				if err := m.st.DeleteDownloadAndChunks(row.DownloadURL, row.Dest); err != nil {
+					if firstErr == nil {
+						firstErr = err
+					}
+				} else {
 					count++
+					deleted = true
 				}
 			}
-			if m.isStagedLibraryPath(row.Dest) {
-				_ = os.Remove(row.Dest)
+			if err := os.Remove(row.Dest); err != nil && !os.IsNotExist(err) {
+				if firstErr == nil {
+					firstErr = err
+				}
+			} else {
+				deleted = true
 			}
-			delete(m.librarySelectedKeys, libraryKey(row))
+			if deleted {
+				delete(m.librarySelectedKeys, libraryKey(row))
+			}
 		}
-		return libraryBulkMsg{action: "delete staged", count: count}
+		return libraryBulkMsg{action: "delete staged", count: count, err: firstErr}
 	}
 }
 
@@ -419,5 +494,9 @@ func (m *Model) isStagedLibraryPath(path string) bool {
 	if err != nil {
 		return false
 	}
-	return rel == "." || (!strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && rel != "..")
+	if rel == "." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || rel == ".." {
+		return false
+	}
+	info, err := os.Stat(absPath)
+	return err == nil && !info.IsDir()
 }

--- a/internal/tui/library_actions.go
+++ b/internal/tui/library_actions.go
@@ -186,7 +186,11 @@ func (m *Model) updateLibraryConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m *Model) libraryFilterValues(field string) []string {
 	seen := map[string]bool{}
-	for _, row := range m.libraryRows {
+	rows := m.libraryFilterRows
+	if len(rows) == 0 {
+		rows = m.libraryRows
+	}
+	for _, row := range rows {
 		var v string
 		switch field {
 		case "type":
@@ -455,25 +459,25 @@ func (m *Model) deleteLibraryStagedCmd(rows []state.ModelMetadata) tea.Cmd {
 			if !m.isStagedLibraryPath(row.Dest) {
 				continue
 			}
-			deleted := false
+			dbDeleted := strings.TrimSpace(row.DownloadURL) == "" || strings.TrimSpace(row.Dest) == ""
 			if strings.TrimSpace(row.DownloadURL) != "" && strings.TrimSpace(row.Dest) != "" {
 				if err := m.st.DeleteDownloadAndChunks(row.DownloadURL, row.Dest); err != nil {
 					if firstErr == nil {
 						firstErr = err
 					}
 				} else {
-					count++
-					deleted = true
+					dbDeleted = true
 				}
 			}
+			fileDeleted := true
 			if err := os.Remove(row.Dest); err != nil && !os.IsNotExist(err) {
+				fileDeleted = false
 				if firstErr == nil {
 					firstErr = err
 				}
-			} else {
-				deleted = true
 			}
-			if deleted {
+			if dbDeleted && fileDeleted {
+				count++
 				keys = append(keys, libraryKey(row))
 			}
 		}

--- a/internal/tui/library_test.go
+++ b/internal/tui/library_test.go
@@ -1,12 +1,15 @@
 package tui
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jxwalker/modfetch/internal/catalog"
 	"github.com/jxwalker/modfetch/internal/config"
 	"github.com/jxwalker/modfetch/internal/state"
 )
@@ -685,6 +688,265 @@ func TestLibrary_ThemeApplication(t *testing.T) {
 	}()
 
 	_ = model.renderLibrary()
+}
+
+func TestLibrary_FilterMenuCyclesFiltersAndSearch(t *testing.T) {
+	model, db, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	models := []state.ModelMetadata{
+		{
+			DownloadURL: "https://example.com/llm.gguf",
+			ModelName:   "llama",
+			ModelType:   "LLM",
+			Source:      "huggingface",
+			Dest:        "/models/llm.gguf",
+		},
+		{
+			DownloadURL: "https://example.com/lora.safetensors",
+			ModelName:   "portrait",
+			ModelType:   "LoRA",
+			Source:      "civitai",
+			Dest:        "/models/lora.safetensors",
+		},
+	}
+	for i := range models {
+		if err := db.UpsertMetadata(&models[i]); err != nil {
+			t.Fatalf("seed metadata: %v", err)
+		}
+	}
+	model.refreshLibraryData()
+
+	model.libraryFilterMenu = true
+	model.libraryFilterIndex = 1
+	_, _ = model.updateLibraryFilterMenu(tea.KeyMsg{Type: tea.KeyEnter})
+	if model.libraryFilterType != "LLM" {
+		t.Fatalf("expected first type filter to be LLM, got %q", model.libraryFilterType)
+	}
+	if len(model.libraryRows) != 1 || model.libraryRows[0].ModelType != "LLM" {
+		t.Fatalf("type filter did not apply: %+v", model.libraryRows)
+	}
+
+	model.libraryFilterIndex = 0
+	_, _ = model.updateLibraryFilterMenu(tea.KeyMsg{Type: tea.KeyEnter})
+	model.librarySearchInput.SetValue("llama")
+	_, _ = model.updateLibraryFilterMenu(tea.KeyMsg{Type: tea.KeyEnter})
+	if model.librarySearch != "llama" || len(model.libraryRows) != 1 {
+		t.Fatalf("search filter did not apply: search=%q rows=%d", model.librarySearch, len(model.libraryRows))
+	}
+}
+
+func TestLibrary_SelectionPersistsAcrossFiltersAndTabs(t *testing.T) {
+	model, db, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	selected := state.ModelMetadata{
+		DownloadURL: "https://example.com/selected.gguf",
+		ModelName:   "selected",
+		ModelType:   "LLM",
+		Source:      "huggingface",
+		Dest:        "/models/selected.gguf",
+	}
+	hidden := state.ModelMetadata{
+		DownloadURL: "https://example.com/hidden.safetensors",
+		ModelName:   "hidden",
+		ModelType:   "LoRA",
+		Source:      "civitai",
+		Dest:        "/models/hidden.safetensors",
+	}
+	if err := db.UpsertMetadata(&selected); err != nil {
+		t.Fatalf("seed selected: %v", err)
+	}
+	if err := db.UpsertMetadata(&hidden); err != nil {
+		t.Fatalf("seed hidden: %v", err)
+	}
+
+	model.activeTab = 4
+	model.refreshLibraryData()
+	for i, row := range model.libraryRows {
+		if row.DownloadURL == selected.DownloadURL {
+			model.librarySelected = i
+			break
+		}
+	}
+	_, _ = model.Update(tea.KeyMsg{Type: tea.KeySpace})
+	if !model.librarySelectedKeys[selected.DownloadURL] {
+		t.Fatal("expected selected model to be tracked")
+	}
+
+	model.libraryFilterType = "LoRA"
+	model.refreshLibraryData()
+	if model.librarySelectedKeys[selected.DownloadURL] != true {
+		t.Fatal("selection should remain tracked while filtered out")
+	}
+	model.libraryFilterType = ""
+	model.refreshLibraryData()
+	if !model.librarySelectedKeys[selected.DownloadURL] {
+		t.Fatal("selection should survive clearing filters")
+	}
+
+	model.activeTab = 0
+	_, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("l")})
+	if model.activeTab != 4 || !model.librarySelectedKeys[selected.DownloadURL] {
+		t.Fatal("library selection should survive tab navigation")
+	}
+}
+
+func TestLibrary_BulkFavoriteToggle(t *testing.T) {
+	model, db, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	createTestMetadata(t, db, 2)
+	model.activeTab = 4
+	model.refreshLibraryData()
+	_, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("A")})
+	_, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("f")})
+
+	for _, row := range model.libraryRows {
+		got, err := db.GetMetadata(row.DownloadURL)
+		if err != nil {
+			t.Fatalf("get metadata: %v", err)
+		}
+		if !got.Favorite {
+			t.Fatalf("expected %s to be favorite", row.DownloadURL)
+		}
+	}
+
+	_, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("f")})
+	for _, row := range model.libraryRows {
+		got, err := db.GetMetadata(row.DownloadURL)
+		if err != nil {
+			t.Fatalf("get metadata: %v", err)
+		}
+		if got.Favorite {
+			t.Fatalf("expected %s to be unfavorited", row.DownloadURL)
+		}
+	}
+}
+
+func TestLibrary_BulkExportSelectedCatalog(t *testing.T) {
+	model, db, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	createTestMetadata(t, db, 2)
+	model.activeTab = 4
+	model.refreshLibraryData()
+	model.librarySelectedKeys[libraryKey(model.libraryRows[0])] = true
+
+	msg := model.exportLibraryRowsCmd(model.selectedLibraryRows())()
+	result, ok := msg.(libraryBulkMsg)
+	if !ok {
+		t.Fatalf("expected libraryBulkMsg, got %T", msg)
+	}
+	if result.err != nil {
+		t.Fatalf("export failed: %v", result.err)
+	}
+	if result.count != 1 {
+		t.Fatalf("expected one exported entry, got %d", result.count)
+	}
+	data, err := os.ReadFile(result.path)
+	if err != nil {
+		t.Fatalf("read export: %v", err)
+	}
+	var exported catalog.Catalog
+	if err := json.Unmarshal(data, &exported); err != nil {
+		t.Fatalf("decode export: %v", err)
+	}
+	if len(exported.Models) != 1 {
+		t.Fatalf("expected one catalog model, got %d", len(exported.Models))
+	}
+}
+
+func TestLibrary_BulkVerifyUpdatesDownloadRow(t *testing.T) {
+	model, db, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	path := filepath.Join(model.cfg.General.DownloadRoot, "model.gguf")
+	if err := os.WriteFile(path, []byte("model"), 0o644); err != nil {
+		t.Fatalf("write model: %v", err)
+	}
+	meta := state.ModelMetadata{
+		DownloadURL: "https://example.com/model.gguf",
+		ModelName:   "model",
+		Dest:        path,
+	}
+	if err := db.UpsertMetadata(&meta); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	model.refreshLibraryData()
+
+	msg := model.verifyLibraryRowsCmd(model.libraryRows)()
+	result, ok := msg.(libraryBulkMsg)
+	if !ok {
+		t.Fatalf("expected libraryBulkMsg, got %T", msg)
+	}
+	if result.err != nil || result.count != 1 {
+		t.Fatalf("verify failed: %+v", result)
+	}
+	rows, err := db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Status != "completed" || rows[0].ActualSHA256 == "" {
+		t.Fatalf("expected completed verified row, got %+v", rows)
+	}
+}
+
+func TestLibrary_DeleteStagedDataRequiresConfirmation(t *testing.T) {
+	model, db, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	path := filepath.Join(model.cfg.General.DownloadRoot, "staged.gguf")
+	if err := os.WriteFile(path, []byte("staged"), 0o644); err != nil {
+		t.Fatalf("write staged: %v", err)
+	}
+	meta := state.ModelMetadata{
+		DownloadURL: "https://example.com/staged.gguf",
+		ModelName:   "staged",
+		Dest:        path,
+	}
+	if err := db.UpsertMetadata(&meta); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	if err := db.UpsertDownload(state.DownloadRow{URL: meta.DownloadURL, Dest: meta.Dest, Status: "completed"}); err != nil {
+		t.Fatalf("seed download: %v", err)
+	}
+	model.activeTab = 4
+	model.refreshLibraryData()
+
+	_, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	if cmd != nil {
+		t.Fatal("delete should wait for confirmation")
+	}
+	if model.libraryConfirm == nil {
+		t.Fatal("expected confirmation state")
+	}
+
+	_, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected delete command after confirmation")
+	}
+	msg := cmd()
+	result, ok := msg.(libraryBulkMsg)
+	if !ok {
+		t.Fatalf("expected libraryBulkMsg, got %T", msg)
+	}
+	if result.err != nil {
+		t.Fatalf("delete failed: %v", result.err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected staged file to be removed, err=%v", err)
+	}
+	rows, err := db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected download row deleted, got %+v", rows)
+	}
+	if _, err := db.GetMetadata(meta.DownloadURL); err != nil {
+		t.Fatalf("metadata should be kept: %v", err)
+	}
 }
 
 // Helper function to create pointer to time

--- a/internal/tui/library_test.go
+++ b/internal/tui/library_test.go
@@ -736,6 +736,50 @@ func TestLibrary_FilterMenuCyclesFiltersAndSearch(t *testing.T) {
 	}
 }
 
+func TestLibrary_FilterMenuValuesUseUnfilteredRows(t *testing.T) {
+	model, db, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	models := []state.ModelMetadata{
+		{
+			DownloadURL: "https://example.com/llm.gguf",
+			ModelName:   "llama",
+			ModelType:   "LLM",
+			Source:      "huggingface",
+			Dest:        "/models/llm.gguf",
+		},
+		{
+			DownloadURL: "https://example.com/lora.safetensors",
+			ModelName:   "portrait",
+			ModelType:   "LoRA",
+			Source:      "civitai",
+			Dest:        "/models/lora.safetensors",
+		},
+	}
+	for i := range models {
+		if err := db.UpsertMetadata(&models[i]); err != nil {
+			t.Fatalf("seed metadata: %v", err)
+		}
+	}
+
+	model.libraryFilterType = "LLM"
+	model.refreshLibraryData()
+	if len(model.libraryRows) != 1 || model.libraryRows[0].ModelType != "LLM" {
+		t.Fatalf("expected active type filter to show LLM only, got %+v", model.libraryRows)
+	}
+
+	model.libraryFilterMenu = true
+	model.libraryFilterIndex = 1
+	_, _ = model.updateLibraryFilterMenu(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if model.libraryFilterType != "LoRA" {
+		t.Fatalf("expected type menu to cycle to LoRA, got %q", model.libraryFilterType)
+	}
+	if len(model.libraryRows) != 1 || model.libraryRows[0].ModelType != "LoRA" {
+		t.Fatalf("expected LoRA row after cycling type filter, got %+v", model.libraryRows)
+	}
+}
+
 func TestLibrary_FilterMenuClearResetsAllFilters(t *testing.T) {
 	model, db, cleanup := setupTestLibrary(t)
 	defer cleanup()

--- a/internal/tui/library_test.go
+++ b/internal/tui/library_test.go
@@ -736,6 +736,58 @@ func TestLibrary_FilterMenuCyclesFiltersAndSearch(t *testing.T) {
 	}
 }
 
+func TestLibrary_FilterMenuClearResetsAllFilters(t *testing.T) {
+	model, db, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	models := []state.ModelMetadata{
+		{
+			DownloadURL: "https://example.com/llm.gguf",
+			ModelName:   "llama",
+			ModelType:   "LLM",
+			Source:      "huggingface",
+			Dest:        "/models/llm.gguf",
+			Favorite:    true,
+		},
+		{
+			DownloadURL: "https://example.com/lora.safetensors",
+			ModelName:   "portrait",
+			ModelType:   "LoRA",
+			Source:      "civitai",
+			Dest:        "/models/lora.safetensors",
+		},
+	}
+	for i := range models {
+		if err := db.UpsertMetadata(&models[i]); err != nil {
+			t.Fatalf("seed metadata: %v", err)
+		}
+	}
+
+	model.librarySearch = "llama"
+	model.librarySearchInput.SetValue("llama")
+	model.libraryFilterType = "LoRA"
+	model.libraryFilterSource = "civitai"
+	model.libraryShowFavorites = true
+	model.refreshLibraryData()
+	if len(model.libraryRows) != 0 {
+		t.Fatalf("expected combined filters to hide all rows, got %d", len(model.libraryRows))
+	}
+
+	model.libraryFilterMenu = true
+	model.libraryFilterIndex = 4
+	_, _ = model.updateLibraryFilterMenu(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if model.librarySearch != "" || model.librarySearchInput.Value() != "" {
+		t.Fatalf("search was not cleared: search=%q input=%q", model.librarySearch, model.librarySearchInput.Value())
+	}
+	if model.libraryFilterType != "" || model.libraryFilterSource != "" || model.libraryShowFavorites {
+		t.Fatalf("filters were not cleared: type=%q source=%q favorites=%v", model.libraryFilterType, model.libraryFilterSource, model.libraryShowFavorites)
+	}
+	if len(model.libraryRows) != 2 {
+		t.Fatalf("expected all rows after clearing filters, got %d", len(model.libraryRows))
+	}
+}
+
 func TestLibrary_SelectionPersistsAcrossFiltersAndTabs(t *testing.T) {
 	model, db, cleanup := setupTestLibrary(t)
 	defer cleanup()
@@ -829,6 +881,27 @@ func TestLibrary_BulkFavoriteToggle(t *testing.T) {
 		if got.Favorite {
 			t.Fatalf("expected %s to be unfavorited", row.DownloadURL)
 		}
+	}
+}
+
+func TestLibrary_BulkMessagePrunesActedSelectionKeys(t *testing.T) {
+	model, _, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	model.librarySelectedKeys["acted"] = true
+	model.librarySelectedKeys["kept"] = true
+
+	_, _ = model.Update(libraryBulkMsg{
+		action: "favorite",
+		count:  1,
+		keys:   []string{"acted"},
+	})
+
+	if model.librarySelectedKeys["acted"] {
+		t.Fatal("expected acted key to be pruned from selection")
+	}
+	if !model.librarySelectedKeys["kept"] {
+		t.Fatal("expected unrelated selection key to remain")
 	}
 }
 
@@ -962,6 +1035,9 @@ func TestLibrary_DeleteStagedDataRequiresConfirmation(t *testing.T) {
 	}
 	if result.err != nil {
 		t.Fatalf("delete failed: %v", result.err)
+	}
+	if len(result.keys) != 1 || result.keys[0] != meta.DownloadURL {
+		t.Fatalf("expected acted key in delete result, got %+v", result.keys)
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("expected staged file to be removed, err=%v", err)

--- a/internal/tui/library_test.go
+++ b/internal/tui/library_test.go
@@ -866,25 +866,41 @@ func TestLibrary_SelectionPersistsAcrossFiltersAndTabs(t *testing.T) {
 		}
 	}
 	_, _ = model.Update(tea.KeyMsg{Type: tea.KeySpace})
-	if !model.librarySelectedKeys[selected.DownloadURL] {
+	selectedKey := libraryKey(selected)
+	if !model.librarySelectedKeys[selectedKey] {
 		t.Fatal("expected selected model to be tracked")
 	}
 
 	model.libraryFilterType = "LoRA"
 	model.refreshLibraryData()
-	if model.librarySelectedKeys[selected.DownloadURL] != true {
+	if model.librarySelectedKeys[selectedKey] != true {
 		t.Fatal("selection should remain tracked while filtered out")
 	}
 	model.libraryFilterType = ""
 	model.refreshLibraryData()
-	if !model.librarySelectedKeys[selected.DownloadURL] {
+	if !model.librarySelectedKeys[selectedKey] {
 		t.Fatal("selection should survive clearing filters")
 	}
 
 	model.activeTab = 0
 	_, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("l")})
-	if model.activeTab != 4 || !model.librarySelectedKeys[selected.DownloadURL] {
+	if model.activeTab != 4 || !model.librarySelectedKeys[selectedKey] {
 		t.Fatal("library selection should survive tab navigation")
+	}
+}
+
+func TestLibraryKeyUsesURLAndDest(t *testing.T) {
+	first := state.ModelMetadata{
+		DownloadURL: "https://example.com/model.gguf",
+		Dest:        "/models/a.gguf",
+	}
+	second := state.ModelMetadata{
+		DownloadURL: "https://example.com/model.gguf",
+		Dest:        "/models/b.gguf",
+	}
+
+	if libraryKey(first) == libraryKey(second) {
+		t.Fatal("expected same URL in different destinations to have distinct library keys")
 	}
 }
 
@@ -967,6 +983,46 @@ func TestLibrary_RetrySkipsLocalURLs(t *testing.T) {
 	msg := cmd()
 	if msg != nil {
 		t.Fatalf("local retry should not start a command, got %T", msg)
+	}
+}
+
+func TestLibrary_RetryCleansRunningStateOnUpsertError(t *testing.T) {
+	model, db, _ := setupTestLibrary(t)
+
+	row := state.ModelMetadata{
+		DownloadURL: "https://example.com/model.gguf",
+		ModelName:   "remote",
+		Dest:        "/models/model.gguf",
+	}
+	cmd := model.retryLibraryRows([]state.ModelMetadata{row})
+	if cmd == nil {
+		t.Fatal("expected retry command")
+	}
+	key := row.DownloadURL + "|" + row.Dest
+	if _, ok := model.running[key]; !ok {
+		t.Fatal("expected retry to register running state before command executes")
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	raw := cmd()
+	if batch, ok := raw.(tea.BatchMsg); ok && len(batch) == 1 {
+		raw = batch[0]()
+	}
+	msg, ok := raw.(libraryBulkMsg)
+	if !ok {
+		t.Fatalf("expected libraryBulkMsg, got %T", raw)
+	}
+	if msg.err == nil || len(msg.runningKeys) != 1 || msg.runningKeys[0] != key {
+		t.Fatalf("expected retry upsert error with cleanup key, got %+v", msg)
+	}
+	_, _ = model.Update(msg)
+	if _, ok := model.running[key]; ok {
+		t.Fatal("expected failed retry to clear running state")
+	}
+	if _, ok := model.retrying[key]; ok {
+		t.Fatal("expected failed retry to clear retrying state")
 	}
 }
 
@@ -1080,7 +1136,7 @@ func TestLibrary_DeleteStagedDataRequiresConfirmation(t *testing.T) {
 	if result.err != nil {
 		t.Fatalf("delete failed: %v", result.err)
 	}
-	if len(result.keys) != 1 || result.keys[0] != meta.DownloadURL {
+	if len(result.keys) != 1 || result.keys[0] != libraryKey(meta) {
 		t.Fatalf("expected acted key in delete result, got %+v", result.keys)
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
@@ -1095,6 +1151,30 @@ func TestLibrary_DeleteStagedDataRequiresConfirmation(t *testing.T) {
 	}
 	if _, err := db.GetMetadata(meta.DownloadURL); err != nil {
 		t.Fatalf("metadata should be kept: %v", err)
+	}
+}
+
+func TestLibrary_DeleteSkipsNonStagedRows(t *testing.T) {
+	model, db, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	meta := state.ModelMetadata{
+		DownloadURL: "https://example.com/placed.gguf",
+		ModelName:   "placed",
+		Dest:        filepath.Join(t.TempDir(), "placed.gguf"),
+	}
+	if err := db.UpsertMetadata(&meta); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	model.activeTab = 4
+	model.refreshLibraryData()
+
+	_, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	if cmd != nil {
+		t.Fatal("non-staged delete should not start a command")
+	}
+	if model.libraryConfirm != nil {
+		t.Fatal("non-staged delete should not open confirmation")
 	}
 }
 

--- a/internal/tui/library_test.go
+++ b/internal/tui/library_test.go
@@ -800,7 +800,11 @@ func TestLibrary_BulkFavoriteToggle(t *testing.T) {
 	model.activeTab = 4
 	model.refreshLibraryData()
 	_, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("A")})
-	_, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("f")})
+	_, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("f")})
+	if cmd == nil {
+		t.Fatal("expected favorite command")
+	}
+	_, _ = model.Update(cmd())
 
 	for _, row := range model.libraryRows {
 		got, err := db.GetMetadata(row.DownloadURL)
@@ -812,7 +816,11 @@ func TestLibrary_BulkFavoriteToggle(t *testing.T) {
 		}
 	}
 
-	_, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("f")})
+	_, cmd = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("f")})
+	if cmd == nil {
+		t.Fatal("expected unfavorite command")
+	}
+	_, _ = model.Update(cmd())
 	for _, row := range model.libraryRows {
 		got, err := db.GetMetadata(row.DownloadURL)
 		if err != nil {
@@ -821,6 +829,27 @@ func TestLibrary_BulkFavoriteToggle(t *testing.T) {
 		if got.Favorite {
 			t.Fatalf("expected %s to be unfavorited", row.DownloadURL)
 		}
+	}
+}
+
+func TestLibrary_RetrySkipsLocalURLs(t *testing.T) {
+	model, _, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	cmd := model.retryLibraryRows([]state.ModelMetadata{{
+		DownloadURL: "file:///models/local.gguf",
+		ModelName:   "local",
+		Dest:        "/models/local.gguf",
+	}})
+	if len(model.running) != 0 {
+		t.Fatalf("local retry should not register running downloads: %+v", model.running)
+	}
+	if cmd == nil {
+		return
+	}
+	msg := cmd()
+	if msg != nil {
+		t.Fatalf("local retry should not start a command, got %T", msg)
 	}
 }
 
@@ -946,6 +975,31 @@ func TestLibrary_DeleteStagedDataRequiresConfirmation(t *testing.T) {
 	}
 	if _, err := db.GetMetadata(meta.DownloadURL); err != nil {
 		t.Fatalf("metadata should be kept: %v", err)
+	}
+}
+
+func TestLibrary_StagedPathRejectsRootAndDirectories(t *testing.T) {
+	model, _, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	root := model.cfg.General.DownloadRoot
+	dir := filepath.Join(root, "nested")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("make dir: %v", err)
+	}
+	file := filepath.Join(root, "model.gguf")
+	if err := os.WriteFile(file, []byte("model"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	if model.isStagedLibraryPath(root) {
+		t.Fatal("download root should not be deletable")
+	}
+	if model.isStagedLibraryPath(dir) {
+		t.Fatal("directories under download root should not be deletable")
+	}
+	if !model.isStagedLibraryPath(file) {
+		t.Fatal("files under download root should be staged")
 	}
 }
 

--- a/internal/tui/library_test.go
+++ b/internal/tui/library_test.go
@@ -1029,6 +1029,7 @@ func TestLibrary_RetryCleansRunningStateOnUpsertError(t *testing.T) {
 func TestLibrary_BulkExportSelectedCatalog(t *testing.T) {
 	model, db, cleanup := setupTestLibrary(t)
 	defer cleanup()
+	model.cfg.General.DataRoot = t.TempDir()
 
 	createTestMetadata(t, db, 2)
 	model.activeTab = 4
@@ -1056,6 +1057,32 @@ func TestLibrary_BulkExportSelectedCatalog(t *testing.T) {
 	}
 	if len(exported.Models) != 1 {
 		t.Fatalf("expected one catalog model, got %d", len(exported.Models))
+	}
+}
+
+func TestLibrary_DetailModelRebindsAfterRefresh(t *testing.T) {
+	model, db, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	meta := state.ModelMetadata{
+		DownloadURL: "https://example.com/detail.gguf",
+		ModelName:   "detail",
+		Dest:        "/models/detail.gguf",
+	}
+	if err := db.UpsertMetadata(&meta); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	model.refreshLibraryData()
+	model.libraryViewingDetail = true
+	model.libraryDetailModel = &model.libraryRows[0]
+
+	meta.Favorite = true
+	if err := db.UpsertMetadata(&meta); err != nil {
+		t.Fatalf("update metadata: %v", err)
+	}
+	model.refreshLibraryData()
+	if model.libraryDetailModel == nil || !model.libraryDetailModel.Favorite {
+		t.Fatalf("expected detail model to rebind to refreshed row, got %+v", model.libraryDetailModel)
 	}
 }
 

--- a/internal/tui/library_view.go
+++ b/internal/tui/library_view.go
@@ -19,6 +19,10 @@ func (m *Model) refreshLibraryData() {
 		return
 	}
 	selectedKey := m.currentLibraryKey()
+	detailKey := ""
+	if m.libraryDetailModel != nil {
+		detailKey = libraryKey(*m.libraryDetailModel)
+	}
 
 	baseFilters := state.MetadataFilters{
 		OrderBy: "updated_at",
@@ -64,6 +68,18 @@ func (m *Model) refreshLibraryData() {
 
 	m.libraryFilterRows = baseRows
 	m.libraryRows = rows
+	if m.libraryViewingDetail && detailKey != "" {
+		m.libraryDetailModel = nil
+		for i := range m.libraryRows {
+			if libraryKey(m.libraryRows[i]) == detailKey {
+				m.libraryDetailModel = &m.libraryRows[i]
+				break
+			}
+		}
+		if m.libraryDetailModel == nil {
+			m.libraryViewingDetail = false
+		}
+	}
 	m.libraryNeedsRefresh = false
 	m.restoreLibrarySelection(selectedKey)
 }

--- a/internal/tui/library_view.go
+++ b/internal/tui/library_view.go
@@ -20,24 +20,38 @@ func (m *Model) refreshLibraryData() {
 	}
 	selectedKey := m.currentLibraryKey()
 
+	baseFilters := state.MetadataFilters{
+		OrderBy: "updated_at",
+		Limit:   libraryRowLimit,
+	}
+
 	// Build filters based on current library filter state
 	filters := state.MetadataFilters{
 		Source:    m.libraryFilterSource,
 		ModelType: m.libraryFilterType,
 		Favorite:  m.libraryShowFavorites,
-		OrderBy:   "updated_at", // Most recently updated first
+		OrderBy:   "updated_at",
 		Limit:     libraryRowLimit,
 	}
 
+	var baseRows []state.ModelMetadata
 	var rows []state.ModelMetadata
 	var err error
 
 	if m.librarySearch != "" {
-		// If searching, use search function
-		rows, err = m.st.SearchMetadata(m.librarySearch)
-		rows = normalizeLibraryRows(m.applyLibraryFilters(rows))
+		baseRows, err = m.st.SearchMetadata(m.librarySearch)
+		if err == nil {
+			baseRows = normalizeLibraryRows(baseRows)
+			rows = m.applyLibraryFilters(append([]state.ModelMetadata(nil), baseRows...))
+		}
 	} else {
-		// Otherwise use filtered list
+		baseRows, err = m.st.ListMetadata(baseFilters)
+		if err != nil {
+			if m.log != nil {
+				m.log.Errorf("failed to load library filter data: %v", err)
+			}
+			return
+		}
 		rows, err = m.st.ListMetadata(filters)
 	}
 
@@ -48,6 +62,7 @@ func (m *Model) refreshLibraryData() {
 		return
 	}
 
+	m.libraryFilterRows = baseRows
 	m.libraryRows = rows
 	m.libraryNeedsRefresh = false
 	m.restoreLibrarySelection(selectedKey)

--- a/internal/tui/library_view.go
+++ b/internal/tui/library_view.go
@@ -76,8 +76,14 @@ func (m *Model) renderLibrary() string {
 	if m.libraryShowFavorites {
 		header += m.th.ok.Render(" • ★ Favorites")
 	}
-	if len(m.librarySelectedKeys) > 0 {
-		header += m.th.label.Render(fmt.Sprintf(" • %d selected", len(m.selectedLibraryRows())))
+	totalSelected := len(m.librarySelectedKeys)
+	if totalSelected > 0 {
+		visibleSelected := len(m.selectedLibraryRows())
+		if visibleSelected == totalSelected {
+			header += m.th.label.Render(fmt.Sprintf(" • %d selected", totalSelected))
+		} else {
+			header += m.th.label.Render(fmt.Sprintf(" • %d/%d selected", visibleSelected, totalSelected))
+		}
 	}
 	sb.WriteString(header + "\n\n")
 

--- a/internal/tui/library_view.go
+++ b/internal/tui/library_view.go
@@ -18,6 +18,7 @@ func (m *Model) refreshLibraryData() {
 	if m.st == nil {
 		return
 	}
+	selectedKey := m.currentLibraryKey()
 
 	// Build filters based on current library filter state
 	filters := state.MetadataFilters{
@@ -34,6 +35,7 @@ func (m *Model) refreshLibraryData() {
 	if m.librarySearch != "" {
 		// If searching, use search function
 		rows, err = m.st.SearchMetadata(m.librarySearch)
+		rows = m.applyLibraryFilters(rows)
 	} else {
 		// Otherwise use filtered list
 		rows, err = m.st.ListMetadata(filters)
@@ -48,11 +50,7 @@ func (m *Model) refreshLibraryData() {
 
 	m.libraryRows = rows
 	m.libraryNeedsRefresh = false
-
-	// Reset selection if out of bounds
-	if m.librarySelected >= len(m.libraryRows) {
-		m.librarySelected = 0
-	}
+	m.restoreLibrarySelection(selectedKey)
 }
 
 // renderLibrary renders the library view showing downloaded models with metadata
@@ -77,6 +75,9 @@ func (m *Model) renderLibrary() string {
 	}
 	if m.libraryShowFavorites {
 		header += m.th.ok.Render(" • ★ Favorites")
+	}
+	if len(m.librarySelectedKeys) > 0 {
+		header += m.th.label.Render(fmt.Sprintf(" • %d selected", len(m.selectedLibraryRows())))
 	}
 	sb.WriteString(header + "\n\n")
 
@@ -117,6 +118,9 @@ func (m *Model) renderLibrary() string {
 		if i == m.librarySelected {
 			style = m.th.rowSelected
 			cursor = "▶ "
+		}
+		if m.librarySelectedKeys[libraryKey(model)] {
+			cursor = "✓ "
 		}
 
 		// Format: [★] ModelName (Type) • Size • Quantization • Source
@@ -169,7 +173,7 @@ func (m *Model) renderLibrary() string {
 
 	// Footer with help
 	sb.WriteString("\n")
-	sb.WriteString(m.th.footer.Render(fmt.Sprintf("Showing %d-%d of %d models | ↑↓ navigate • Enter view details • / search • F filter • Q quit",
+	sb.WriteString(m.th.footer.Render(fmt.Sprintf("Showing %d-%d of %d models | ↑↓ navigate • Space select • f favorite • F filter • E export • Q quit",
 		start+1, end, len(m.libraryRows))))
 
 	return sb.String()
@@ -329,9 +333,80 @@ func (m *Model) renderLibraryDetail() string {
 	}
 
 	// Footer
-	sb.WriteString(m.th.footer.Render("Press Esc to go back • F to toggle favorite • Q to quit"))
+	sb.WriteString(m.th.footer.Render("Press Esc to go back • f to toggle favorite • Q to quit"))
 
 	return sb.String()
+}
+
+func (m *Model) renderLibraryFilterMenu() string {
+	rows := []struct {
+		name  string
+		value string
+	}{
+		{"Search", emptyLabel(m.librarySearch)},
+		{"Type", emptyLabel(m.libraryFilterType)},
+		{"Source", emptyLabel(m.libraryFilterSource)},
+		{"Favorites", boolLabel(m.libraryShowFavorites)},
+		{"Clear filters", ""},
+	}
+	var sb strings.Builder
+	sb.WriteString(m.th.head.Render("Library Filters") + "\n\n")
+	for i, row := range rows {
+		cursor := "  "
+		style := m.th.row
+		if i == m.libraryFilterIndex {
+			cursor = "▶ "
+			style = m.th.rowSelected
+		}
+		value := row.value
+		if i == 0 && m.libraryFilterEditing {
+			value = m.librarySearchInput.View()
+		}
+		if value != "" {
+			sb.WriteString(style.Render(fmt.Sprintf("%s%-14s %s", cursor, row.name, value)) + "\n")
+		} else {
+			sb.WriteString(style.Render(fmt.Sprintf("%s%s", cursor, row.name)) + "\n")
+		}
+	}
+	sb.WriteString("\n")
+	sb.WriteString(m.th.footer.Render("↑↓ choose • Enter cycle/edit • Esc close"))
+	return sb.String()
+}
+
+func (m *Model) renderLibraryConfirm() string {
+	if m.libraryConfirm == nil {
+		return ""
+	}
+	var title string
+	switch m.libraryConfirm.action {
+	case "delete-staged":
+		title = "Delete staged data"
+	default:
+		title = "Confirm action"
+	}
+	var sb strings.Builder
+	sb.WriteString(m.th.bad.Render(title) + "\n\n")
+	sb.WriteString(fmt.Sprintf("Affected items: %d\n", len(m.libraryConfirm.rows)))
+	if m.cfg != nil && strings.TrimSpace(m.cfg.General.DownloadRoot) != "" {
+		sb.WriteString("Files under the download root may be removed; library metadata is kept.\n")
+	}
+	sb.WriteString("\n")
+	sb.WriteString(m.th.footer.Render("Enter/y confirm • Esc/n cancel"))
+	return sb.String()
+}
+
+func emptyLabel(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "(all)"
+	}
+	return value
+}
+
+func boolLabel(value bool) string {
+	if value {
+		return "only favorites"
+	}
+	return "(all)"
 }
 
 // renderSettings displays current configuration

--- a/internal/tui/library_view.go
+++ b/internal/tui/library_view.go
@@ -390,7 +390,7 @@ func (m *Model) renderLibraryFilterMenu() string {
 		}
 	}
 	sb.WriteString("\n")
-	sb.WriteString(m.th.footer.Render("↑↓ choose • Enter cycle/edit • Esc close"))
+	sb.WriteString(m.th.footer.Render("↑↓ choose • Enter/Space cycle/edit • Esc close"))
 	return sb.String()
 }
 

--- a/internal/tui/library_view.go
+++ b/internal/tui/library_view.go
@@ -26,7 +26,7 @@ func (m *Model) refreshLibraryData() {
 		ModelType: m.libraryFilterType,
 		Favorite:  m.libraryShowFavorites,
 		OrderBy:   "updated_at", // Most recently updated first
-		Limit:     1000,         // Reasonable limit
+		Limit:     libraryRowLimit,
 	}
 
 	var rows []state.ModelMetadata
@@ -35,7 +35,7 @@ func (m *Model) refreshLibraryData() {
 	if m.librarySearch != "" {
 		// If searching, use search function
 		rows, err = m.st.SearchMetadata(m.librarySearch)
-		rows = m.applyLibraryFilters(rows)
+		rows = normalizeLibraryRows(m.applyLibraryFilters(rows))
 	} else {
 		// Otherwise use filtered list
 		rows, err = m.st.ListMetadata(filters)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -69,11 +69,12 @@ type probeMsg struct {
 }
 
 type libraryBulkMsg struct {
-	action string
-	count  int
-	path   string
-	keys   []string
-	err    error
+	action      string
+	count       int
+	path        string
+	keys        []string
+	runningKeys []string
+	err         error
 }
 
 type obs struct {
@@ -395,11 +396,22 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case libraryBulkMsg:
+		for _, key := range msg.runningKeys {
+			if cancel, ok := m.running[key]; ok {
+				cancel()
+				delete(m.running, key)
+			}
+			delete(m.retrying, key)
+		}
 		for _, key := range msg.keys {
 			delete(m.librarySelectedKeys, key)
 		}
 		if msg.err != nil {
-			m.addToast(fmt.Sprintf("%s failed: %v", msg.action, msg.err))
+			if msg.count > 0 {
+				m.addToast(fmt.Sprintf("%s partial: %d item(s), error: %v", msg.action, msg.count, msg.err))
+			} else {
+				m.addToast(fmt.Sprintf("%s failed: %v", msg.action, msg.err))
+			}
 		} else if msg.path != "" {
 			m.addToast(fmt.Sprintf("%s: %d item(s) → %s", msg.action, msg.count, truncateMiddle(msg.path, 48)))
 		} else {
@@ -807,7 +819,17 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if len(targets) == 0 {
 				return m, nil
 			}
-			m.libraryConfirm = &libraryConfirmAction{action: "delete-staged", rows: targets}
+			deletableTargets := make([]state.ModelMetadata, 0, len(targets))
+			for _, row := range targets {
+				if m.isStagedLibraryPath(row.Dest) {
+					deletableTargets = append(deletableTargets, row)
+				}
+			}
+			if len(deletableTargets) == 0 {
+				m.addToast("no staged library files selected")
+				return m, nil
+			}
+			m.libraryConfirm = &libraryConfirmAction{action: "delete-staged", rows: deletableTargets}
 			return m, nil
 		}
 		rows := m.selectionOrCurrent()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -68,9 +68,21 @@ type probeMsg struct {
 	info      string
 }
 
+type libraryBulkMsg struct {
+	action string
+	count  int
+	path   string
+	err    error
+}
+
 type obs struct {
 	bytes int64
 	t     time.Time
+}
+
+type libraryConfirmAction struct {
+	action string
+	rows   []state.ModelMetadata
 }
 
 type toast struct {
@@ -161,6 +173,11 @@ type Model struct {
 	libraryFilterType    string          // Filter by model type: "", "LLM", "LoRA", etc.
 	libraryFilterSource  string          // Filter by source: "", "huggingface", "civitai"
 	libraryShowFavorites bool            // Show only favorites
+	librarySelectedKeys  map[string]bool // Selected library metadata rows keyed by download URL or dest
+	libraryFilterMenu    bool            // Filter menu is visible
+	libraryFilterIndex   int             // Selected filter menu row
+	libraryFilterEditing bool            // Editing search inside filter menu
+	libraryConfirm       *libraryConfirmAction
 	libraryNeedsRefresh  bool            // Flag to reload library data
 	librarySearchInput   textinput.Model // Search input for library
 	librarySearchActive  bool            // Search input is active
@@ -208,6 +225,7 @@ func New(cfg *config.Config, st *state.DB, version string) tea.Model {
 		placeType:  map[string]string{}, autoPlace: map[string]bool{},
 		// Library state
 		libraryRows:         []state.ModelMetadata{},
+		librarySelectedKeys: map[string]bool{},
 		libraryNeedsRefresh: true,
 		librarySearchInput:  libSearch,
 		log:                 logging.New("info", false),
@@ -257,6 +275,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.librarySearchActive {
 			return m.updateLibrarySearch(msg)
+		}
+		if m.libraryFilterMenu {
+			return m.updateLibraryFilterMenu(msg)
+		}
+		if m.libraryConfirm != nil {
+			return m.updateLibraryConfirm(msg)
 		}
 		return m.updateNormal(msg)
 	case tickMsg:
@@ -367,6 +391,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.libraryNeedsRefresh = true
 		}
 		return m, nil
+	case libraryBulkMsg:
+		if msg.err != nil {
+			m.addToast(fmt.Sprintf("%s failed: %v", msg.action, msg.err))
+		} else if msg.path != "" {
+			m.addToast(fmt.Sprintf("%s: %d item(s) → %s", msg.action, msg.count, truncateMiddle(msg.path, 48)))
+		} else {
+			m.addToast(fmt.Sprintf("%s: %d item(s)", msg.action, msg.count))
+		}
+		m.libraryNeedsRefresh = true
+		m.refreshLibraryData()
+		return m, m.refresh()
 	case dlDoneMsg:
 		// Apply placement metadata if needed (safe concurrent map access from Update thread)
 		if msg.needsPlaceMap && msg.origKey != msg.resKey {
@@ -487,6 +522,14 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.scanDirectoriesCmd()
 		}
 		return m, nil
+	case "F":
+		if m.activeTab == 4 && !m.libraryViewingDetail {
+			m.libraryFilterMenu = true
+			m.libraryFilterIndex = 0
+			m.libraryFilterEditing = false
+			return m, nil
+		}
+		return m, nil
 	case "s":
 		m.sortMode = "speed"
 		m.saveUIState()
@@ -570,7 +613,6 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "5", "l":
 		// Switch to Library tab (key 5 or 'l' for library)
 		m.activeTab = 4
-		m.librarySelected = 0
 		m.libraryViewingDetail = false
 		// Load library data if needed
 		if m.libraryNeedsRefresh || len(m.libraryRows) == 0 {
@@ -617,6 +659,17 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case " ":
+		if m.activeTab == 4 {
+			if !m.libraryViewingDetail && m.librarySelected >= 0 && m.librarySelected < len(m.libraryRows) {
+				key := libraryKey(m.libraryRows[m.librarySelected])
+				if m.librarySelectedKeys[key] {
+					delete(m.librarySelectedKeys, key)
+				} else {
+					m.librarySelectedKeys[key] = true
+				}
+			}
+			return m, nil
+		}
 		rows := m.visibleRows()
 		if m.selected >= 0 && m.selected < len(rows) {
 			key := keyFor(rows[m.selected])
@@ -628,16 +681,33 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case "A":
+		if m.activeTab == 4 {
+			for _, row := range m.libraryRows {
+				m.librarySelectedKeys[libraryKey(row)] = true
+			}
+			return m, nil
+		}
 		for _, r := range m.visibleRows() {
 			m.selectedKeys[keyFor(r)] = true
 		}
 		return m, nil
 	case "X":
+		if m.activeTab == 4 {
+			m.librarySelectedKeys = map[string]bool{}
+			return m, nil
+		}
 		m.selectedKeys = map[string]bool{}
 		return m, nil
 	case "r":
 		fallthrough
 	case "y":
+		if m.activeTab == 4 {
+			targets := m.selectedLibraryRows()
+			if len(targets) == 0 {
+				return m, nil
+			}
+			return m, m.retryLibraryRows(targets)
+		}
 		targets := m.selectionOrCurrent()
 		if len(targets) == 0 {
 			return m, nil
@@ -657,6 +727,13 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.addToast(fmt.Sprintf("retrying %d item(s)…", len(targets)))
 		return m, tea.Batch(cmds...)
 	case "p":
+		if m.activeTab == 4 {
+			targets := m.selectedLibraryRows()
+			if len(targets) == 0 {
+				return m, nil
+			}
+			return m, m.placeLibraryRowsCmd(targets)
+		}
 		cnt := 0
 		for _, r := range m.selectionOrCurrent() {
 			key := keyFor(r)
@@ -668,6 +745,36 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if cnt > 0 {
 			m.addToast(fmt.Sprintf("cancelled %d", cnt))
+		}
+		return m, nil
+	case "V":
+		if m.activeTab == 4 {
+			targets := m.selectedLibraryRows()
+			if len(targets) == 0 {
+				return m, nil
+			}
+			return m, m.verifyLibraryRowsCmd(targets)
+		}
+		return m, nil
+	case "E":
+		if m.activeTab == 4 {
+			targets := m.selectedLibraryRows()
+			if len(targets) == 0 {
+				return m, nil
+			}
+			return m, m.exportLibraryRowsCmd(targets)
+		}
+		return m, nil
+	case "f":
+		if m.activeTab == 4 {
+			if m.libraryViewingDetail && m.libraryDetailModel != nil {
+				return m, m.toggleFavoriteLibraryRows([]state.ModelMetadata{*m.libraryDetailModel})
+			}
+			targets := m.selectedLibraryRows()
+			if len(targets) == 0 {
+				return m, nil
+			}
+			return m, m.toggleFavoriteLibraryRows(targets)
 		}
 		return m, nil
 	case "O":
@@ -689,6 +796,14 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case "D":
+		if m.activeTab == 4 {
+			targets := m.selectedLibraryRows()
+			if len(targets) == 0 {
+				return m, nil
+			}
+			m.libraryConfirm = &libraryConfirmAction{action: "delete-staged", rows: targets}
+			return m, nil
+		}
 		rows := m.selectionOrCurrent()
 		if len(rows) == 0 {
 			return m, nil
@@ -786,6 +901,12 @@ func (m *Model) View() string {
 	}
 	if m.batchMode {
 		modal = m.th.border.Width(m.w - 4).Render(m.renderBatchModal())
+	}
+	if m.libraryFilterMenu {
+		modal = m.th.border.Width(m.w - 4).Render(m.renderLibraryFilterMenu())
+	}
+	if m.libraryConfirm != nil {
+		modal = m.th.border.Width(m.w - 4).Render(m.renderLibraryConfirm())
 	}
 
 	// Minimal footer: show filter or search input when active

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -72,6 +72,7 @@ type libraryBulkMsg struct {
 	action string
 	count  int
 	path   string
+	keys   []string
 	err    error
 }
 
@@ -392,6 +393,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case libraryBulkMsg:
+		for _, key := range msg.keys {
+			delete(m.librarySelectedKeys, key)
+		}
 		if msg.err != nil {
 			m.addToast(fmt.Sprintf("%s failed: %v", msg.action, msg.err))
 		} else if msg.path != "" {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -768,13 +768,13 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "f":
 		if m.activeTab == 4 {
 			if m.libraryViewingDetail && m.libraryDetailModel != nil {
-				return m, m.toggleFavoriteLibraryRows([]state.ModelMetadata{*m.libraryDetailModel})
+				return m, m.toggleFavoriteLibraryRowsCmd([]state.ModelMetadata{*m.libraryDetailModel})
 			}
 			targets := m.selectedLibraryRows()
 			if len(targets) == 0 {
 				return m, nil
 			}
-			return m, m.toggleFavoriteLibraryRows(targets)
+			return m, m.toggleFavoriteLibraryRowsCmd(targets)
 		}
 		return m, nil
 	case "O":

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -167,6 +167,7 @@ type Model struct {
 	civRateLimited bool
 	// Library view state
 	libraryRows          []state.ModelMetadata
+	libraryFilterRows    []state.ModelMetadata
 	librarySelected      int
 	librarySearch        string
 	libraryViewingDetail bool
@@ -226,6 +227,7 @@ func New(cfg *config.Config, st *state.DB, version string) tea.Model {
 		placeType:  map[string]string{}, autoPlace: map[string]bool{},
 		// Library state
 		libraryRows:         []state.ModelMetadata{},
+		libraryFilterRows:   []state.ModelMetadata{},
 		librarySelectedKeys: map[string]bool{},
 		libraryNeedsRefresh: true,
 		librarySearchInput:  libSearch,


### PR DESCRIPTION
## Summary

- add the Library `F` filter menu for search, type, source, favorites, and clear-all
- add library multi-select plus bulk retry, verify, place, favorite/unfavorite, selected catalog export, and confirmed staged-data deletion
- document the new Library controls and mark the roadmap slice complete

## Validation

- `git diff --check`
- `GOCACHE="$PWD/.cache/go-build" GOMODCACHE="$PWD/.cache/gomod" go test ./internal/tui ./internal/catalog ./cmd/modfetch`
- `GOCACHE="$PWD/.cache/go-build" GOMODCACHE="$PWD/.cache/gomod" go test ./...`
- `GOCACHE="$PWD/.cache/go-build" GOMODCACHE="$PWD/.cache/gomod" make build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->