### PR TITLE
Add scanner performance and repair UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,9 @@ The modfetch TUI provides a beautiful, full-featured interface for managing your
 - **Directory Scanner**: Automatically discover models in your configured directories
   - Scans download_root and placement directories
   - Extracts metadata from filenames (quantization, parameter count, version)
+  - Uses bounded parallel scanning with serialized database writes
   - O(log n) duplicate detection with database indexes (10-100x faster than linear scan)
-  - Press `S` in Library view to trigger a scan
+  - Press `S` in Library view or run `modfetch library scan --repair-stale`
 - **Settings Tab**: View your configuration at a glance
   - See directory paths, API token status, placement rules, download settings
   - Visual indicators for HuggingFace and CivitAI token status
@@ -313,6 +314,9 @@ modfetch download --batch jobs.yml --place
 # Back up or migrate your model library catalog
 modfetch library export --output modfetch-catalog.json
 modfetch library import --input modfetch-catalog.json --dry-run
+
+# Discover existing local models and remove missing-file metadata
+modfetch library scan --repair-stale
 ```
 
 ### Detailed Examples
@@ -468,8 +472,8 @@ Troubleshooting
 - Missing tokens: Set `HF_TOKEN` or `CIVITAI_TOKEN` in your environment when accessing private resources.
 - TLS or HEAD failures: Downloader falls back to single‑stream when Range/HEAD is unsupported.
 - Resume: Re‑running the same download will resume and verify integrity.
-- Library not showing models: Press `S` in Library view to scan your directories.
-- Slow scanning: First scan may take time; subsequent scans use indexed duplicate detection (10-100x faster).
+- Library not showing models: Press `S` in Library view or run `modfetch library scan`.
+- Slow scanning: Use `modfetch library scan --workers 4`; subsequent scans also use indexed duplicate detection.
 
 Roadmap
 - See docs/ROADMAP.md for the active, prioritized roadmap
@@ -478,5 +482,5 @@ Roadmap
   - Library catalog export/import
   - TUI bulk operations and filter menu
   - Placement presets
-  - Parallel scanner improvements
+  - Scanner performance and repair UX
   - Release hardening

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -73,7 +73,7 @@ _modfetch_completions()
             COMPREPLY=( $(compgen -W "--config --log-level --json" -- "$cur") ) ;;
         library)
             if [[ ${cword} -eq 2 ]]; then
-                COMPREPLY=( $(compgen -W "export import" -- "$cur") )
+                COMPREPLY=( $(compgen -W "export import scan" -- "$cur") )
                 return
             fi
             case ${words[2]} in
@@ -81,6 +81,8 @@ _modfetch_completions()
                     COMPREPLY=( $(compgen -W "--config --log-level --json --format --output" -- "$cur") ) ;;
                 import)
                     COMPREPLY=( $(compgen -W "--config --log-level --json --input --dry-run" -- "$cur") ) ;;
+                scan)
+                    COMPREPLY=( $(compgen -W "--config --log-level --json --dir --workers --repair-stale --no-progress" -- "$cur") ) ;;
                 *) ;;
             esac ;;
         clean)
@@ -152,7 +154,7 @@ _modfetch() {
       ;;
     library)
       if (( CURRENT == 3 )); then
-        _arguments '*:subcommands:(export import)'
+        _arguments '*:subcommands:(export import scan)'
       else
         case $words[3] in
           export)
@@ -160,6 +162,9 @@ _modfetch() {
             ;;
           import)
             _arguments '*:options:(--config --log-level --json --input --dry-run)'
+            ;;
+          scan)
+            _arguments '*:options:(--config --log-level --json --dir --workers --repair-stale --no-progress)'
             ;;
         esac
       fi
@@ -249,10 +254,15 @@ complete -c modfetch -n "__fish_seen_subcommand_from download" -l quant -d "Hugg
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l list-quants -d "List HuggingFace quantizations"
 complete -c modfetch -n "__fish_seen_subcommand_from library" -a "export" -d "Export model catalog"
 complete -c modfetch -n "__fish_seen_subcommand_from library" -a "import" -d "Import model catalog"
+complete -c modfetch -n "__fish_seen_subcommand_from library" -a "scan" -d "Scan model directories"
 complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from export" -l format -d "Catalog format"
 complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from export" -l output -d "Output catalog path"
 complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from import" -l input -d "Input catalog path"
 complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from import" -l dry-run -d "Report changes without writing"
+complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from scan" -l dir -d "Directory to scan"
+complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from scan" -l workers -d "Scanner worker count"
+complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from scan" -l repair-stale -d "Remove metadata for missing files"
+complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from scan" -l no-progress -d "Disable progress output"
 complete -c modfetch -n "__fish_seen_subcommand_from dedupe" -l mode -d "hardlink|symlink"
 complete -c modfetch -n "__fish_seen_subcommand_from dedupe" -l dry-run -d "Show dedupe changes without modifying files"
 # batch import flags

--- a/cmd/modfetch/library_cmd.go
+++ b/cmd/modfetch/library_cmd.go
@@ -8,20 +8,25 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/jxwalker/modfetch/internal/catalog"
+	"github.com/jxwalker/modfetch/internal/config"
+	"github.com/jxwalker/modfetch/internal/scanner"
 	"github.com/jxwalker/modfetch/internal/state"
 )
 
 func handleLibrary(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		return errors.New("library subcommand required: export or import")
+		return errors.New("library subcommand required: export, import, or scan")
 	}
 	switch args[0] {
 	case "export":
 		return handleLibraryExport(ctx, args[1:])
 	case "import":
 		return handleLibraryImport(ctx, args[1:])
+	case "scan":
+		return handleLibraryScan(ctx, args[1:])
 	default:
 		return fmt.Errorf("unknown library subcommand: %s", args[0])
 	}
@@ -110,12 +115,129 @@ func handleLibraryImport(ctx context.Context, args []string) error {
 	return nil
 }
 
+type stringListFlag []string
+
+func (f *stringListFlag) String() string {
+	return strings.Join(*f, ",")
+}
+
+func (f *stringListFlag) Set(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("directory path is empty")
+	}
+	*f = append(*f, value)
+	return nil
+}
+
+func handleLibraryScan(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("library scan", flag.ContinueOnError)
+	common := addCommonConfigLogFlags(fs, "print scan result as JSON")
+	workers := fs.Int("workers", 0, "parallel scanner workers (default: bounded by CPU, max 8)")
+	repairStale := fs.Bool("repair-stale", false, "remove library metadata for missing files under scanned directories")
+	noProgress := fs.Bool("no-progress", false, "disable progress output")
+	var dirFlags stringListFlag
+	fs.Var(&dirFlags, "dir", "directory to scan (repeatable; default: configured library directories)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	cfg, db, err := openLibraryConfigAndDB(*common.configPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	dirs := []string(dirFlags)
+	if len(dirs) == 0 {
+		dirs = scanner.ConfiguredDirectories(cfg)
+	}
+	if len(dirs) == 0 {
+		return errors.New("no directories configured to scan")
+	}
+
+	var progress scanner.ProgressFunc
+	if !*common.jsonOut && !*noProgress {
+		progress = func(p scanner.Progress) {
+			if p.Path == "" {
+				return
+			}
+			_, _ = fmt.Fprintf(os.Stderr, "\rScanning: files=%d added=%d skipped=%d stale_removed=%d errors=%d",
+				p.FilesScanned, p.ModelsAdded, p.ModelsSkipped, p.StaleRemoved, p.Errors)
+		}
+	}
+
+	sc := scanner.NewScanner(db)
+	result, err := sc.ScanWithContext(ctx, dirs, scanner.Options{
+		Workers:     *workers,
+		RepairStale: *repairStale,
+		Progress:    progress,
+	})
+	if progress != nil {
+		_, _ = fmt.Fprintln(os.Stderr)
+	}
+	if err != nil {
+		return err
+	}
+	if *common.jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(libraryScanOutputFromResult(result, dirs))
+	}
+	fmt.Printf("Scan summary: files=%d found=%d added=%d skipped=%d stale_checked=%d stale_removed=%d errors=%d\n",
+		result.FilesScanned, result.ModelsFound, result.ModelsAdded, result.ModelsSkipped,
+		result.StaleChecked, result.StaleRemoved, len(result.Errors))
+	for _, err := range result.Errors {
+		fmt.Printf("error: %v\n", err)
+	}
+	return nil
+}
+
+type libraryScanOutput struct {
+	Directories   []string `json:"directories"`
+	FilesScanned  int      `json:"files_scanned"`
+	ModelsFound   int      `json:"models_found"`
+	ModelsAdded   int      `json:"models_added"`
+	ModelsSkipped int      `json:"models_skipped"`
+	StaleChecked  int      `json:"stale_checked"`
+	StaleRemoved  int      `json:"stale_removed"`
+	Errors        []string `json:"errors,omitempty"`
+}
+
+func libraryScanOutputFromResult(result *scanner.ScanResult, dirs []string) libraryScanOutput {
+	output := libraryScanOutput{Directories: dirs}
+	if result == nil {
+		return output
+	}
+	output.FilesScanned = result.FilesScanned
+	output.ModelsFound = result.ModelsFound
+	output.ModelsAdded = result.ModelsAdded
+	output.ModelsSkipped = result.ModelsSkipped
+	output.StaleChecked = result.StaleChecked
+	output.StaleRemoved = result.StaleRemoved
+	for _, err := range result.Errors {
+		output.Errors = append(output.Errors, err.Error())
+	}
+	return output
+}
+
 func openLibraryDB(configPath string) (*state.DB, error) {
+	_, db, err := openLibraryConfigAndDB(configPath)
+	return db, err
+}
+
+func openLibraryConfigAndDB(configPath string) (*config.Config, *state.DB, error) {
 	cfg, _, err := loadConfig(configPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return state.Open(cfg)
+	db, err := state.Open(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cfg, db, nil
 }
 
 func outputWriter(path string) (io.Writer, func(), error) {

--- a/cmd/modfetch/library_cmd_test.go
+++ b/cmd/modfetch/library_cmd_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -111,6 +113,86 @@ func TestHandleLibraryImportJSONReturnsErrorOnConflicts(t *testing.T) {
 	err = handleLibrary(context.Background(), []string{"import", "--config", cfgPath, "--input", catalogPath, "--json"})
 	if err == nil || !strings.Contains(err.Error(), "conflict") {
 		t.Fatalf("expected JSON import conflict error, got %v", err)
+	}
+}
+
+func TestHandleLibraryScanConfiguredDirectory(t *testing.T) {
+	dir := t.TempDir()
+	cfgRoot := filepath.Join(dir, "cfg")
+	cfgPath := writeLibraryConfig(t, cfgRoot)
+	downloadRoot := filepath.Join(cfgRoot, "downloads")
+	if err := os.MkdirAll(downloadRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	modelPath := filepath.Join(downloadRoot, "cli-model.gguf")
+	if err := os.WriteFile(modelPath, []byte("model"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := handleLibrary(context.Background(), []string{"scan", "--config", cfgPath, "--workers", "2", "--no-progress"}); err != nil {
+		t.Fatalf("library scan: %v", err)
+	}
+
+	db, err := state.Open(&config.Config{General: config.General{
+		DataRoot:     filepath.Join(cfgRoot, "data"),
+		DownloadRoot: downloadRoot,
+	}})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	meta, err := db.GetMetadataByDest(modelPath)
+	if err != nil {
+		t.Fatalf("get scanned metadata: %v", err)
+	}
+	if meta == nil || meta.Source != "local" || meta.ModelName != "cli" {
+		t.Fatalf("unexpected scanned metadata: %+v", meta)
+	}
+}
+
+func TestHandleLibraryScanRepairStale(t *testing.T) {
+	dir := t.TempDir()
+	cfgRoot := filepath.Join(dir, "cfg")
+	cfgPath := writeLibraryConfig(t, cfgRoot)
+	downloadRoot := filepath.Join(cfgRoot, "downloads")
+	if err := os.MkdirAll(downloadRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	missingPath := filepath.Join(downloadRoot, "missing.gguf")
+
+	db, err := state.Open(&config.Config{General: config.General{
+		DataRoot:     filepath.Join(cfgRoot, "data"),
+		DownloadRoot: downloadRoot,
+	}})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.UpsertMetadata(&state.ModelMetadata{
+		DownloadURL: "file://" + missingPath,
+		Dest:        missingPath,
+		ModelName:   "missing",
+		Source:      "local",
+	}); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	if err := handleLibrary(context.Background(), []string{"scan", "--config", cfgPath, "--repair-stale", "--json"}); err != nil {
+		t.Fatalf("library scan repair: %v", err)
+	}
+
+	db, err = state.Open(&config.Config{General: config.General{
+		DataRoot:     filepath.Join(cfgRoot, "data"),
+		DownloadRoot: downloadRoot,
+	}})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if meta, err := db.GetMetadata("file://" + missingPath); !errors.Is(err, sql.ErrNoRows) || meta != nil {
+		t.Fatalf("stale metadata should be removed, meta=%+v err=%v", meta, err)
 	}
 }
 

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -107,6 +107,7 @@ Commands:
   tui               Open the interactive terminal dashboard
   library export    Export model library catalog as JSON
   library import    Import model library catalog JSON
+  library scan      Scan configured model directories into the library
   batch import      Import URLs from a text file and produce a YAML batch
   version           Print version
   help              Show this help

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -35,6 +35,7 @@ modfetch verify --all              # Verify all downloads
 modfetch place --path FILE         # Place model into app
 modfetch clean --days 7            # Clean old partials
 modfetch library export --output catalog.json
+modfetch library scan --repair-stale
 modfetch config validate           # Validate config
 modfetch tui                       # Launch visual TUI
 ```
@@ -153,9 +154,16 @@ Show rows from the download state database.
 
 ### library
 
-Export or import the model library catalog for backup and machine migration.
+Scan, export, or import the model library catalog for local maintenance,
+backup, and machine migration.
 
 ```bash
+# Scan configured download and placement directories into the library
+modfetch library scan
+
+# Scan a specific directory with four workers and repair stale metadata
+modfetch library scan --dir ~/models --workers 4 --repair-stale
+
 # Export metadata, favorites, source URLs, destination paths, and checksums
 modfetch library export --format json --output modfetch-catalog.json
 
@@ -165,6 +173,19 @@ modfetch library import --input modfetch-catalog.json --dry-run
 # Import catalog entries and print a machine-readable summary
 modfetch library import --input modfetch-catalog.json --json
 ```
+
+`library scan` recognizes `.gguf`, `.ggml`, `.safetensors`, `.ckpt`, `.pt`,
+`.pth`, `.bin`, `.h5`, `.pb`, and `.onnx` model files. By default, it scans the
+configured download root, each placement app base, and each placement app path
+joined to its base. Use repeated `--dir` flags to override that directory list.
+Progress is printed to stderr unless `--json` or `--no-progress` is set.
+
+Scan options:
+- `--dir PATH` - scan this directory instead of configured roots; repeatable
+- `--workers N` - set bounded scanner workers; default is CPU-bound with max 8
+- `--repair-stale` - remove library metadata for missing files under scanned roots
+- `--no-progress` - suppress progress output
+- `--json` - print a machine-readable scan summary
 
 Exported catalogs include a schema version and one entry per model metadata row.
 When a matching download row exists, the catalog also carries expected and

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -292,19 +292,26 @@ The scanner automatically discovers models in your configured directories.
 
 ### Triggering a Scan
 
-Press `S` in the Library tab to scan directories:
+Press `S` in the Library tab to scan directories, or run the same scanner from
+the CLI:
 
+```bash
+modfetch library scan
+modfetch library scan --dir ~/models --workers 4 --repair-stale
 ```
-Scanning directories...
-Found 42 models (15 new, 27 existing)
-```
+
+The TUI shows scanning state in the Library header and reports files scanned,
+models added, and duplicates skipped when the scan finishes. The CLI prints
+progress to stderr and a final summary to stdout. Stale-record repair is opt-in
+through `modfetch library scan --repair-stale`.
 
 ### What Gets Scanned
 
 The scanner searches these locations:
 
 1. **Download Root**: `cfg.General.DownloadRoot`
-2. **Placement Directories**: All `cfg.Placement.Rules[].Dest` paths
+2. **Placement App Bases**: Each `cfg.Placement.Apps[*].Base`
+3. **Placement App Paths**: Each configured app path joined to its base
 
 ### Supported File Types
 
@@ -356,7 +363,7 @@ The scanner uses **indexed database queries** for fast duplicate detection:
 After scanning, you'll see a toast notification:
 
 ```
-Scan complete: 15 new, 27 skipped, 0 errors
+scan complete: 42 files scanned, 15 models added, 27 skipped, 1 stale removed
 ```
 
 The library view automatically refreshes to show newly discovered models.
@@ -495,7 +502,8 @@ For large libraries (1000+ models):
 1. Press `S` to trigger a manual scan
 2. Check that files are in configured directories:
    - `cfg.General.DownloadRoot`
-   - `cfg.Placement.Rules[].Dest`
+   - `cfg.Placement.Apps[*].Base`
+   - configured placement app paths joined to their base
 3. Verify file extension is supported (see [Supported File Types](#supported-file-types))
 
 ### Missing Metadata

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,7 +4,7 @@ This is the active project roadmap after the v0.6.3 release. Historical backlog
 items that shipped in v0.6.x are summarized at the end for traceability.
 
 Status key:
-- [TODO] not started
+- [PLANNED] not started
 - [NEXT] next implementation slice
 - [IN PROGRESS] active work
 - [DONE] shipped on main
@@ -99,16 +99,16 @@ Acceptance checks:
 - Preset output is explicit YAML that users can inspect and edit.
 - `--dry-run` explains every planned link/copy and every skipped artifact.
 
-### 5. Scanner Performance and Repair UX [TODO]
+### 5. Scanner Performance and Repair UX [DONE]
 
 Outcome: large model directories scan faster and failed scans are easier to
 recover from.
 
-- [TODO] Add bounded parallel directory scanning with serialized DB writes.
-- [TODO] Add scan progress reporting for CLI and TUI.
-- [TODO] Add optional stale-record repair for files moved or deleted outside
+- [DONE] Add bounded parallel directory scanning with serialized DB writes.
+- [DONE] Add scan progress reporting for CLI and TUI.
+- [DONE] Add optional stale-record repair for files moved or deleted outside
   modfetch.
-- [TODO] Benchmark sequential versus parallel scans on representative trees.
+- [DONE] Benchmark sequential versus parallel scans on representative trees.
 
 Acceptance checks:
 - Parallel scan results match sequential scan results.
@@ -116,16 +116,16 @@ Acceptance checks:
 - Benchmarks show the change helps on large directories without regressing small
   scans materially.
 
-### 6. Release and Documentation Hardening [TODO]
+### 6. Release and Documentation Hardening [PLANNED]
 
 Outcome: release quality stays repeatable as install surfaces expand.
 
 - [DONE] Add a release checklist that covers changelog section, installer,
   package formula, release notes extraction, artifacts, checksums, and smoke
   installs.
-- [TODO] Add a docs drift check for current version strings and stale installation
+- [PLANNED] Add a docs drift check for current version strings and stale installation
   claims.
-- [TODO] Keep README.md, docs/QUICKSTART.md, docs/USER_GUIDE.md,
+- [PLANNED] Keep README.md, docs/QUICKSTART.md, docs/USER_GUIDE.md,
   docs/CLI_GUIDE.md, docs/INSTALLATION.md, and CHANGELOG.md aligned before
   each tag.
 

--- a/docs/SCANNER.md
+++ b/docs/SCANNER.md
@@ -389,7 +389,8 @@ placement:
 
 **Note:** Scanner automatically discovers all configured directories from:
 1. `cfg.General.DownloadRoot`
-2. All `cfg.Placement.Rules[].Dest` paths
+2. Each `cfg.Placement.Apps[*].Base`
+3. Each configured placement app path joined to its base
 
 ## Implementation Details
 
@@ -420,26 +421,34 @@ if err := db.UpsertMetadata(meta); err != nil {
 
 ### Concurrency
 
-**Current implementation:** Single-threaded sequential scan
+**Current implementation:** Bounded parallel scan with serialized database work.
 
-**Rationale:**
-- Simplicity and reliability
-- I/O bound (disk reads are bottleneck)
-- Database writes require serialization anyway
+- File walking feeds a fixed worker pool.
+- Workers extract file metadata in parallel.
+- Duplicate checks, metadata upserts, and stale-record deletes are serialized
+  through one database writer path.
+- Cancellation stops new work and leaves already-written rows valid.
 
-**Future enhancement:** Parallel scanning with worker pool:
+Use `Options.Workers` in Go callers or `modfetch library scan --workers N` from
+the CLI. A value of `0` uses the default bounded by CPU count with a maximum of
+8 workers.
+
 ```go
-// Sketch: concurrent scanning with a worker pool
-func (s *Scanner) ScanDirectoriesConcurrent(dirs []string, workers int) (*ScanResult, error) {
-    // Future enhancement; current scanner is intentionally sequential.
-}
+result, err := scanner.ScanWithContext(ctx, dirs, scanner.Options{
+    Workers:     4,
+    RepairStale: true,
+    Progress: func(p scanner.Progress) {
+        fmt.Printf("files=%d added=%d skipped=%d\n",
+            p.FilesScanned, p.ModelsAdded, p.ModelsSkipped)
+    },
+})
 ```
 
 ### Memory Efficiency
 
 **Current approach:**
 - Streaming file walk (low memory)
-- One file processed at a time
+- Bounded file processing through the scanner worker pool
 - No buffering of full result set
 
 **Memory usage:** O(1) per file (constant, regardless of library size)
@@ -541,7 +550,8 @@ Comprehensive test suite in `scanner_test.go`:
 1. Verify indexed queries are used
 2. Check disk I/O with `iostat`
 3. Exclude unnecessary directories
-4. Consider parallel scanning (future enhancement)
+4. Increase bounded workers with `modfetch library scan --workers 4`
+5. Benchmark on your tree with `go test -bench 'ScanDirectories.*1000' ./internal/scanner`
 
 ### Missing Models
 

--- a/docs/TUI_GUIDE.md
+++ b/docs/TUI_GUIDE.md
@@ -118,7 +118,7 @@ help overlay.
 - `p` - Place selected files using configured placement rules
 - `E` - Export selected models to `library-selected-catalog.json`
 - `D` - Delete selected staged download data after confirmation
-- `S` - Scan directories for new models
+- `S` - Scan configured directories for new models
 
 ### Settings Tab Keys
 

--- a/internal/scanner/dirs.go
+++ b/internal/scanner/dirs.go
@@ -1,0 +1,94 @@
+package scanner
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jxwalker/modfetch/internal/config"
+)
+
+// ConfiguredDirectories returns the library scan roots implied by config.
+func ConfiguredDirectories(cfg *config.Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	var dirs []string
+	seen := map[string]bool{}
+	add := func(path string) {
+		path = strings.TrimSpace(path)
+		if path == "" || seen[path] {
+			return
+		}
+		seen[path] = true
+		dirs = append(dirs, path)
+	}
+
+	add(cfg.General.DownloadRoot)
+	appNames := make([]string, 0, len(cfg.Placement.Apps))
+	for name := range cfg.Placement.Apps {
+		appNames = append(appNames, name)
+	}
+	sort.Strings(appNames)
+	for _, name := range appNames {
+		app := cfg.Placement.Apps[name]
+		base := strings.TrimSpace(app.Base)
+		add(base)
+
+		pathKeys := make([]string, 0, len(app.Paths))
+		for key := range app.Paths {
+			pathKeys = append(pathKeys, key)
+		}
+		sort.Strings(pathKeys)
+		for _, key := range pathKeys {
+			path := strings.TrimSpace(app.Paths[key])
+			if path == "" {
+				continue
+			}
+			if base == "" || filepath.IsAbs(path) {
+				add(path)
+				continue
+			}
+			add(filepath.Join(base, path))
+		}
+	}
+	return filterRedundantDirs(dirs)
+}
+
+func filterRedundantDirs(dirs []string) []string {
+	filtered := make([]string, 0, len(dirs))
+	for i, dir := range dirs {
+		redundant := false
+		for j, other := range dirs {
+			if i == j {
+				continue
+			}
+			if pathsEquivalent(dir, other) {
+				if j < i {
+					redundant = true
+					break
+				}
+				continue
+			}
+			if pathWithinDirs(dir, []string{other}) {
+				redundant = true
+				break
+			}
+		}
+		if !redundant {
+			filtered = append(filtered, dir)
+		}
+	}
+	return filtered
+}
+
+func pathsEquivalent(a, b string) bool {
+	for _, aVariant := range pathVariants(a) {
+		for _, bVariant := range pathVariants(b) {
+			if aVariant == bVariant {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,11 +1,16 @@
 package scanner
 
 import (
+	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jxwalker/modfetch/internal/metadata"
@@ -28,7 +33,32 @@ type ScanResult struct {
 	ModelsFound   int
 	ModelsAdded   int
 	ModelsSkipped int
+	StaleChecked  int
+	StaleRemoved  int
 	Errors        []error
+}
+
+// Progress describes the latest scanner state for CLI and TUI callers.
+type Progress struct {
+	Phase         string
+	Path          string
+	FilesScanned  int
+	ModelsFound   int
+	ModelsAdded   int
+	ModelsSkipped int
+	StaleChecked  int
+	StaleRemoved  int
+	Errors        int
+}
+
+// ProgressFunc receives progress snapshots during a scan.
+type ProgressFunc func(Progress)
+
+// Options controls scanner behavior.
+type Options struct {
+	Workers     int
+	Progress    ProgressFunc
+	RepairStale bool
 }
 
 // ModelFileExtensions are file extensions we recognize as model files
@@ -47,70 +77,113 @@ var ModelFileExtensions = []string{
 
 // ScanDirectories scans multiple directories for model files
 func (s *Scanner) ScanDirectories(dirs []string) (*ScanResult, error) {
-	result := &ScanResult{
-		Errors: []error{},
-	}
-
-	for _, dir := range dirs {
-		if err := s.scanDirectory(dir, result); err != nil {
-			result.Errors = append(result.Errors, fmt.Errorf("scanning %s: %w", dir, err))
-		}
-	}
-
-	return result, nil
+	return s.ScanDirectoriesWithOptions(context.Background(), dirs, Options{})
 }
 
-// scanDirectory recursively scans a single directory
-func (s *Scanner) scanDirectory(dir string, result *ScanResult) error {
-	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			// Skip directories we can't access due to permissions
-			if os.IsPermission(err) {
-				return filepath.SkipDir
+// ScanDirectoriesWithOptions scans multiple directories with bounded worker
+// concurrency while keeping database operations serialized.
+func (s *Scanner) ScanDirectoriesWithOptions(ctx context.Context, dirs []string, opts Options) (*ScanResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	dirs = normalizeScanDirs(dirs)
+	result := &ScanResult{Errors: []error{}}
+	if opts.RepairStale {
+		s.repairStaleRecords(ctx, dirs, result, opts.Progress)
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+	}
+
+	workers := opts.Workers
+	if workers <= 0 {
+		workers = defaultWorkerCount()
+	}
+
+	jobs := make(chan scanJob)
+	candidates := make(chan scanCandidate)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for job := range jobs {
+				meta := s.extractMetadata(job.path, job.info)
+				select {
+				case candidates <- scanCandidate{path: job.path, meta: meta}:
+				case <-ctx.Done():
+					return
+				}
 			}
-			// Return other errors (like non-existent paths) so they're captured
-			if os.IsNotExist(err) {
+		}()
+	}
+
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		for candidate := range candidates {
+			s.storeCandidate(candidate, result, opts.Progress)
+		}
+	}()
+
+	var walkErrors []error
+	for _, dir := range dirs {
+		if err := ctx.Err(); err != nil {
+			break
+		}
+		err := filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {
+			if err != nil {
+				if os.IsPermission(err) {
+					if entry == nil {
+						return err
+					}
+					if entry != nil && entry.IsDir() {
+						return filepath.SkipDir
+					}
+					walkErrors = append(walkErrors, fmt.Errorf("permission denied %s: %w", path, err))
+					return nil
+				}
+				if os.IsNotExist(err) {
+					if path == dir {
+						return err
+					}
+					walkErrors = append(walkErrors, fmt.Errorf("path disappeared %s: %w", path, err))
+					return nil
+				}
+				return nil
+			}
+			if err := ctx.Err(); err != nil {
 				return err
 			}
-			return nil
+			if entry.IsDir() || !isModelFile(path) {
+				return nil
+			}
+			info, err := entry.Info()
+			if err != nil {
+				walkErrors = append(walkErrors, fmt.Errorf("stat %s: %w", path, err))
+				return nil
+			}
+			select {
+			case jobs <- scanJob{path: path, info: info}:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		})
+		if err != nil && err != context.Canceled {
+			walkErrors = append(walkErrors, fmt.Errorf("scanning %s: %w", dir, err))
 		}
+	}
 
-		// Skip directories
-		if info.IsDir() {
-			return nil
-		}
-
-		// Check if this is a model file
-		if !isModelFile(path) {
-			return nil
-		}
-
-		result.FilesScanned++
-
-		// Check if we already have metadata for this file
-		existing, err := s.findExistingMetadata(path)
-		if err == nil && existing != nil {
-			result.ModelsSkipped++
-			return nil
-		}
-
-		// Extract metadata from file
-		meta := s.extractMetadata(path, info)
-
-		// Try to enrich metadata if we can determine the source
-		// (This would require the file to have source URL in extended attributes or similar)
-
-		result.ModelsFound++
-
-		// Store in database
-		if err := s.db.UpsertMetadata(meta); err != nil {
-			result.Errors = append(result.Errors, fmt.Errorf("storing metadata for %s: %w", path, err))
-			return nil
-		}
-
-		result.ModelsAdded++
-		return nil
-	})
+	close(jobs)
+	wg.Wait()
+	close(candidates)
+	<-writerDone
+	result.Errors = append(result.Errors, walkErrors...)
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	return result, nil
 }
 
 // isModelFile checks if a file is a recognized model file
@@ -124,6 +197,175 @@ func isModelFile(path string) bool {
 	return false
 }
 
+type scanJob struct {
+	path string
+	info os.FileInfo
+}
+
+type scanCandidate struct {
+	path string
+	meta *state.ModelMetadata
+}
+
+func defaultWorkerCount() int {
+	workers := runtime.NumCPU()
+	if workers < 1 {
+		return 1
+	}
+	if workers > 8 {
+		return 8
+	}
+	return workers
+}
+
+func normalizeScanDirs(dirs []string) []string {
+	normalized := make([]string, 0, len(dirs))
+	for _, dir := range dirs {
+		dir = strings.TrimSpace(dir)
+		if dir == "" {
+			continue
+		}
+		if absDir, err := filepath.Abs(dir); err == nil {
+			dir = absDir
+		}
+		normalized = append(normalized, filepath.Clean(dir))
+	}
+	return normalized
+}
+
+func (s *Scanner) storeCandidate(candidate scanCandidate, result *ScanResult, progress ProgressFunc) {
+	result.FilesScanned++
+	result.ModelsFound++
+
+	existing, err := s.findExistingMetadata(candidate.path)
+	if err == nil && existing != nil {
+		result.ModelsSkipped++
+		reportProgress(progress, "scan", candidate.path, result)
+		return
+	}
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		result.Errors = append(result.Errors, fmt.Errorf("checking existing metadata for %s: %w", candidate.path, err))
+		reportProgress(progress, "scan", candidate.path, result)
+		return
+	}
+
+	if err := s.db.UpsertMetadata(candidate.meta); err != nil {
+		result.Errors = append(result.Errors, fmt.Errorf("storing metadata for %s: %w", candidate.path, err))
+		reportProgress(progress, "scan", candidate.path, result)
+		return
+	}
+
+	result.ModelsAdded++
+	reportProgress(progress, "scan", candidate.path, result)
+}
+
+func (s *Scanner) repairStaleRecords(ctx context.Context, dirs []string, result *ScanResult, progress ProgressFunc) {
+	rows, err := s.db.ListMetadata(state.MetadataFilters{})
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Errorf("listing metadata for stale repair: %w", err))
+		reportProgress(progress, "repair", "", result)
+		return
+	}
+	dirVariants := pathVariantList(dirs)
+	for _, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		if row.Dest == "" || !isModelFile(row.Dest) || !pathWithinDirVariants(row.Dest, dirVariants) {
+			continue
+		}
+		result.StaleChecked++
+		if _, err := os.Stat(row.Dest); err == nil {
+			reportProgress(progress, "repair", row.Dest, result)
+			continue
+		} else if !os.IsNotExist(err) {
+			result.Errors = append(result.Errors, fmt.Errorf("checking stale metadata %s: %w", row.Dest, err))
+			reportProgress(progress, "repair", row.Dest, result)
+			continue
+		}
+		if err := s.db.DeleteMetadata(row.DownloadURL); err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("removing stale metadata %s: %w", row.DownloadURL, err))
+			reportProgress(progress, "repair", row.Dest, result)
+			continue
+		}
+		result.StaleRemoved++
+		reportProgress(progress, "repair", row.Dest, result)
+	}
+}
+
+func pathWithinDirs(path string, dirs []string) bool {
+	return pathWithinDirVariants(path, pathVariantList(dirs))
+}
+
+func pathWithinDirVariants(path string, dirVariants [][]string) bool {
+	candidatePaths := pathVariants(path)
+	if len(candidatePaths) == 0 {
+		return false
+	}
+	for _, dirVariantGroup := range dirVariants {
+		for _, dirVariant := range dirVariantGroup {
+			for _, pathVariant := range candidatePaths {
+				rel, err := filepath.Rel(dirVariant, pathVariant)
+				if err != nil {
+					continue
+				}
+				if rel == "." || (rel != "" && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && rel != "..") {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func pathVariantList(paths []string) [][]string {
+	var variants [][]string
+	for _, path := range paths {
+		pathVariant := pathVariants(path)
+		if len(pathVariant) > 0 {
+			variants = append(variants, pathVariant)
+		}
+	}
+	return variants
+}
+
+func pathVariants(path string) []string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil
+	}
+	cleanPath := filepath.Clean(absPath)
+	variants := []string{cleanPath}
+	if evalPath, err := filepath.EvalSymlinks(cleanPath); err == nil {
+		evalPath = filepath.Clean(evalPath)
+		if evalPath != cleanPath {
+			variants = append(variants, evalPath)
+		}
+	}
+	return variants
+}
+
+func reportProgress(progress ProgressFunc, phase, path string, result *ScanResult) {
+	if progress == nil {
+		return
+	}
+	progress(Progress{
+		Phase:         phase,
+		Path:          path,
+		FilesScanned:  result.FilesScanned,
+		ModelsFound:   result.ModelsFound,
+		ModelsAdded:   result.ModelsAdded,
+		ModelsSkipped: result.ModelsSkipped,
+		StaleChecked:  result.StaleChecked,
+		StaleRemoved:  result.StaleRemoved,
+		Errors:        len(result.Errors),
+	})
+}
+
 // findExistingMetadata checks if we already have metadata for this file
 // This uses an indexed query for O(log n) performance instead of O(n)
 func (s *Scanner) findExistingMetadata(path string) (*state.ModelMetadata, error) {
@@ -133,7 +375,7 @@ func (s *Scanner) findExistingMetadata(path string) (*state.ModelMetadata, error
 		return nil, err
 	}
 	if meta == nil {
-		return nil, fmt.Errorf("not found")
+		return nil, sql.ErrNoRows
 	}
 	return meta, nil
 }
@@ -244,58 +486,21 @@ func extractNameAndVersion(filename string, meta *state.ModelMetadata) {
 
 // ScanWithProgress scans directories and calls progress callback
 func (s *Scanner) ScanWithProgress(dirs []string, progressFn func(path string, found int)) (*ScanResult, error) {
-	result := &ScanResult{
-		Errors: []error{},
-	}
-
-	for _, dir := range dirs {
-		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				if os.IsPermission(err) {
-					return filepath.SkipDir
-				}
-				return nil
+	return s.ScanDirectoriesWithOptions(context.Background(), dirs, Options{
+		Progress: func(progress Progress) {
+			if progressFn != nil && progress.Path != "" && progress.Phase == "scan" {
+				progressFn(progress.Path, progress.ModelsFound)
 			}
+		},
+	})
+}
 
-			if info.IsDir() {
-				return nil
-			}
+// ScanWithProgressDetail scans directories and reports detailed progress.
+func (s *Scanner) ScanWithProgressDetail(dirs []string, opts Options) (*ScanResult, error) {
+	return s.ScanDirectoriesWithOptions(context.Background(), dirs, opts)
+}
 
-			if !isModelFile(path) {
-				return nil
-			}
-
-			result.FilesScanned++
-
-			// Report progress
-			if progressFn != nil {
-				progressFn(path, result.ModelsFound)
-			}
-
-			// Check if exists
-			existing, err := s.findExistingMetadata(path)
-			if err == nil && existing != nil {
-				result.ModelsSkipped++
-				return nil
-			}
-
-			// Extract and store metadata
-			meta := s.extractMetadata(path, info)
-			result.ModelsFound++
-
-			if err := s.db.UpsertMetadata(meta); err != nil {
-				result.Errors = append(result.Errors, fmt.Errorf("storing %s: %w", path, err))
-				return nil
-			}
-
-			result.ModelsAdded++
-			return nil
-		})
-
-		if err != nil {
-			result.Errors = append(result.Errors, fmt.Errorf("walking %s: %w", dir, err))
-		}
-	}
-
-	return result, nil
+// ScanWithContext scans directories with cancellation support.
+func (s *Scanner) ScanWithContext(ctx context.Context, dirs []string, opts Options) (*ScanResult, error) {
+	return s.ScanDirectoriesWithOptions(ctx, dirs, opts)
 }

--- a/internal/scanner/scanner_bench_test.go
+++ b/internal/scanner/scanner_bench_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,8 +28,22 @@ func BenchmarkScanDirectories_10000Files(b *testing.B) {
 	benchmarkScanDirectories(b, 10000)
 }
 
+// BenchmarkScanDirectoriesSequential_1000Files benchmarks single-worker scans.
+func BenchmarkScanDirectoriesSequential_1000Files(b *testing.B) {
+	benchmarkScanDirectoriesWithWorkers(b, 1000, 1)
+}
+
+// BenchmarkScanDirectoriesParallel_1000Files benchmarks bounded parallel scans.
+func BenchmarkScanDirectoriesParallel_1000Files(b *testing.B) {
+	benchmarkScanDirectoriesWithWorkers(b, 1000, 4)
+}
+
 // benchmarkScanDirectories is the common benchmark implementation
 func benchmarkScanDirectories(b *testing.B, fileCount int) {
+	benchmarkScanDirectoriesWithWorkers(b, fileCount, 0)
+}
+
+func benchmarkScanDirectoriesWithWorkers(b *testing.B, fileCount, workers int) {
 	// Setup: Create temporary database and test files
 	tmpDir := b.TempDir()
 	dbPath := filepath.Join(tmpDir, "bench.db")
@@ -51,7 +66,7 @@ func benchmarkScanDirectories(b *testing.B, fileCount int) {
 
 	// Run benchmark
 	for i := 0; i < b.N; i++ {
-		result, err := scanner.ScanDirectories([]string{modelsDir})
+		result, err := scanner.ScanDirectoriesWithOptions(context.Background(), []string{modelsDir}, Options{Workers: workers})
 		if err != nil {
 			b.Fatalf("Scan failed: %v", err)
 		}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,12 +1,16 @@
 package scanner
 
 import (
+	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/jxwalker/modfetch/internal/config"
 	"github.com/jxwalker/modfetch/internal/state"
 )
 
@@ -411,6 +415,10 @@ func TestScanner_DuplicateSkipping(t *testing.T) {
 		t.Errorf("Second scan: expected 0 models added (duplicate), got %d", result2.ModelsAdded)
 	}
 
+	if result2.ModelsFound != 1 {
+		t.Errorf("Second scan: expected 1 model found before duplicate skip, got %d", result2.ModelsFound)
+	}
+
 	if result2.ModelsSkipped != 1 {
 		t.Errorf("Second scan: expected 1 model skipped, got %d", result2.ModelsSkipped)
 	}
@@ -646,5 +654,264 @@ func TestScanner_FileFormat(t *testing.T) {
 				t.Fatalf("Failed to clean up: %v", err)
 			}
 		})
+	}
+}
+
+func TestScanner_ParallelMatchesSingleWorker(t *testing.T) {
+	testDir := t.TempDir()
+	files := []string{
+		"llama-2-7b.Q4_K_M.gguf",
+		"sdxl-lora-v1.safetensors",
+		"vae-ft-mse.ckpt",
+		"nested/mistral-7b-instruct.Q5_K_S.gguf",
+	}
+	for _, name := range files {
+		createTestFile(t, testDir, name, 1024)
+	}
+
+	dbSeq, cleanupSeq := setupTestDB(t)
+	defer cleanupSeq()
+	seqScanner := NewScanner(dbSeq)
+	seqResult, err := seqScanner.ScanDirectoriesWithOptions(context.Background(), []string{testDir}, Options{Workers: 1})
+	if err != nil {
+		t.Fatalf("single-worker scan failed: %v", err)
+	}
+
+	dbParallel, cleanupParallel := setupTestDB(t)
+	defer cleanupParallel()
+	parallelScanner := NewScanner(dbParallel)
+	parallelResult, err := parallelScanner.ScanDirectoriesWithOptions(context.Background(), []string{testDir}, Options{Workers: 4})
+	if err != nil {
+		t.Fatalf("parallel scan failed: %v", err)
+	}
+
+	if seqResult.FilesScanned != parallelResult.FilesScanned ||
+		seqResult.ModelsFound != parallelResult.ModelsFound ||
+		seqResult.ModelsAdded != parallelResult.ModelsAdded ||
+		seqResult.ModelsSkipped != parallelResult.ModelsSkipped ||
+		seqResult.StaleChecked != parallelResult.StaleChecked ||
+		seqResult.StaleRemoved != parallelResult.StaleRemoved ||
+		len(seqResult.Errors) != len(parallelResult.Errors) {
+		t.Fatalf("parallel result mismatch\nsingle=%+v\nparallel=%+v", seqResult, parallelResult)
+	}
+
+	seqRows, err := dbSeq.ListMetadata(state.MetadataFilters{OrderBy: "name"})
+	if err != nil {
+		t.Fatalf("list single-worker metadata: %v", err)
+	}
+	parallelRows, err := dbParallel.ListMetadata(state.MetadataFilters{OrderBy: "name"})
+	if err != nil {
+		t.Fatalf("list parallel metadata: %v", err)
+	}
+	if len(seqRows) != len(parallelRows) {
+		t.Fatalf("metadata count mismatch: single=%d parallel=%d", len(seqRows), len(parallelRows))
+	}
+	for i := range seqRows {
+		if seqRows[i].Dest != parallelRows[i].Dest ||
+			seqRows[i].ModelName != parallelRows[i].ModelName ||
+			seqRows[i].ModelType != parallelRows[i].ModelType ||
+			seqRows[i].Quantization != parallelRows[i].Quantization {
+			t.Fatalf("metadata mismatch at %d:\nsingle=%+v\nparallel=%+v", i, seqRows[i], parallelRows[i])
+		}
+	}
+}
+
+func TestScanner_RepairStaleRecords(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	testDir := t.TempDir()
+	existingPath := createTestFile(t, testDir, "existing.gguf", 1024)
+	missingPath := filepath.Join(testDir, "missing.gguf")
+	outsideMissingPath := filepath.Join(t.TempDir(), "outside.gguf")
+
+	for _, meta := range []*state.ModelMetadata{
+		{DownloadURL: "file://" + existingPath, Dest: existingPath, ModelName: "existing", Source: "local"},
+		{DownloadURL: "file://" + missingPath, Dest: missingPath, ModelName: "missing", Source: "local"},
+		{DownloadURL: "file://" + outsideMissingPath, Dest: outsideMissingPath, ModelName: "outside", Source: "local"},
+	} {
+		if err := db.UpsertMetadata(meta); err != nil {
+			t.Fatalf("seed metadata: %v", err)
+		}
+	}
+
+	scanner := NewScanner(db)
+	result, err := scanner.ScanDirectoriesWithOptions(context.Background(), []string{testDir}, Options{
+		Workers:     2,
+		RepairStale: true,
+	})
+	if err != nil {
+		t.Fatalf("repair scan failed: %v", err)
+	}
+	if result.StaleChecked != 2 {
+		t.Fatalf("expected 2 stale checks under scan dir, got %d", result.StaleChecked)
+	}
+	if result.StaleRemoved != 1 {
+		t.Fatalf("expected 1 stale record removed, got %d", result.StaleRemoved)
+	}
+	if _, err := db.GetMetadata("file://" + missingPath); err != sql.ErrNoRows {
+		t.Fatalf("missing metadata should be deleted, got %v", err)
+	}
+	if _, err := db.GetMetadata("file://" + outsideMissingPath); err != nil {
+		t.Fatalf("outside metadata should be preserved, got %v", err)
+	}
+}
+
+func TestScanner_RepairStaleCancellationReturnsOnlyError(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	testDir := t.TempDir()
+	missingPath := filepath.Join(testDir, "missing.gguf")
+	if err := db.UpsertMetadata(&state.ModelMetadata{
+		DownloadURL: "file://" + missingPath,
+		Dest:        missingPath,
+		ModelName:   "missing",
+		Source:      "local",
+	}); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	scanner := NewScanner(db)
+	result, err := scanner.ScanDirectoriesWithOptions(ctx, []string{testDir}, Options{RepairStale: true})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got result=%+v err=%v", result, err)
+	}
+	if result == nil {
+		t.Fatal("expected scan result")
+	}
+	if len(result.Errors) != 0 {
+		t.Fatalf("cancellation should be returned once as an error, got result errors: %+v", result.Errors)
+	}
+}
+
+func TestScanner_CancellationLeavesStoredRowsValid(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	testDir := t.TempDir()
+	for i := 0; i < 100; i++ {
+		createTestFile(t, testDir, fmt.Sprintf("model-%03d.gguf", i), 1024)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	scanner := NewScanner(db)
+	result, err := scanner.ScanDirectoriesWithOptions(ctx, []string{testDir}, Options{
+		Workers: 4,
+		Progress: func(progress Progress) {
+			if progress.FilesScanned >= 1 {
+				cancel()
+			}
+		},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got result=%+v err=%v", result, err)
+	}
+
+	rows, err := db.ListMetadata(state.MetadataFilters{})
+	if err != nil {
+		t.Fatalf("list metadata after cancellation: %v", err)
+	}
+	for _, row := range rows {
+		if row.DownloadURL == "" || row.Dest == "" {
+			t.Fatalf("invalid stored row after cancellation: %+v", row)
+		}
+		if _, err := os.Stat(row.Dest); err != nil {
+			t.Fatalf("stored row points at missing file after cancellation: %+v err=%v", row, err)
+		}
+	}
+}
+
+func TestConfiguredDirectoriesDeterministicAndTrimmed(t *testing.T) {
+	cfg := &config.Config{
+		General: config.General{DownloadRoot: " /downloads "},
+		Placement: config.Placement{Apps: map[string]config.AppPlacement{
+			"z-app": {
+				Base: " /z ",
+				Paths: map[string]string{
+					"b": " loras ",
+					"a": " checkpoints ",
+				},
+			},
+			"a-app": {
+				Base: "   ",
+				Paths: map[string]string{
+					"abs": " /absolute/path ",
+				},
+			},
+			"m-app": {
+				Base: " /m ",
+				Paths: map[string]string{
+					"abs":   " /override ",
+					"empty": "  ",
+				},
+			},
+		}},
+	}
+
+	got := ConfiguredDirectories(cfg)
+	want := []string{
+		"/downloads",
+		"/absolute/path",
+		"/m",
+		"/override",
+		"/z",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("configured dirs mismatch\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestConfiguredDirectoriesFiltersRedundantSubdirectories(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "child")
+	cfg := &config.Config{
+		General: config.General{DownloadRoot: root},
+		Placement: config.Placement{Apps: map[string]config.AppPlacement{
+			"app": {
+				Base: root,
+				Paths: map[string]string{
+					"child": child,
+				},
+			},
+		}},
+	}
+
+	got := ConfiguredDirectories(cfg)
+	if len(got) != 1 || got[0] != root {
+		t.Fatalf("expected only parent directory, got %#v", got)
+	}
+}
+
+func TestPathWithinDirsNormalizesTrailingSlash(t *testing.T) {
+	dir := t.TempDir()
+	path := createTestFile(t, dir, "model.gguf", 1024)
+
+	if !pathWithinDirs(path, []string{dir + string(os.PathSeparator)}) {
+		t.Fatalf("expected %s to be inside %s/", path, dir)
+	}
+}
+
+func TestPathWithinDirsHandlesSymlinkedDirectory(t *testing.T) {
+	parent := t.TempDir()
+	realDir := filepath.Join(parent, "real")
+	linkDir := filepath.Join(parent, "link")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlink not available: %v", err)
+	}
+	realPath := createTestFile(t, realDir, "model.gguf", 1024)
+	linkPath := filepath.Join(linkDir, "model.gguf")
+
+	if !pathWithinDirs(realPath, []string{linkDir}) {
+		t.Fatalf("expected real path %s to be inside symlinked dir %s", realPath, linkDir)
+	}
+	if !pathWithinDirs(linkPath, []string{linkDir}) {
+		t.Fatalf("expected symlink path %s to be inside symlinked dir %s", linkPath, linkDir)
 	}
 }

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -25,14 +25,14 @@ func (m *Model) recoverCmd() tea.Cmd {
 		if err != nil {
 			return recoverRowsMsg{rows: nil}
 		}
-		var todo []state.DownloadRow
+		var pending []state.DownloadRow
 		for _, r := range rows {
 			st := strings.ToLower(strings.TrimSpace(r.Status))
 			if st == "running" || st == "planning" || st == "hold" {
-				todo = append(todo, r)
+				pending = append(pending, r)
 			}
 		}
-		return recoverRowsMsg{rows: todo}
+		return recoverRowsMsg{rows: pending}
 	}
 }
 

--- a/internal/tui/library_test.go
+++ b/internal/tui/library_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jxwalker/modfetch/internal/catalog"
 	"github.com/jxwalker/modfetch/internal/config"
+	"github.com/jxwalker/modfetch/internal/scanner"
 	"github.com/jxwalker/modfetch/internal/state"
 )
 
@@ -559,6 +561,106 @@ func TestLibrary_ScanDirectoriesCmd_NoDirectories(t *testing.T) {
 
 	if scanMsg.err == nil {
 		t.Error("Should return error when no directories configured")
+	}
+}
+
+func TestLibrary_ScanDirectoriesStreamReportsProgress(t *testing.T) {
+	model, _, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	modelPath := filepath.Join(model.cfg.General.DownloadRoot, "stream-model.gguf")
+	if err := os.WriteFile(modelPath, []byte("model"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ch := make(chan tea.Msg, 16)
+	done := make(chan tea.Msg, 1)
+	go func() {
+		done <- model.scanDirectoriesStreamCmd(context.Background(), ch)()
+	}()
+
+	sawProgress := false
+	var complete scanCompleteMsg
+	for msg := range ch {
+		switch msg := msg.(type) {
+		case scanProgressMsg:
+			if msg.progress.FilesScanned > 0 {
+				sawProgress = true
+			}
+		case scanCompleteMsg:
+			complete = msg
+		}
+	}
+	if msg := <-done; msg != nil {
+		t.Fatalf("stream command should return nil, got %T", msg)
+	}
+	if !sawProgress {
+		t.Fatal("expected scan progress message")
+	}
+	if complete.err != nil {
+		t.Fatalf("scan failed: %v", complete.err)
+	}
+	if complete.result == nil || complete.result.FilesScanned != 1 || complete.result.ModelsAdded != 1 {
+		t.Fatalf("unexpected scan result: %+v", complete.result)
+	}
+}
+
+func TestLibrary_ScanDirectoriesStreamStopsAfterCancellation(t *testing.T) {
+	model, _, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ch := make(chan tea.Msg)
+	done := make(chan tea.Msg, 1)
+	go func() {
+		done <- model.scanDirectoriesStreamCmd(ctx, ch)()
+	}()
+
+	streamClosed := false
+	for !streamClosed {
+		select {
+		case _, ok := <-ch:
+			streamClosed = !ok
+		case <-time.After(time.Second):
+			t.Fatal("scan stream did not close after cancellation")
+		}
+	}
+
+	select {
+	case msg := <-done:
+		if msg != nil {
+			t.Fatalf("stream command should return nil, got %T", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("scan stream command blocked after cancellation")
+	}
+}
+
+func TestLibrary_ScanCompleteCancelsContext(t *testing.T) {
+	model, _, cleanup := setupTestLibrary(t)
+	defer cleanup()
+
+	cancelled := false
+	model.libraryScanning = true
+	model.libraryScanCancel = func() {
+		cancelled = true
+	}
+
+	updated, cmd := model.Update(scanCompleteMsg{result: &scanner.ScanResult{}})
+	if cmd != nil {
+		t.Fatalf("scan completion should not return a command, got %T", cmd)
+	}
+	updatedModel := updated.(*Model)
+	if !cancelled {
+		t.Fatal("expected scan completion to call cancel")
+	}
+	if updatedModel.libraryScanCancel != nil {
+		t.Fatal("expected scan cancel function to be cleared")
+	}
+	if updatedModel.libraryScanning {
+		t.Fatal("expected scan state to be cleared")
 	}
 }
 

--- a/internal/tui/library_view.go
+++ b/internal/tui/library_view.go
@@ -1,8 +1,8 @@
 package tui
 
 import (
+	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -106,6 +106,18 @@ func (m *Model) renderLibrary() string {
 	}
 	if m.libraryShowFavorites {
 		header += m.th.ok.Render(" • ★ Favorites")
+	}
+	if m.libraryScanning {
+		header += m.th.label.Render(fmt.Sprintf(" • Scanning: %d files, %d added, %d skipped",
+			m.libraryScanProgress.FilesScanned,
+			m.libraryScanProgress.ModelsAdded,
+			m.libraryScanProgress.ModelsSkipped))
+	} else if m.libraryScanProgress.FilesScanned > 0 || m.libraryScanProgress.StaleChecked > 0 {
+		header += m.th.label.Render(fmt.Sprintf(" • Last scan: %d files, %d added, %d skipped, %d stale removed",
+			m.libraryScanProgress.FilesScanned,
+			m.libraryScanProgress.ModelsAdded,
+			m.libraryScanProgress.ModelsSkipped,
+			m.libraryScanProgress.StaleRemoved))
 	}
 	totalSelected := len(m.librarySelectedKeys)
 	if totalSelected > 0 {
@@ -474,48 +486,60 @@ func (m *Model) updateLibrarySearch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 // scanDirectoriesCmd initiates a directory scan for models
-
 func (m *Model) scanDirectoriesCmd() tea.Cmd {
 	return func() tea.Msg {
-		if m.st == nil || m.cfg == nil {
-			return scanCompleteMsg{err: fmt.Errorf("database or config not available")}
-		}
-
-		// Get directories to scan from config
-		dirs := []string{}
-
-		// Add download root
-		if m.cfg.General.DownloadRoot != "" {
-			dirs = append(dirs, m.cfg.General.DownloadRoot)
-		}
-
-		// Add placement app base directories and subdirectories
-		for _, app := range m.cfg.Placement.Apps {
-			if app.Base != "" {
-				dirs = append(dirs, app.Base)
-			}
-			for _, path := range app.Paths {
-				if path != "" {
-					fullPath := filepath.Join(app.Base, path)
-					dirs = append(dirs, fullPath)
-				}
-			}
-		}
-
-		if len(dirs) == 0 {
-			return scanCompleteMsg{err: fmt.Errorf("no directories configured to scan")}
-		}
-
-		// Perform scan
-		scanner := scanner.NewScanner(m.st)
-		result, err := scanner.ScanDirectories(dirs)
-
-		if err != nil {
-			return scanCompleteMsg{err: err, result: result}
-		}
-
-		return scanCompleteMsg{result: result}
+		result, err := m.runDirectoryScan(context.Background(), nil)
+		return scanCompleteMsg{result: result, err: err}
 	}
+}
+
+func (m *Model) scanDirectoriesStreamCmd(ctx context.Context, ch chan tea.Msg) tea.Cmd {
+	return func() tea.Msg {
+		defer close(ch)
+
+		progressFn := func(progress scanner.Progress) {
+			select {
+			case ch <- scanProgressMsg{progress: progress, ch: ch}:
+			case <-ctx.Done():
+			default:
+			}
+		}
+		result, err := m.runDirectoryScan(ctx, progressFn)
+		select {
+		case ch <- scanCompleteMsg{result: result, err: err}:
+		case <-ctx.Done():
+		}
+		return nil
+	}
+}
+
+func (m *Model) runDirectoryScan(ctx context.Context, progress scanner.ProgressFunc) (*scanner.ScanResult, error) {
+	if m.st == nil || m.cfg == nil {
+		return nil, fmt.Errorf("database or config not available")
+	}
+
+	dirs := scanner.ConfiguredDirectories(m.cfg)
+	if len(dirs) == 0 {
+		return nil, fmt.Errorf("no directories configured to scan")
+	}
+
+	sc := scanner.NewScanner(m.st)
+	return sc.ScanWithContext(ctx, dirs, scanner.Options{Progress: progress})
+}
+
+func waitForScanMsg(ch <-chan tea.Msg) tea.Cmd {
+	return func() tea.Msg {
+		msg, ok := <-ch
+		if !ok {
+			return nil
+		}
+		return msg
+	}
+}
+
+type scanProgressMsg struct {
+	progress scanner.Progress
+	ch       <-chan tea.Msg
 }
 
 // scanCompleteMsg is sent when directory scan completes

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jxwalker/modfetch/internal/logging"
 	"github.com/jxwalker/modfetch/internal/placer"
 	"github.com/jxwalker/modfetch/internal/resolver"
+	"github.com/jxwalker/modfetch/internal/scanner"
 	"github.com/jxwalker/modfetch/internal/state"
 )
 
@@ -185,6 +186,8 @@ type Model struct {
 	librarySearchInput   textinput.Model // Search input for library
 	librarySearchActive  bool            // Search input is active
 	libraryScanning      bool            // Currently scanning directories
+	libraryScanProgress  scanner.Progress
+	libraryScanCancel    context.CancelFunc
 	stateEvents          <-chan struct{}
 	stopStateEvents      func()
 	log                  *logging.Logger
@@ -382,15 +385,35 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Metadata was successfully stored, mark library as needing refresh
 		m.libraryNeedsRefresh = true
 		return m, nil
+	case scanProgressMsg:
+		m.libraryScanProgress = msg.progress
+		if m.libraryScanning {
+			return m, waitForScanMsg(msg.ch)
+		}
+		return m, nil
 	case scanCompleteMsg:
 		// Handle directory scan completion
 		m.libraryScanning = false
+		if m.libraryScanCancel != nil {
+			m.libraryScanCancel()
+			m.libraryScanCancel = nil
+		}
 
 		if msg.err != nil {
 			m.addToast(fmt.Sprintf("scan error: %v", msg.err))
 		} else if msg.result != nil {
-			m.addToast(fmt.Sprintf("scan complete: %d files scanned, %d models added, %d skipped",
-				msg.result.FilesScanned, msg.result.ModelsAdded, msg.result.ModelsSkipped))
+			m.libraryScanProgress = scanner.Progress{
+				Phase:         "complete",
+				FilesScanned:  msg.result.FilesScanned,
+				ModelsFound:   msg.result.ModelsFound,
+				ModelsAdded:   msg.result.ModelsAdded,
+				ModelsSkipped: msg.result.ModelsSkipped,
+				StaleChecked:  msg.result.StaleChecked,
+				StaleRemoved:  msg.result.StaleRemoved,
+				Errors:        len(msg.result.Errors),
+			}
+			m.addToast(fmt.Sprintf("scan complete: %d files scanned, %d models added, %d skipped, %d stale removed",
+				msg.result.FilesScanned, msg.result.ModelsAdded, msg.result.ModelsSkipped, msg.result.StaleRemoved))
 			// Refresh library to show new models - will be loaded when user views library tab
 			m.libraryNeedsRefresh = true
 		}
@@ -504,6 +527,10 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch s {
 	case "q", "ctrl+c":
+		if m.libraryScanCancel != nil {
+			m.libraryScanCancel()
+			m.libraryScanCancel = nil
+		}
 		if m.stopStateEvents != nil {
 			m.stopStateEvents()
 			m.stopStateEvents = nil
@@ -537,7 +564,12 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "S":
 		// Scan directories for existing models
 		if m.activeTab == 4 && !m.libraryScanning {
-			return m, m.scanDirectoriesCmd()
+			m.libraryScanning = true
+			m.libraryScanProgress = scanner.Progress{Phase: "scan"}
+			ctx, cancel := context.WithCancel(context.Background())
+			m.libraryScanCancel = cancel
+			ch := make(chan tea.Msg, 16)
+			return m, tea.Batch(m.scanDirectoriesStreamCmd(ctx, ch), waitForScanMsg(ch))
 		}
 		return m, nil
 	case "F":


### PR DESCRIPTION
## Summary
- add bounded parallel scanner options with serialized metadata database writes and cancellation support
- add `modfetch library scan` with progress, JSON output, worker selection, and opt-in stale metadata repair
- show TUI scan state/last scan summary and document scanner CLI, repair flow, and roadmap completion

## Verification
- `GOCACHE="$PWD/.cache/go-build" GOMODCACHE="$PWD/.cache/gomod" go test ./...`
- `GOCACHE="$PWD/.cache/go-build" GOMODCACHE="$PWD/.cache/gomod" go test -run '^$' -bench 'BenchmarkScanDirectories(Sequential|Parallel)_1000Files' -benchmem ./internal/scanner`
- `GOCACHE="$PWD/.cache/go-build" GOMODCACHE="$PWD/.cache/gomod" make build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->