### PR TITLE
[codex] Add placement presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,9 @@ modfetch verify --all
 # Place model into app directory
 modfetch place --path /path/to/model.safetensors
 
+# Preview a named preset without editing config first
+modfetch place --path /path/to/model.gguf --preset ollama --dry-run
+
 # Batch downloads
 modfetch download --batch jobs.yml --place
 

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -139,7 +139,7 @@ _modfetch() {
       _arguments '*:options:(--config --log-level --json --mode --dry-run)'
       ;;
     place)
-      _arguments '--preset[Apply placement preset]:preset:(automatic1111 comfyui forge hf-cache ollama)' '*:options:(--config --log-level --json --path --type --mode --preset --list-presets --dry-run)'
+      _arguments '--preset[Apply placement preset]:preset:_values -s , preset automatic1111 comfyui forge hf-cache ollama' '*:options:(--config --log-level --json --path --type --mode --list-presets --dry-run)'
       ;;
     verify)
       _arguments '*:options:(--config --path --all --safetensors --safetensors-deep --scan-dir --repair --quarantine-incomplete --only-errors --summary --fix-sidecar --log-level --json)'

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -34,6 +34,7 @@ _modfetch_completions()
 {
     local cur prev words cword
     _init_completion || return
+    local presets="automatic1111 comfyui forge hf-cache ollama"
     local cmds="config download place verify status tui library batch dedupe clean hostcaps version help completion"
     if [[ ${cword} -eq 1 ]]; then
         COMPREPLY=( $(compgen -W "${cmds}" -- "$cur") )
@@ -59,6 +60,10 @@ _modfetch_completions()
         dedupe)
             COMPREPLY=( $(compgen -W "--config --log-level --json --mode --dry-run" -- "$cur") ) ;;
         place)
+            if [[ "$prev" == "--preset" ]]; then
+                COMPREPLY=( $(compgen -W "${presets}" -- "$cur") )
+                return
+            fi
             COMPREPLY=( $(compgen -W "--config --log-level --json --path --type --mode --preset --list-presets --dry-run" -- "$cur") ) ;;
         verify)
             COMPREPLY=( $(compgen -W "--config --path --all --safetensors --safetensors-deep --scan-dir --repair --quarantine-incomplete --only-errors --summary --fix-sidecar --log-level --json" -- "$cur") ) ;;
@@ -134,7 +139,7 @@ _modfetch() {
       _arguments '*:options:(--config --log-level --json --mode --dry-run)'
       ;;
     place)
-      _arguments '*:options:(--config --log-level --json --path --type --mode --preset --list-presets --dry-run)'
+      _arguments '--preset[Apply placement preset]:preset:(automatic1111 comfyui forge hf-cache ollama)' '*:options:(--config --log-level --json --path --type --mode --preset --list-presets --dry-run)'
       ;;
     verify)
       _arguments '*:options:(--config --path --all --safetensors --safetensors-deep --scan-dir --repair --quarantine-incomplete --only-errors --summary --fix-sidecar --log-level --json)'
@@ -267,7 +272,7 @@ complete -c modfetch -n "__fish_seen_subcommand_from batch; and __fish_seen_subc
 complete -c modfetch -n "__fish_seen_subcommand_from place" -l path -d "File to place"
 complete -c modfetch -n "__fish_seen_subcommand_from place" -l type -d "Artifact type override"
 complete -c modfetch -n "__fish_seen_subcommand_from place" -l mode -d "Placement mode"
-complete -c modfetch -n "__fish_seen_subcommand_from place" -l preset -d "Apply placement preset"
+complete -c modfetch -n "__fish_seen_subcommand_from place" -l preset -a "automatic1111 comfyui forge hf-cache ollama" -d "Apply placement preset"
 complete -c modfetch -n "__fish_seen_subcommand_from place" -l list-presets -d "List placement presets"
 complete -c modfetch -n "__fish_seen_subcommand_from place" -l dry-run -d "Show planned placements only"
 complete -c modfetch -n "__fish_seen_subcommand_from verify" -l path -d "File to verify"

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -59,7 +59,7 @@ _modfetch_completions()
         dedupe)
             COMPREPLY=( $(compgen -W "--config --log-level --json --mode --dry-run" -- "$cur") ) ;;
         place)
-            COMPREPLY=( $(compgen -W "--config --log-level --json --path --type --mode --dry-run" -- "$cur") ) ;;
+            COMPREPLY=( $(compgen -W "--config --log-level --json --path --type --mode --preset --list-presets --dry-run" -- "$cur") ) ;;
         verify)
             COMPREPLY=( $(compgen -W "--config --path --all --safetensors --safetensors-deep --scan-dir --repair --quarantine-incomplete --only-errors --summary --fix-sidecar --log-level --json" -- "$cur") ) ;;
         status)
@@ -134,7 +134,7 @@ _modfetch() {
       _arguments '*:options:(--config --log-level --json --mode --dry-run)'
       ;;
     place)
-      _arguments '*:options:(--config --log-level --json --path --type --mode --dry-run)'
+      _arguments '*:options:(--config --log-level --json --path --type --mode --preset --list-presets --dry-run)'
       ;;
     verify)
       _arguments '*:options:(--config --path --all --safetensors --safetensors-deep --scan-dir --repair --quarantine-incomplete --only-errors --summary --fix-sidecar --log-level --json)'
@@ -267,6 +267,8 @@ complete -c modfetch -n "__fish_seen_subcommand_from batch; and __fish_seen_subc
 complete -c modfetch -n "__fish_seen_subcommand_from place" -l path -d "File to place"
 complete -c modfetch -n "__fish_seen_subcommand_from place" -l type -d "Artifact type override"
 complete -c modfetch -n "__fish_seen_subcommand_from place" -l mode -d "Placement mode"
+complete -c modfetch -n "__fish_seen_subcommand_from place" -l preset -d "Apply placement preset"
+complete -c modfetch -n "__fish_seen_subcommand_from place" -l list-presets -d "List placement presets"
 complete -c modfetch -n "__fish_seen_subcommand_from place" -l dry-run -d "Show planned placements only"
 complete -c modfetch -n "__fish_seen_subcommand_from verify" -l path -d "File to verify"
 complete -c modfetch -n "__fish_seen_subcommand_from verify" -l all -d "Verify all"

--- a/cmd/modfetch/completion_test.go
+++ b/cmd/modfetch/completion_test.go
@@ -20,7 +20,7 @@ func TestCompletionCurrentFlags(t *testing.T) {
 	tests := map[string][]string{
 		"config":   {"--strict", "--out"},
 		"download": {"--no-resume", "--summary-json", "--batch-parallel", "--dry-run", "--force", "--no-auth-preflight", "--quant", "--list-quants"},
-		"place":    {"--dry-run"},
+		"place":    {"--dry-run", "--preset", "--list-presets"},
 		"batch":    {"--naming-pattern"},
 		"hostcaps": {"--config", "--list", "--clear", "--clear-all", "--json"},
 		"tui":      {"--json"},

--- a/cmd/modfetch/config_path.go
+++ b/cmd/modfetch/config_path.go
@@ -46,7 +46,7 @@ func loadConfig(flagPath string) (*config.Config, string, error) {
 	c, err := config.Load(cfgPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, cfgPath, fmt.Errorf("config file not found: %s", cfgPath)
+			return nil, cfgPath, fmt.Errorf("config file not found: %s: %w", cfgPath, err)
 		}
 		return nil, cfgPath, err
 	}

--- a/cmd/modfetch/config_wizard.go
+++ b/cmd/modfetch/config_wizard.go
@@ -40,6 +40,9 @@ func handleConfigWizard(ctx context.Context, args []string) error {
 	if !ok {
 		return errors.New("unexpected model type from wizard")
 	}
+	if err := wiz.Err(); err != nil {
+		return err
+	}
 	cfg := wiz.Config()
 	if cfg == nil {
 		return errors.New("no config produced")

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -932,7 +932,11 @@ func handlePlace(ctx context.Context, args []string) error {
 	presetNames := placer.ParsePresetList(*preset)
 	c, _, err := loadConfig(*common.configPath)
 	if err != nil {
-		if len(presetNames) == 0 || strings.TrimSpace(*common.configPath) != "" || strings.TrimSpace(os.Getenv("MODFETCH_CONFIG")) != "" {
+		canUsePresetOnly := len(presetNames) > 0 &&
+			strings.TrimSpace(*common.configPath) == "" &&
+			strings.TrimSpace(os.Getenv("MODFETCH_CONFIG")) == "" &&
+			errors.Is(err, os.ErrNotExist)
+		if !canUsePresetOnly {
 			return err
 		}
 		c = &config.Config{Version: 1, General: config.General{PlacementMode: "symlink"}}

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -913,30 +913,86 @@ func handlePlace(ctx context.Context, args []string) error {
 	filePath := fs.String("path", "", "path to file to place")
 	artType := fs.String("type", "", "artifact type override (optional)")
 	mode := fs.String("mode", "", "placement mode override: symlink|hardlink|copy (optional)")
+	preset := fs.String("preset", "", "placement preset(s) to apply: "+strings.Join(placer.PresetNames(), ", "))
+	listPresets := fs.Bool("list-presets", false, "list available placement presets")
 	dryRun := fs.Bool("dry-run", false, "print planned destinations only; do not modify files")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	if *listPresets {
+		for _, name := range placer.PresetNames() {
+			p := placer.Presets()[name]
+			fmt.Printf("%-14s %s\n", name, p.Description)
+		}
+		return nil
+	}
 	if *filePath == "" {
 		return errors.New("--path is required")
 	}
+	presetNames := placer.ParsePresetList(*preset)
 	c, _, err := loadConfig(*common.configPath)
 	if err != nil {
+		if len(presetNames) == 0 || strings.TrimSpace(*common.configPath) != "" || strings.TrimSpace(os.Getenv("MODFETCH_CONFIG")) != "" {
+			return err
+		}
+		c = &config.Config{Version: 1, General: config.General{PlacementMode: "symlink"}}
+	}
+	if err := placer.ApplyPresets(c, presetNames); err != nil {
 		return err
 	}
 	log := logging.New(*common.logLevel, *common.jsonOut)
 	if *dryRun {
-		atype := *artType
-		if atype == "" {
-			atype = classifier.Detect(c, *filePath)
+		result := classifier.Result{Type: strings.TrimSpace(*artType), Confidence: "override", Reason: "--type override"}
+		if result.Type == "" {
+			result = classifier.Analyze(c, *filePath)
 		}
-		targets, err := placer.ComputeTargets(c, atype)
+		targets, err := placer.ComputeTargets(c, result.Type)
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Would place %s (type=%s) to:\n", *filePath, atype)
+		placeMode := strings.TrimSpace(*mode)
+		if placeMode == "" {
+			placeMode = c.General.PlacementMode
+		}
+		if placeMode == "" {
+			placeMode = "symlink"
+		}
+		if *common.jsonOut {
+			planned := make([]map[string]string, 0, len(targets))
+			for _, t := range targets {
+				planned = append(planned, map[string]string{
+					"action": "place",
+					"mode":   placeMode,
+					"source": *filePath,
+					"target": filepath.Join(t, filepath.Base(*filePath)),
+				})
+			}
+			if len(planned) == 0 {
+				planned = append(planned, map[string]string{
+					"action": "skip",
+					"reason": "no mapping targets for type " + result.Type,
+					"source": *filePath,
+				})
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(map[string]any{
+				"type":       result.Type,
+				"confidence": result.Confidence,
+				"reason":     result.Reason,
+				"preset":     presetNames,
+				"planned":    planned,
+			})
+		}
+		fmt.Printf("Would place %s\n", *filePath)
+		fmt.Printf("Detected type: %s (confidence=%s; %s)\n", result.Type, result.Confidence, result.Reason)
+		fmt.Printf("Placement mode: %s\n", placeMode)
+		if len(targets) == 0 {
+			fmt.Printf("Would skip: no mapping targets for type %s\n", result.Type)
+			return nil
+		}
 		for _, t := range targets {
-			fmt.Printf("  %s\n", t)
+			fmt.Printf("  %s -> %s\n", placeMode, filepath.Join(t, filepath.Base(*filePath)))
 		}
 		return nil
 	}

--- a/cmd/modfetch/place_cmd_test.go
+++ b/cmd/modfetch/place_cmd_test.go
@@ -30,6 +30,12 @@ func TestHandlePlacePresetDryRunWithoutConfig(t *testing.T) {
 	if !strings.Contains(out, "Detected type: llm.gguf") {
 		t.Fatalf("expected detected type in output, got:\n%s", out)
 	}
+	if !strings.Contains(out, "confidence=high") {
+		t.Fatalf("expected confidence in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Placement mode: symlink") {
+		t.Fatalf("expected placement mode in output, got:\n%s", out)
+	}
 	want := filepath.Join(home, ".ollama", "models", "model.gguf")
 	if !strings.Contains(out, want) {
 		t.Fatalf("expected planned ollama target %q in output:\n%s", want, out)

--- a/cmd/modfetch/place_cmd_test.go
+++ b/cmd/modfetch/place_cmd_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHandlePlacePresetDryRunWithoutConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("MODFETCH_CONFIG", "")
+
+	src := filepath.Join(t.TempDir(), "model.gguf")
+	if err := os.WriteFile(src, []byte("GGUF"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := handlePlace(context.Background(), []string{"--path", src, "--preset", "ollama", "--dry-run"}); err != nil {
+			t.Fatalf("handle place: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Detected type: llm.gguf") {
+		t.Fatalf("expected detected type in output, got:\n%s", out)
+	}
+	want := filepath.Join(home, ".ollama", "models", "model.gguf")
+	if !strings.Contains(out, want) {
+		t.Fatalf("expected planned ollama target %q in output:\n%s", want, out)
+	}
+}
+
+func TestHandlePlaceListPresets(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := handlePlace(context.Background(), []string{"--list-presets"}); err != nil {
+			t.Fatalf("list presets: %v", err)
+		}
+	})
+	for _, name := range []string{"automatic1111", "comfyui", "forge", "hf-cache", "ollama"} {
+		if !strings.Contains(out, name) {
+			t.Fatalf("preset list missing %q:\n%s", name, out)
+		}
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = old
+	}()
+
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return buf.String()
+}

--- a/cmd/modfetch/place_cmd_test.go
+++ b/cmd/modfetch/place_cmd_test.go
@@ -57,15 +57,24 @@ func captureStdout(t *testing.T, fn func()) string {
 		t.Fatalf("pipe: %v", err)
 	}
 	defer func() { _ = r.Close() }()
+	closedWriter := false
+	closeWriter := func() {
+		if closedWriter {
+			return
+		}
+		closedWriter = true
+		if err := w.Close(); err != nil {
+			t.Fatalf("close pipe writer: %v", err)
+		}
+	}
+	defer closeWriter()
 	os.Stdout = w
 	defer func() {
 		os.Stdout = old
 	}()
 
 	fn()
-	if err := w.Close(); err != nil {
-		t.Fatalf("close pipe writer: %v", err)
-	}
+	closeWriter()
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, r); err != nil {
 		t.Fatalf("read stdout: %v", err)

--- a/cmd/modfetch/place_cmd_test.go
+++ b/cmd/modfetch/place_cmd_test.go
@@ -56,6 +56,7 @@ func captureStdout(t *testing.T, fn func()) string {
 	if err != nil {
 		t.Fatalf("pipe: %v", err)
 	}
+	defer func() { _ = r.Close() }()
 	os.Stdout = w
 	defer func() {
 		os.Stdout = old

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -309,6 +309,8 @@ modfetch place --path FILE [OPTIONS]
 
 **Optional:**
 - `--dry-run` - Preview placement without writing
+- `--preset NAME[,NAME]` - Apply named placement presets for this run
+- `--list-presets` - Print available placement presets and exit
 
 **Examples:**
 
@@ -318,15 +320,21 @@ modfetch place --path ~/Downloads/llama-2-7b.gguf
 
 # Preview placement
 modfetch place --path ~/models/sdxl.safetensors --dry-run
+
+# Preview an Ollama placement without writing a config first
+modfetch place --path ~/Downloads/llama-2-7b.Q4_K_M.gguf --preset ollama --dry-run
+
+# Overlay ComfyUI and AUTOMATIC1111 preset targets onto an existing config
+modfetch place --config ./config.yml --path ~/models/sdxl.safetensors --preset comfyui,automatic1111 --dry-run
 ```
 
 **Output:**
 
 ```
-Placing: ~/Downloads/llama-2-7b.gguf
-Matched rule: *.gguf → /opt/ollama/models
+Would place ~/Downloads/llama-2-7b.gguf
+Detected type: llm.gguf (confidence=high; file extension .gguf)
 Placement mode: symlink
-✓ Created symlink: /opt/ollama/models/llama-2-7b.gguf → ~/Downloads/llama-2-7b.gguf
+  symlink -> /Users/me/.ollama/models/llama-2-7b.gguf
 ```
 
 See [PLACEMENT.md](PLACEMENT.md) for configuration details.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -87,6 +87,10 @@ Strict validation is intended as a v1.0 readiness check. Regular validation rema
 ## Placement mapping
 - Map artifact types to target apps/paths. Common types:
   - `sd.checkpoint`, `sd.lora`, `sd.vae`, `sd.controlnet`, `sd.embedding`, `llm.gguf`, `llm.safetensors`, `generic`.
+- The config wizard can add named presets through the `placement.presets`
+  prompt. Preset choices include `comfyui`, `automatic1111`, `forge`,
+  `ollama`, and `hf-cache`. Presets are emitted as normal `placement.apps` and
+  `placement.mapping` YAML, so you can inspect and edit the resulting config.
 - Example:
 ```
 placement:

--- a/docs/PLACEMENT.md
+++ b/docs/PLACEMENT.md
@@ -15,6 +15,28 @@ Deduplication
 Artifact types (detected heuristically; override with `--type`)
 - `sd.checkpoint`, `sd.lora`, `sd.vae`, `sd.controlnet`, `sd.embedding`, `llm.gguf`, `llm.safetensors`, `generic`.
 
+Presets
+- `comfyui`: ComfyUI `models/checkpoints`, `models/loras`, `models/vae`, `models/controlnet`, and `models/embeddings`.
+- `automatic1111`: AUTOMATIC1111 Stable Diffusion WebUI model folders.
+- `forge`: Forge Stable Diffusion WebUI model folders.
+- `ollama`: Ollama `~/.ollama/models` for LLM artifacts.
+- `hf-cache`: generic Hugging Face-style export folder under `~/.cache/huggingface/modfetch`.
+
+List presets:
+```
+modfetch place --list-presets
+```
+
+Preview a preset without writing a config first:
+```
+modfetch place --path /path/to/model.gguf --preset ollama --dry-run
+```
+
+Apply one or more presets on top of an existing config:
+```
+modfetch place --config ./config.yml --path /path/to/model.safetensors --preset comfyui,automatic1111 --dry-run
+```
+
 Examples
 - Dry-run: see where a file would be placed without making changes:
 ```
@@ -29,3 +51,6 @@ modfetch place --config ./config.yml --path /path/to/file.safetensors
 modfetch place --config ./config.yml --path /path/to/myLoRA.safetensors --type sd.lora
 ```
 
+Dry-run output includes the detected type, confidence, placement mode, and the
+exact destination path for each planned link/copy. If no mapping applies,
+modfetch prints a skip reason instead of silently doing nothing.

--- a/docs/PLACEMENT.md
+++ b/docs/PLACEMENT.md
@@ -17,8 +17,8 @@ Artifact types (detected heuristically; override with `--type`)
 
 Presets
 - `comfyui`: ComfyUI `models/checkpoints`, `models/loras`, `models/vae`, `models/controlnet`, and `models/embeddings`.
-- `automatic1111`: AUTOMATIC1111 Stable Diffusion WebUI model folders.
-- `forge`: Forge Stable Diffusion WebUI model folders.
+- `automatic1111`: AUTOMATIC1111 `models/Stable-diffusion`, `models/Lora`, `models/VAE`, `extensions/sd-webui-controlnet/models`, and `embeddings`.
+- `forge`: Forge `models/Stable-diffusion`, `models/Lora`, `models/VAE`, `extensions/sd-webui-controlnet/models`, and `embeddings`.
 - `ollama`: Ollama `~/.ollama/models` for LLM artifacts.
 - `hf-cache`: generic Hugging Face-style export folder under `~/.cache/huggingface/modfetch`.
 

--- a/docs/PLACEMENT.md
+++ b/docs/PLACEMENT.md
@@ -23,17 +23,17 @@ Presets
 - `hf-cache`: generic Hugging Face-style export folder under `~/.cache/huggingface/modfetch`.
 
 List presets:
-```
+```bash
 modfetch place --list-presets
 ```
 
 Preview a preset without writing a config first:
-```
+```bash
 modfetch place --path /path/to/model.gguf --preset ollama --dry-run
 ```
 
 Apply one or more presets on top of an existing config:
-```
+```bash
 modfetch place --config ./config.yml --path /path/to/model.safetensors --preset comfyui,automatic1111 --dry-run
 ```
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -84,16 +84,16 @@ Acceptance checks:
 - Destructive actions require confirmation and show the exact affected count.
 - Keyboard help and TUI guide match the implemented controls.
 
-### 4. Placement and Classifier Presets [TODO]
+### 4. Placement and Classifier Presets [DONE]
 
 Outcome: first-time setup for common local AI tools needs less custom YAML.
 
-- [TODO] Add named placement presets for common targets such as Ollama,
+- [DONE] Add named placement presets for common targets such as Ollama,
   ComfyUI, AUTOMATIC1111/Forge-style Stable Diffusion layouts, and generic
   Hugging Face cache exports where appropriate.
-- [TODO] Add `modfetch config wizard` support for selecting presets.
-- [TODO] Add `modfetch place --preset NAME --dry-run` preview behavior.
-- [TODO] Improve classifier confidence reporting for ambiguous artifacts.
+- [DONE] Add `modfetch config wizard` support for selecting presets.
+- [DONE] Add `modfetch place --preset NAME --dry-run` preview behavior.
+- [DONE] Improve classifier confidence reporting for ambiguous artifacts.
 
 Acceptance checks:
 - Preset output is explicit YAML that users can inspect and edit.

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -16,9 +16,19 @@ import (
 // sd.checkpoint, sd.lora, sd.vae, sd.controlnet, sd.embedding,
 // llm.gguf, llm.safetensors, generic
 
+type Result struct {
+	Type       string
+	Confidence string
+	Reason     string
+}
+
 // Detect attempts to determine the artifact type of a file.
 // Custom rules from the config are consulted before built-ins.
 func Detect(cfg *config.Config, filePath string) string {
+	return Analyze(cfg, filePath).Type
+}
+
+func Analyze(cfg *config.Config, filePath string) Result {
 	name := strings.ToLower(filepath.Base(filePath))
 
 	// Custom rules first
@@ -29,7 +39,7 @@ func Detect(cfg *config.Config, filePath string) string {
 				continue
 			}
 			if re.MatchString(name) {
-				return r.Type
+				return Result{Type: r.Type, Confidence: "high", Reason: "matched classifier rule " + r.Regex}
 			}
 		}
 	}
@@ -37,32 +47,32 @@ func Detect(cfg *config.Config, filePath string) string {
 	ext := strings.ToLower(filepath.Ext(name))
 	switch ext {
 	case ".gguf":
-		return "llm.gguf"
+		return Result{Type: "llm.gguf", Confidence: "high", Reason: "file extension .gguf"}
 	case ".ckpt":
-		return "sd.checkpoint"
+		return Result{Type: "sd.checkpoint", Confidence: "high", Reason: "file extension .ckpt"}
 	case ".safetensors":
 		// heuristics based on name
 		if strings.Contains(name, "lora") || strings.Contains(name, "lycoris") || strings.Contains(name, "locon") {
-			return "sd.lora"
+			return Result{Type: "sd.lora", Confidence: "medium", Reason: "safetensors filename suggests LoRA"}
 		}
 		if strings.Contains(name, "vae") {
-			return "sd.vae"
+			return Result{Type: "sd.vae", Confidence: "medium", Reason: "safetensors filename suggests VAE"}
 		}
 		if strings.Contains(name, "controlnet") {
-			return "sd.controlnet"
+			return Result{Type: "sd.controlnet", Confidence: "medium", Reason: "safetensors filename suggests ControlNet"}
 		}
 		// Ambiguous: default to sd.checkpoint for SD ecosystem, can be overridden
-		return "sd.checkpoint"
+		return Result{Type: "sd.checkpoint", Confidence: "low", Reason: "ambiguous .safetensors default"}
 	case ".pt":
 		if strings.Contains(name, "embed") || strings.Contains(name, "embedding") {
-			return "sd.embedding"
+			return Result{Type: "sd.embedding", Confidence: "medium", Reason: "filename suggests embedding"}
 		}
-		return "generic"
+		return Result{Type: "generic", Confidence: "low", Reason: "unrecognized .pt filename"}
 	default:
 		if t := detectMagic(filePath); t != "" {
-			return t
+			return Result{Type: t, Confidence: "medium", Reason: "file header matched " + t}
 		}
-		return "generic"
+		return Result{Type: "generic", Confidence: "low", Reason: "no extension or header rule matched"}
 	}
 }
 

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -36,3 +36,29 @@ func TestDetectCustomRuleOverrides(t *testing.T) {
 		t.Fatalf("expected sd.lora, got %s", got)
 	}
 }
+
+func TestAnalyzeReportsAmbiguousSafetensorsConfidence(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "model.safetensors")
+	if err := os.WriteFile(p, []byte("dummy"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	got := Analyze(nil, p)
+	if got.Type != "sd.checkpoint" || got.Confidence != "low" {
+		t.Fatalf("expected low-confidence checkpoint, got %+v", got)
+	}
+}
+
+func TestAnalyzeReportsFilenameHeuristicConfidence(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "portrait-lora.safetensors")
+	if err := os.WriteFile(p, []byte("dummy"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	got := Analyze(nil, p)
+	if got.Type != "sd.lora" || got.Confidence != "medium" {
+		t.Fatalf("expected medium-confidence LoRA, got %+v", got)
+	}
+}

--- a/internal/placer/presets.go
+++ b/internal/placer/presets.go
@@ -17,94 +17,96 @@ type Preset struct {
 	Mapping     []config.MappingRule
 }
 
+var presetCatalog = map[string]Preset{
+	"automatic1111": {
+		Name:        "automatic1111",
+		Description: "AUTOMATIC1111 Stable Diffusion WebUI layout",
+		Apps: map[string]config.AppPlacement{
+			"automatic1111": {
+				Base: "~/stable-diffusion-webui",
+				Paths: map[string]string{
+					"checkpoints": "models/Stable-diffusion",
+					"loras":       "models/Lora",
+					"vae":         "models/VAE",
+					"controlnet":  "extensions/sd-webui-controlnet/models",
+					"embeddings":  "embeddings",
+				},
+			},
+		},
+		Mapping: sdMapping("automatic1111"),
+	},
+	"comfyui": {
+		Name:        "comfyui",
+		Description: "ComfyUI models directory layout",
+		Apps: map[string]config.AppPlacement{
+			"comfyui": {
+				Base: "~/ComfyUI",
+				Paths: map[string]string{
+					"checkpoints": "models/checkpoints",
+					"loras":       "models/loras",
+					"vae":         "models/vae",
+					"controlnet":  "models/controlnet",
+					"embeddings":  "models/embeddings",
+				},
+			},
+		},
+		Mapping: sdMapping("comfyui"),
+	},
+	"forge": {
+		Name:        "forge",
+		Description: "Forge Stable Diffusion WebUI layout",
+		Apps: map[string]config.AppPlacement{
+			"forge": {
+				Base: "~/stable-diffusion-webui-forge",
+				Paths: map[string]string{
+					"checkpoints": "models/Stable-diffusion",
+					"loras":       "models/Lora",
+					"vae":         "models/VAE",
+					"controlnet":  "extensions/sd-webui-controlnet/models",
+					"embeddings":  "embeddings",
+				},
+			},
+		},
+		Mapping: sdMapping("forge"),
+	},
+	"hf-cache": {
+		Name:        "hf-cache",
+		Description: "Generic Hugging Face cache/export directory",
+		Apps: map[string]config.AppPlacement{
+			"hf-cache": {
+				Base: "~/.cache/huggingface/modfetch",
+				Paths: map[string]string{
+					"models": "models",
+				},
+			},
+		},
+		Mapping: []config.MappingRule{
+			{Match: "generic", Targets: []config.MappingTarget{{App: "hf-cache", PathKey: "models"}}},
+			{Match: "llm.gguf", Targets: []config.MappingTarget{{App: "hf-cache", PathKey: "models"}}},
+			{Match: "llm.safetensors", Targets: []config.MappingTarget{{App: "hf-cache", PathKey: "models"}}},
+			{Match: "sd.checkpoint", Targets: []config.MappingTarget{{App: "hf-cache", PathKey: "models"}}},
+		},
+	},
+	"ollama": {
+		Name:        "ollama",
+		Description: "Ollama local models directory for LLM artifacts",
+		Apps: map[string]config.AppPlacement{
+			"ollama": {
+				Base: "~/.ollama",
+				Paths: map[string]string{
+					"models": "models",
+				},
+			},
+		},
+		Mapping: []config.MappingRule{
+			{Match: "llm.gguf", Targets: []config.MappingTarget{{App: "ollama", PathKey: "models"}}},
+			{Match: "llm.safetensors", Targets: []config.MappingTarget{{App: "ollama", PathKey: "models"}}},
+		},
+	},
+}
+
 func Presets() map[string]Preset {
-	return map[string]Preset{
-		"automatic1111": {
-			Name:        "automatic1111",
-			Description: "AUTOMATIC1111 Stable Diffusion WebUI layout",
-			Apps: map[string]config.AppPlacement{
-				"automatic1111": {
-					Base: "~/stable-diffusion-webui",
-					Paths: map[string]string{
-						"checkpoints": "models/Stable-diffusion",
-						"loras":       "models/Lora",
-						"vae":         "models/VAE",
-						"controlnet":  "extensions/sd-webui-controlnet/models",
-						"embeddings":  "embeddings",
-					},
-				},
-			},
-			Mapping: sdMapping("automatic1111"),
-		},
-		"comfyui": {
-			Name:        "comfyui",
-			Description: "ComfyUI models directory layout",
-			Apps: map[string]config.AppPlacement{
-				"comfyui": {
-					Base: "~/ComfyUI",
-					Paths: map[string]string{
-						"checkpoints": "models/checkpoints",
-						"loras":       "models/loras",
-						"vae":         "models/vae",
-						"controlnet":  "models/controlnet",
-						"embeddings":  "models/embeddings",
-					},
-				},
-			},
-			Mapping: sdMapping("comfyui"),
-		},
-		"forge": {
-			Name:        "forge",
-			Description: "Forge Stable Diffusion WebUI layout",
-			Apps: map[string]config.AppPlacement{
-				"forge": {
-					Base: "~/stable-diffusion-webui-forge",
-					Paths: map[string]string{
-						"checkpoints": "models/Stable-diffusion",
-						"loras":       "models/Lora",
-						"vae":         "models/VAE",
-						"controlnet":  "extensions/sd-webui-controlnet/models",
-						"embeddings":  "embeddings",
-					},
-				},
-			},
-			Mapping: sdMapping("forge"),
-		},
-		"hf-cache": {
-			Name:        "hf-cache",
-			Description: "Generic Hugging Face cache/export directory",
-			Apps: map[string]config.AppPlacement{
-				"hf-cache": {
-					Base: "~/.cache/huggingface/modfetch",
-					Paths: map[string]string{
-						"models": "models",
-					},
-				},
-			},
-			Mapping: []config.MappingRule{
-				{Match: "generic", Targets: []config.MappingTarget{{App: "hf-cache", PathKey: "models"}}},
-				{Match: "llm.gguf", Targets: []config.MappingTarget{{App: "hf-cache", PathKey: "models"}}},
-				{Match: "llm.safetensors", Targets: []config.MappingTarget{{App: "hf-cache", PathKey: "models"}}},
-				{Match: "sd.checkpoint", Targets: []config.MappingTarget{{App: "hf-cache", PathKey: "models"}}},
-			},
-		},
-		"ollama": {
-			Name:        "ollama",
-			Description: "Ollama local models directory for LLM artifacts",
-			Apps: map[string]config.AppPlacement{
-				"ollama": {
-					Base: "~/.ollama",
-					Paths: map[string]string{
-						"models": "models",
-					},
-				},
-			},
-			Mapping: []config.MappingRule{
-				{Match: "llm.gguf", Targets: []config.MappingTarget{{App: "ollama", PathKey: "models"}}},
-				{Match: "llm.safetensors", Targets: []config.MappingTarget{{App: "ollama", PathKey: "models"}}},
-			},
-		},
-	}
+	return presetCatalog
 }
 
 func PresetNames() []string {

--- a/internal/placer/presets.go
+++ b/internal/placer/presets.go
@@ -1,0 +1,219 @@
+package placer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jxwalker/modfetch/internal/config"
+)
+
+type Preset struct {
+	Name        string
+	Description string
+	Apps        map[string]config.AppPlacement
+	Mapping     []config.MappingRule
+}
+
+func Presets() map[string]Preset {
+	return map[string]Preset{
+		"automatic1111": {
+			Name:        "automatic1111",
+			Description: "AUTOMATIC1111 Stable Diffusion WebUI layout",
+			Apps: map[string]config.AppPlacement{
+				"automatic1111": {
+					Base: "~/stable-diffusion-webui",
+					Paths: map[string]string{
+						"checkpoints": "models/Stable-diffusion",
+						"loras":       "models/Lora",
+						"vae":         "models/VAE",
+						"controlnet":  "extensions/sd-webui-controlnet/models",
+						"embeddings":  "embeddings",
+					},
+				},
+			},
+			Mapping: sdMapping("automatic1111"),
+		},
+		"comfyui": {
+			Name:        "comfyui",
+			Description: "ComfyUI models directory layout",
+			Apps: map[string]config.AppPlacement{
+				"comfyui": {
+					Base: "~/ComfyUI",
+					Paths: map[string]string{
+						"checkpoints": "models/checkpoints",
+						"loras":       "models/loras",
+						"vae":         "models/vae",
+						"controlnet":  "models/controlnet",
+						"embeddings":  "models/embeddings",
+					},
+				},
+			},
+			Mapping: sdMapping("comfyui"),
+		},
+		"forge": {
+			Name:        "forge",
+			Description: "Forge Stable Diffusion WebUI layout",
+			Apps: map[string]config.AppPlacement{
+				"forge": {
+					Base: "~/stable-diffusion-webui-forge",
+					Paths: map[string]string{
+						"checkpoints": "models/Stable-diffusion",
+						"loras":       "models/Lora",
+						"vae":         "models/VAE",
+						"controlnet":  "extensions/sd-webui-controlnet/models",
+						"embeddings":  "embeddings",
+					},
+				},
+			},
+			Mapping: sdMapping("forge"),
+		},
+		"hf-cache": {
+			Name:        "hf-cache",
+			Description: "Generic Hugging Face cache/export directory",
+			Apps: map[string]config.AppPlacement{
+				"hf-cache": {
+					Base: "~/.cache/huggingface/modfetch",
+					Paths: map[string]string{
+						"models": "models",
+					},
+				},
+			},
+			Mapping: []config.MappingRule{
+				{Match: "generic", Targets: []config.MappingTarget{{App: "hf-cache", PathKey: "models"}}},
+				{Match: "llm.gguf", Targets: []config.MappingTarget{{App: "hf-cache", PathKey: "models"}}},
+				{Match: "llm.safetensors", Targets: []config.MappingTarget{{App: "hf-cache", PathKey: "models"}}},
+				{Match: "sd.checkpoint", Targets: []config.MappingTarget{{App: "hf-cache", PathKey: "models"}}},
+			},
+		},
+		"ollama": {
+			Name:        "ollama",
+			Description: "Ollama local models directory for LLM artifacts",
+			Apps: map[string]config.AppPlacement{
+				"ollama": {
+					Base: "~/.ollama",
+					Paths: map[string]string{
+						"models": "models",
+					},
+				},
+			},
+			Mapping: []config.MappingRule{
+				{Match: "llm.gguf", Targets: []config.MappingTarget{{App: "ollama", PathKey: "models"}}},
+				{Match: "llm.safetensors", Targets: []config.MappingTarget{{App: "ollama", PathKey: "models"}}},
+			},
+		},
+	}
+}
+
+func PresetNames() []string {
+	presets := Presets()
+	names := make([]string, 0, len(presets))
+	for name := range presets {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func ApplyPresets(cfg *config.Config, names []string) error {
+	for _, name := range names {
+		if err := ApplyPreset(cfg, name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ApplyPreset(cfg *config.Config, name string) error {
+	if cfg == nil {
+		return fmt.Errorf("nil config")
+	}
+	preset, ok := Presets()[strings.ToLower(strings.TrimSpace(name))]
+	if !ok {
+		return fmt.Errorf("unknown placement preset %q (available: %s)", name, strings.Join(PresetNames(), ", "))
+	}
+	if cfg.Placement.Apps == nil {
+		cfg.Placement.Apps = map[string]config.AppPlacement{}
+	}
+	for appName, presetApp := range preset.Apps {
+		current := cfg.Placement.Apps[appName]
+		if strings.TrimSpace(current.Base) == "" {
+			current.Base = expandPresetPath(presetApp.Base)
+		}
+		if current.Paths == nil {
+			current.Paths = map[string]string{}
+		}
+		for key, path := range presetApp.Paths {
+			if strings.TrimSpace(current.Paths[key]) == "" {
+				current.Paths[key] = path
+			}
+		}
+		cfg.Placement.Apps[appName] = current
+	}
+	for _, rule := range preset.Mapping {
+		mergeMappingRule(&cfg.Placement.Mapping, rule)
+	}
+	return nil
+}
+
+func ParsePresetList(raw string) []string {
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	})
+	names := make([]string, 0, len(fields))
+	for _, field := range fields {
+		name := strings.ToLower(strings.TrimSpace(field))
+		if name != "" && name != "none" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func sdMapping(app string) []config.MappingRule {
+	return []config.MappingRule{
+		{Match: "sd.checkpoint", Targets: []config.MappingTarget{{App: app, PathKey: "checkpoints"}}},
+		{Match: "sd.lora", Targets: []config.MappingTarget{{App: app, PathKey: "loras"}}},
+		{Match: "sd.vae", Targets: []config.MappingTarget{{App: app, PathKey: "vae"}}},
+		{Match: "sd.controlnet", Targets: []config.MappingTarget{{App: app, PathKey: "controlnet"}}},
+		{Match: "sd.embedding", Targets: []config.MappingTarget{{App: app, PathKey: "embeddings"}}},
+	}
+}
+
+func mergeMappingRule(rules *[]config.MappingRule, presetRule config.MappingRule) {
+	for i := range *rules {
+		if (*rules)[i].Match == presetRule.Match {
+			for _, target := range presetRule.Targets {
+				if !hasMappingTarget((*rules)[i].Targets, target) {
+					(*rules)[i].Targets = append((*rules)[i].Targets, target)
+				}
+			}
+			return
+		}
+	}
+	*rules = append(*rules, presetRule)
+}
+
+func hasMappingTarget(targets []config.MappingTarget, want config.MappingTarget) bool {
+	for _, target := range targets {
+		if target.App == want.App && target.PathKey == want.PathKey {
+			return true
+		}
+	}
+	return false
+}
+
+func expandPresetPath(path string) string {
+	if path == "~" || strings.HasPrefix(path, "~/") || strings.HasPrefix(path, "~\\") {
+		home, err := os.UserHomeDir()
+		if err == nil && strings.TrimSpace(home) != "" {
+			if path == "~" {
+				return home
+			}
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}

--- a/internal/placer/presets_test.go
+++ b/internal/placer/presets_test.go
@@ -1,0 +1,70 @@
+package placer
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/config"
+)
+
+func TestApplyPresetAddsAppsAndMappings(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	cfg := &config.Config{}
+	if err := ApplyPreset(cfg, "comfyui"); err != nil {
+		t.Fatalf("apply preset: %v", err)
+	}
+
+	app := cfg.Placement.Apps["comfyui"]
+	if app.Base != filepath.Join(home, "ComfyUI") {
+		t.Fatalf("unexpected comfyui base %q", app.Base)
+	}
+	if app.Paths["checkpoints"] != "models/checkpoints" {
+		t.Fatalf("missing checkpoints path: %+v", app.Paths)
+	}
+	targets, err := ComputeTargets(cfg, "sd.lora")
+	if err != nil {
+		t.Fatalf("compute targets: %v", err)
+	}
+	want := filepath.Join(home, "ComfyUI", "models", "loras")
+	if len(targets) != 1 || targets[0] != want {
+		t.Fatalf("targets = %+v, want %q", targets, want)
+	}
+}
+
+func TestApplyPresetsMergesWithoutDuplicatingTargets(t *testing.T) {
+	cfg := &config.Config{}
+	if err := ApplyPresets(cfg, []string{"comfyui", "comfyui"}); err != nil {
+		t.Fatalf("apply presets: %v", err)
+	}
+	targets, err := ComputeTargets(cfg, "sd.checkpoint")
+	if err != nil {
+		t.Fatalf("compute targets: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected one deduped target, got %+v", targets)
+	}
+}
+
+func TestApplyPresetReportsUnknownName(t *testing.T) {
+	err := ApplyPreset(&config.Config{}, "missing")
+	if err == nil || !strings.Contains(err.Error(), "unknown placement preset") {
+		t.Fatalf("expected unknown preset error, got %v", err)
+	}
+}
+
+func TestParsePresetList(t *testing.T) {
+	got := ParsePresetList("comfyui, ollama none\tforge")
+	want := []string{"comfyui", "ollama", "forge"}
+	if len(got) != len(want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %+v, want %+v", got, want)
+		}
+	}
+}

--- a/internal/tui/configwizard/wizard.go
+++ b/internal/tui/configwizard/wizard.go
@@ -14,9 +14,11 @@ import (
 
 type Wizard struct {
 	inputs []textinput.Model
+	labels []string
 	focus  int
 	done   bool
 	out    *config.Config
+	err    error
 }
 
 func New(defaults *config.Config) *Wizard {
@@ -92,6 +94,18 @@ func New(defaults *config.Config) *Wizard {
 	fields = append(fields, mk("concurrency.per_file_chunks", fmt.Sprint(pfc)))
 
 	w.inputs = fields
+	w.labels = []string{
+		"general.data_root",
+		"general.download_root",
+		"general.placement_mode",
+		"placement.presets",
+		"sources.huggingface.enabled",
+		"sources.huggingface.token_env",
+		"sources.civitai.enabled",
+		"sources.civitai.token_env",
+		"concurrency.chunk_size_mb",
+		"concurrency.per_file_chunks",
+	}
 	w.focus = 0
 	w.inputs[0].Focus()
 	return w
@@ -111,7 +125,7 @@ func (w *Wizard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.String() == "enter" {
 				if i == len(w.inputs)-1 {
 					w.done = true
-					w.out = w.buildConfig()
+					w.out, w.err = w.buildConfig()
 					return w, tea.Quit
 				}
 			}
@@ -147,24 +161,12 @@ func (w *Wizard) View() string {
 	var b strings.Builder
 	b.WriteString(lipgloss.NewStyle().Bold(true).Render("modfetch config wizard") + "\n")
 	b.WriteString("Fill in fields. Tab/Shift-Tab to navigate, Enter to submit. q to quit.\n\n")
-	labels := []string{
-		"general.data_root",
-		"general.download_root",
-		"general.placement_mode",
-		"placement.presets",
-		"sources.huggingface.enabled",
-		"sources.huggingface.token_env",
-		"sources.civitai.enabled",
-		"sources.civitai.token_env",
-		"concurrency.chunk_size_mb",
-		"concurrency.per_file_chunks",
-	}
 	for i, input := range w.inputs {
 		marker := " "
 		if i == w.focus {
 			marker = ">"
 		}
-		b.WriteString(fmt.Sprintf("%s %-32s %s\n", marker, labels[i]+":", input.View()))
+		b.WriteString(fmt.Sprintf("%s %-32s %s\n", marker, w.labels[i]+":", input.View()))
 	}
 	if w.done {
 		b.WriteString("\nDone. Saving...\n")
@@ -172,7 +174,7 @@ func (w *Wizard) View() string {
 	return b.String()
 }
 
-func (w *Wizard) buildConfig() *config.Config {
+func (w *Wizard) buildConfig() (*config.Config, error) {
 	get := func(i int) string { return strings.TrimSpace(w.inputs[i].Value()) }
 	parseBool := func(s string) bool {
 		return strings.EqualFold(s, "true") || s == "1" || strings.EqualFold(s, "y") || strings.EqualFold(s, "yes")
@@ -191,14 +193,18 @@ func (w *Wizard) buildConfig() *config.Config {
 		pm = "symlink"
 	}
 	o.General.PlacementMode = pm
-	_ = placer.ApplyPresets(o, placer.ParsePresetList(get(3)))
+	if err := placer.ApplyPresets(o, placer.ParsePresetList(get(3))); err != nil {
+		return nil, err
+	}
 	o.Sources.HuggingFace.Enabled = parseBool(get(4))
 	o.Sources.HuggingFace.TokenEnv = get(5)
 	o.Sources.CivitAI.Enabled = parseBool(get(6))
 	o.Sources.CivitAI.TokenEnv = get(7)
 	o.Concurrency.ChunkSizeMB = parseInt(get(8), 8)
 	o.Concurrency.PerFileChunks = parseInt(get(9), 4)
-	return o
+	return o, nil
 }
 
 func (w *Wizard) Config() *config.Config { return w.out }
+
+func (w *Wizard) Err() error { return w.err }

--- a/internal/tui/configwizard/wizard.go
+++ b/internal/tui/configwizard/wizard.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/jxwalker/modfetch/internal/config"
+	"github.com/jxwalker/modfetch/internal/placer"
 )
 
 type Wizard struct {
@@ -20,7 +21,7 @@ type Wizard struct {
 
 func New(defaults *config.Config) *Wizard {
 	w := &Wizard{}
-	fields := make([]textinput.Model, 0, 9)
+	fields := make([]textinput.Model, 0, 10)
 	mk := func(ph, val string) textinput.Model {
 		ti := textinput.New()
 		ti.Prompt = "> "
@@ -47,6 +48,7 @@ func New(defaults *config.Config) *Wizard {
 	fields = append(fields, mk("general.data_root", dr))
 	fields = append(fields, mk("general.download_root", dd))
 	fields = append(fields, mk("general.placement_mode (symlink|hardlink|copy)", pm))
+	fields = append(fields, mk("placement.presets (comma list or none)", "none"))
 	// hf enabled, token env
 	hfEn := "true"
 	hfTok := "HF_TOKEN"
@@ -149,6 +151,7 @@ func (w *Wizard) View() string {
 		"general.data_root",
 		"general.download_root",
 		"general.placement_mode",
+		"placement.presets",
 		"sources.huggingface.enabled",
 		"sources.huggingface.token_env",
 		"sources.civitai.enabled",
@@ -188,12 +191,13 @@ func (w *Wizard) buildConfig() *config.Config {
 		pm = "symlink"
 	}
 	o.General.PlacementMode = pm
-	o.Sources.HuggingFace.Enabled = parseBool(get(3))
-	o.Sources.HuggingFace.TokenEnv = get(4)
-	o.Sources.CivitAI.Enabled = parseBool(get(5))
-	o.Sources.CivitAI.TokenEnv = get(6)
-	o.Concurrency.ChunkSizeMB = parseInt(get(7), 8)
-	o.Concurrency.PerFileChunks = parseInt(get(8), 4)
+	_ = placer.ApplyPresets(o, placer.ParsePresetList(get(3)))
+	o.Sources.HuggingFace.Enabled = parseBool(get(4))
+	o.Sources.HuggingFace.TokenEnv = get(5)
+	o.Sources.CivitAI.Enabled = parseBool(get(6))
+	o.Sources.CivitAI.TokenEnv = get(7)
+	o.Concurrency.ChunkSizeMB = parseInt(get(8), 8)
+	o.Concurrency.PerFileChunks = parseInt(get(9), 4)
 	return o
 }
 

--- a/internal/tui/configwizard/wizard_test.go
+++ b/internal/tui/configwizard/wizard_test.go
@@ -11,8 +11,11 @@ func TestWizardAppliesPlacementPresets(t *testing.T) {
 	t.Setenv("USERPROFILE", home)
 
 	w := New(nil)
-	w.inputs[3].SetValue("comfyui,ollama")
-	cfg := w.buildConfig()
+	setWizardInput(t, w, "placement.presets", "comfyui,ollama")
+	cfg, err := w.buildConfig()
+	if err != nil {
+		t.Fatalf("build config: %v", err)
+	}
 
 	if cfg.Placement.Apps["comfyui"].Base != filepath.Join(home, "ComfyUI") {
 		t.Fatalf("expected comfyui preset app, got %+v", cfg.Placement.Apps["comfyui"])
@@ -20,4 +23,24 @@ func TestWizardAppliesPlacementPresets(t *testing.T) {
 	if cfg.Placement.Apps["ollama"].Base != filepath.Join(home, ".ollama") {
 		t.Fatalf("expected ollama preset app, got %+v", cfg.Placement.Apps["ollama"])
 	}
+}
+
+func TestWizardReportsUnknownPlacementPreset(t *testing.T) {
+	w := New(nil)
+	setWizardInput(t, w, "placement.presets", "missing")
+
+	if _, err := w.buildConfig(); err == nil {
+		t.Fatal("expected unknown preset error")
+	}
+}
+
+func setWizardInput(t *testing.T, w *Wizard, placeholder, value string) {
+	t.Helper()
+	for i, label := range w.labels {
+		if label == placeholder {
+			w.inputs[i].SetValue(value)
+			return
+		}
+	}
+	t.Fatalf("wizard input %q not found", placeholder)
 }

--- a/internal/tui/configwizard/wizard_test.go
+++ b/internal/tui/configwizard/wizard_test.go
@@ -1,0 +1,23 @@
+package configwizard
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestWizardAppliesPlacementPresets(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	w := New(nil)
+	w.inputs[3].SetValue("comfyui,ollama")
+	cfg := w.buildConfig()
+
+	if cfg.Placement.Apps["comfyui"].Base != filepath.Join(home, "ComfyUI") {
+		t.Fatalf("expected comfyui preset app, got %+v", cfg.Placement.Apps["comfyui"])
+	}
+	if cfg.Placement.Apps["ollama"].Base != filepath.Join(home, ".ollama") {
+		t.Fatalf("expected ollama preset app, got %+v", cfg.Placement.Apps["ollama"])
+	}
+}


### PR DESCRIPTION
## Summary
- add named placement presets for ComfyUI, AUTOMATIC1111, Forge, Ollama, and generic Hugging Face exports
- add place --preset/--list-presets dry-run planning with classifier confidence output
- wire presets into config wizard output and refresh placement docs/roadmap

## Tests
- git diff --check
- GOCACHE="/Users/james/Documents/dev/modfetch/.cache/go-build" GOMODCACHE="/Users/james/Documents/dev/modfetch/.cache/gomod" go test ./internal/placer ./internal/classifier ./internal/tui/configwizard ./cmd/modfetch
- GOCACHE="/Users/james/Documents/dev/modfetch/.cache/go-build" GOMODCACHE="/Users/james/Documents/dev/modfetch/.cache/gomod" go test ./...
- GOCACHE="/Users/james/Documents/dev/modfetch/.cache/go-build" GOMODCACHE="/Users/james/Documents/dev/modfetch/.cache/gomod" make build
- ./bin/modfetch place --list-presets
- HOME="<tmp>" MODFETCH_CONFIG= ./bin/modfetch place --path "<tmp>/model.gguf" --preset ollama --dry-run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->