### PR TITLE
[codex] Add AUR package metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Docs drift check
         run: scripts/check-docs-drift.sh
       - name: AUR package check
-        run: scripts/check-aur-package.sh v0.7.0
+        run: scripts/check-aur-package.sh
 
   test:
     needs: [lint]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           args: --timeout=5m
       - name: Docs drift check
         run: scripts/check-docs-drift.sh
+      - name: AUR package check
+        run: scripts/check-aur-package.sh v0.7.0
 
   test:
     needs: [lint]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+Added
+- Added AUR `modfetch-bin` packaging metadata for the published Linux release
+  binaries.
+- Added portable AUR package validation that checks `PKGBUILD`, `.SRCINFO`, and
+  published release checksums.
+
+Docs
+- Documented Arch Linux AUR package maintenance and release checklist coverage.
+
 ## v0.7.0 — 2026-04-28
 
 Added

--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ Contributing
     - macOS: amd64, arm64, universal (fat) binary
     - Checksums (.sha256) for all artifacts
   - Release notes are extracted from the matching `CHANGELOG.md` section by `scripts/release-notes.sh`
+  - Package metadata is tracked under `packaging/homebrew/` and `packaging/aur/`
   - Optional (local): `make release-dist` and `make macos-universal` if you want to reproduce artifacts locally
 
 See CONTRIBUTING.md for full guidelines.
@@ -477,10 +478,9 @@ Troubleshooting
 
 Roadmap
 - See docs/ROADMAP.md for the active, prioritized roadmap
-- v0.7.0 focus:
-  - Package distribution
-  - Library catalog export/import
-  - TUI bulk operations and filter menu
-  - Placement presets
-  - Scanner performance and repair UX
-  - Release hardening
+- v0.7.x focus:
+  - AUR package publication
+  - Metadata enrichment from additional registries
+  - Remote catalog sync targets
+  - User-driven archive format expansion
+  - Non-interactive TUI scripting hooks

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -62,9 +62,17 @@ sudo cp bin/modfetch /usr/local/bin/
   brew tap jxwalker/tap
   brew install jxwalker/tap/modfetch
   ```
+- **Arch Linux / AUR**: package metadata is maintained in `packaging/aur/`.
+  After `modfetch-bin` is published to AUR, install it with:
+  ```bash
+  git clone https://aur.archlinux.org/modfetch-bin.git
+  cd modfetch-bin
+  makepkg -si
+  ```
+  Until then, use the one-line installer or manual release binary.
 - **Ubuntu/Debian**: One-liner installer handles all dependencies
 - **CentOS/RHEL**: Ensure `curl` and `tar` are installed first
-- **Arch Linux**: Use the one-line installer or manual release binary until an AUR package is published.
+- **Other distributions**: Use the one-line installer or manual release binary.
 
 ## Configuration
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -42,6 +42,26 @@ Use this checklist from a clean `main` checkout before tagging a modfetch releas
   ```
 - Open and merge a tap PR, then confirm the tap branch was deleted.
 
+## AUR Package
+
+- Update `packaging/aur/PKGBUILD` and `packaging/aur/.SRCINFO` after release
+  assets are published.
+- Set `pkgver` to the release version without the leading `v`.
+- Update SHA256 values from the published Linux release assets and LICENSE file.
+- Validate the packaged metadata and published checksums:
+  ```bash
+  scripts/check-aur-package.sh vX.Y.Z
+  ```
+- On an Arch Linux machine, validate the source package before pushing to AUR:
+  ```bash
+  cd packaging/aur
+  makepkg --printsrcinfo > .SRCINFO
+  makepkg -si
+  modfetch version
+  namcap PKGBUILD
+  ```
+- Push the package files to `ssh://aur@aur.archlinux.org/modfetch-bin.git`.
+
 ## Final Verification
 
 - Ensure `git status --short --branch` is clean on `main`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -138,7 +138,9 @@ Acceptance checks:
 
 These are useful, but not required for the first v0.7.0 release:
 
-- AUR packaging after Homebrew is stable.
+- [IN PROGRESS] AUR packaging after Homebrew is stable:
+  package metadata and validation are staged in `packaging/aur/`; AUR
+  publication is pending an AUR-registered SSH key.
 - Metadata enrichment from additional model registries.
 - Remote catalog sync targets.
 - More archive formats if users report concrete needs.

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,0 +1,18 @@
+pkgbase = modfetch-bin
+	pkgdesc = Robust CLI/TUI downloader for LLM and Stable Diffusion assets
+	pkgver = 0.7.0
+	pkgrel = 1
+	url = https://github.com/jxwalker/modfetch
+	arch = x86_64
+	arch = aarch64
+	license = MIT
+	provides = modfetch
+	conflicts = modfetch
+	source = LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v0.7.0/LICENSE
+	sha256sums = 73be8e0a20ff3b0a6991d6405d4d485e5ffc8dfb07a13a1f1b7afb081f57ee54
+	source_x86_64 = modfetch-0.7.0-linux-amd64::https://github.com/jxwalker/modfetch/releases/download/v0.7.0/modfetch_linux_amd64
+	sha256sums_x86_64 = 7fe79e9ac38961e9bc7238b268388b36af98a7a2b6c6891fc94397ac504e7118
+	source_aarch64 = modfetch-0.7.0-linux-arm64::https://github.com/jxwalker/modfetch/releases/download/v0.7.0/modfetch_linux_arm64
+	sha256sums_aarch64 = 398c2d3d1d9cc7a83b5d9dc99ca2c0176a3ee5b4db3b73f4b9b9e6c9a55da1eb
+
+pkgname = modfetch-bin

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: James Walker <james@jimm5.local>
+# Maintainer: James Walker <james@jameswalker.org.uk>
 pkgname=modfetch-bin
 _pkgname=modfetch
 pkgver=0.7.0

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: James Walker <james@jimm5.local>
+pkgname=modfetch-bin
+_pkgname=modfetch
+pkgver=0.7.0
+pkgrel=1
+pkgdesc="Robust CLI/TUI downloader for LLM and Stable Diffusion assets"
+arch=('x86_64' 'aarch64')
+url="https://github.com/jxwalker/modfetch"
+license=('MIT')
+provides=('modfetch')
+conflicts=('modfetch')
+
+source=("LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v${pkgver}/LICENSE")
+sha256sums=('73be8e0a20ff3b0a6991d6405d4d485e5ffc8dfb07a13a1f1b7afb081f57ee54')
+
+source_x86_64=("${_pkgname}-${pkgver}-linux-amd64::https://github.com/jxwalker/modfetch/releases/download/v${pkgver}/${_pkgname}_linux_amd64")
+sha256sums_x86_64=('7fe79e9ac38961e9bc7238b268388b36af98a7a2b6c6891fc94397ac504e7118')
+
+source_aarch64=("${_pkgname}-${pkgver}-linux-arm64::https://github.com/jxwalker/modfetch/releases/download/v${pkgver}/${_pkgname}_linux_arm64")
+sha256sums_aarch64=('398c2d3d1d9cc7a83b5d9dc99ca2c0176a3ee5b4db3b73f4b9b9e6c9a55da1eb')
+
+package() {
+  local binary
+  case "$CARCH" in
+    x86_64)
+      binary="${srcdir}/${_pkgname}-${pkgver}-linux-amd64"
+      ;;
+    aarch64)
+      binary="${srcdir}/${_pkgname}-${pkgver}-linux-arm64"
+      ;;
+    *)
+      echo "unsupported architecture: ${CARCH}" >&2
+      return 1
+      ;;
+  esac
+
+  install -Dm755 "$binary" "${pkgdir}/usr/bin/${_pkgname}"
+  install -Dm644 "${srcdir}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -1,0 +1,28 @@
+# AUR Packaging
+
+This directory stages the `modfetch-bin` AUR package. It packages the published
+Linux release binaries instead of rebuilding from source.
+
+Validate metadata and live release checksums from the repository root:
+
+```bash
+scripts/check-aur-package.sh v0.7.0
+```
+
+Before publishing from an Arch Linux machine:
+
+```bash
+cd packaging/aur
+makepkg --printsrcinfo > .SRCINFO
+makepkg -si
+modfetch version
+namcap PKGBUILD
+```
+
+To publish, push `PKGBUILD` and `.SRCINFO` to:
+
+```bash
+ssh://aur@aur.archlinux.org/modfetch-bin.git
+```
+
+Publication requires an AUR account with a registered SSH key.

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -6,7 +6,7 @@ Linux release binaries instead of rebuilding from source.
 Validate metadata and live release checksums from the repository root:
 
 ```bash
-scripts/check-aur-package.sh v0.7.0
+scripts/check-aur-package.sh
 ```
 
 Before publishing from an Arch Linux machine:

--- a/scripts/check-aur-package.sh
+++ b/scripts/check-aur-package.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+aur_dir="$root/packaging/aur"
+pkgbuild="$aur_dir/PKGBUILD"
+srcinfo="$aur_dir/.SRCINFO"
+
+if [[ ! -s "$pkgbuild" || ! -s "$srcinfo" ]]; then
+  echo "AUR packaging files are missing or empty" >&2
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$pkgbuild"
+
+expected_tag="${1:-v${pkgver}}"
+expected_pkgver="${expected_tag#v}"
+release_base="https://github.com/jxwalker/modfetch/releases/download/v${pkgver}"
+
+failures=0
+fail() {
+  echo "AUR package check: $*" >&2
+  failures=$((failures + 1))
+}
+
+require_equal() {
+  local actual="$1"
+  local expected="$2"
+  local label="$3"
+  if [[ "$actual" != "$expected" ]]; then
+    fail "$label expected '$expected' but found '$actual'"
+  fi
+}
+
+require_file_contains() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+  if ! grep -Eq "$pattern" "$file"; then
+    fail "$label"
+  fi
+}
+
+fetch_sha256_file() {
+  local url="$1"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" | awk '{ print $1; exit }'
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO- "$url" | awk '{ print $1; exit }'
+  else
+    echo "curl or wget is required for AUR checksum validation" >&2
+    exit 1
+  fi
+}
+
+fetch_sha256_body() {
+  local url="$1"
+  if command -v curl >/dev/null 2>&1; then
+    if command -v sha256sum >/dev/null 2>&1; then
+      curl -fsSL "$url" | sha256sum | awk '{ print $1; exit }'
+    else
+      curl -fsSL "$url" | shasum -a 256 | awk '{ print $1; exit }'
+    fi
+  elif command -v wget >/dev/null 2>&1; then
+    if command -v sha256sum >/dev/null 2>&1; then
+      wget -qO- "$url" | sha256sum | awk '{ print $1; exit }'
+    else
+      wget -qO- "$url" | shasum -a 256 | awk '{ print $1; exit }'
+    fi
+  else
+    echo "curl or wget is required for AUR checksum validation" >&2
+    exit 1
+  fi
+}
+
+array_has() {
+  local needle="$1"
+  shift
+  local item
+  for item in "$@"; do
+    [[ "$item" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+require_equal "$pkgname" "modfetch-bin" "pkgname"
+require_equal "$_pkgname" "modfetch" "_pkgname"
+require_equal "$pkgver" "$expected_pkgver" "pkgver"
+require_equal "${pkgrel}" "1" "pkgrel"
+array_has "x86_64" "${arch[@]}" || fail "arch must include x86_64"
+array_has "aarch64" "${arch[@]}" || fail "arch must include aarch64"
+array_has "modfetch" "${provides[@]}" || fail "provides must include modfetch"
+array_has "modfetch" "${conflicts[@]}" || fail "conflicts must include modfetch"
+
+require_equal "${source[0]}" "LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v${pkgver}/LICENSE" "license source"
+require_equal "${source_x86_64[0]}" "modfetch-${pkgver}-linux-amd64::${release_base}/modfetch_linux_amd64" "x86_64 source"
+require_equal "${source_aarch64[0]}" "modfetch-${pkgver}-linux-arm64::${release_base}/modfetch_linux_arm64" "aarch64 source"
+
+require_equal "${sha256sums[0]}" "$(fetch_sha256_body "https://raw.githubusercontent.com/jxwalker/modfetch/v${pkgver}/LICENSE")" "LICENSE checksum"
+require_equal "${sha256sums_x86_64[0]}" "$(fetch_sha256_file "${release_base}/modfetch_linux_amd64.sha256")" "x86_64 checksum"
+require_equal "${sha256sums_aarch64[0]}" "$(fetch_sha256_file "${release_base}/modfetch_linux_arm64.sha256")" "aarch64 checksum"
+
+require_file_contains "$pkgbuild" 'install -Dm755 "\$binary" "\$\{pkgdir\}/usr/bin/\$\{_pkgname\}"' "PKGBUILD must install modfetch into /usr/bin"
+require_file_contains "$pkgbuild" 'install -Dm644 "\$\{srcdir\}/LICENSE" "\$\{pkgdir\}/usr/share/licenses/\$\{pkgname\}/LICENSE"' "PKGBUILD must install the license"
+
+require_file_contains "$srcinfo" '^pkgbase = modfetch-bin$' ".SRCINFO pkgbase mismatch"
+require_file_contains "$srcinfo" "pkgver = ${pkgver}$" ".SRCINFO pkgver mismatch"
+require_file_contains "$srcinfo" "source_x86_64 = modfetch-${pkgver}-linux-amd64::${release_base}/modfetch_linux_amd64$" ".SRCINFO x86_64 source mismatch"
+require_file_contains "$srcinfo" "sha256sums_x86_64 = ${sha256sums_x86_64[0]}$" ".SRCINFO x86_64 checksum mismatch"
+require_file_contains "$srcinfo" "source_aarch64 = modfetch-${pkgver}-linux-arm64::${release_base}/modfetch_linux_arm64$" ".SRCINFO aarch64 source mismatch"
+require_file_contains "$srcinfo" "sha256sums_aarch64 = ${sha256sums_aarch64[0]}$" ".SRCINFO aarch64 checksum mismatch"
+
+if command -v makepkg >/dev/null 2>&1; then
+  tmp_srcinfo="$(mktemp)"
+  (cd "$aur_dir" && makepkg --printsrcinfo > "$tmp_srcinfo")
+  if ! diff -u "$srcinfo" "$tmp_srcinfo"; then
+    fail ".SRCINFO does not match makepkg --printsrcinfo"
+  fi
+  rm -f "$tmp_srcinfo"
+else
+  echo "makepkg not found; completed portable AUR metadata and checksum validation"
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+  exit 1
+fi
+
+echo "AUR package check passed for ${expected_tag}"

--- a/scripts/check-aur-package.sh
+++ b/scripts/check-aur-package.sh
@@ -34,14 +34,26 @@ extract_pkgbuild_scalar() {
 extract_pkgbuild_array_first() {
   local file="$1"
   local var_name="$2"
-  local line
+  local block value
 
-  line="$(grep -E "^[[:space:]]*${var_name}=\\(" "$file" | head -n 1 || true)"
-  if [[ -z "$line" ]]; then
+  block="$(awk -v var_name="$var_name" '
+    $0 ~ "^[[:space:]]*" var_name "=\\(" {
+      in_array = 1
+    }
+    in_array {
+      print
+      if ($0 ~ /\)/) {
+        exit
+      }
+    }
+  ' "$file")"
+  if [[ -z "$block" ]]; then
     return 1
   fi
 
-  printf '%s\n' "$line" | sed -E "s/^[^(]*\\([[:space:]]*['\"]([^'\"]+)['\"].*/\\1/"
+  value="$(printf '%s\n' "$block" | sed -nE "s/^[^(]*\\([[:space:]]*['\"]([^'\"]+)['\"].*/\\1/p; s/^[[:space:]]*['\"]([^'\"]+)['\"].*/\\1/p" | head -n 1)"
+  [[ -n "$value" ]] || return 1
+  printf '%s\n' "$value"
 }
 
 pkgname="$(extract_pkgbuild_scalar "$pkgbuild" "pkgname")"

--- a/scripts/check-aur-package.sh
+++ b/scripts/check-aur-package.sh
@@ -11,8 +11,46 @@ if [[ ! -s "$pkgbuild" || ! -s "$srcinfo" ]]; then
   exit 1
 fi
 
-# shellcheck source=/dev/null
-source "$pkgbuild"
+extract_pkgbuild_scalar() {
+  local file="$1"
+  local var_name="$2"
+  local line value
+
+  line="$(grep -E "^[[:space:]]*${var_name}=" "$file" | head -n 1 || true)"
+  if [[ -z "$line" ]]; then
+    return 1
+  fi
+
+  value="${line#*=}"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  value="${value#\"}"
+  value="${value%\"}"
+  value="${value#\'}"
+  value="${value%\'}"
+  printf '%s\n' "$value"
+}
+
+extract_pkgbuild_array_first() {
+  local file="$1"
+  local var_name="$2"
+  local line
+
+  line="$(grep -E "^[[:space:]]*${var_name}=\\(" "$file" | head -n 1 || true)"
+  if [[ -z "$line" ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "$line" | sed -E "s/^[^(]*\\([[:space:]]*['\"]([^'\"]+)['\"].*/\\1/"
+}
+
+pkgname="$(extract_pkgbuild_scalar "$pkgbuild" "pkgname")"
+_pkgname="$(extract_pkgbuild_scalar "$pkgbuild" "_pkgname")"
+pkgver="$(extract_pkgbuild_scalar "$pkgbuild" "pkgver")"
+pkgrel="$(extract_pkgbuild_scalar "$pkgbuild" "pkgrel")"
+pkgbuild_license_sha="$(extract_pkgbuild_array_first "$pkgbuild" "sha256sums")"
+pkgbuild_x86_sha="$(extract_pkgbuild_array_first "$pkgbuild" "sha256sums_x86_64")"
+pkgbuild_arm_sha="$(extract_pkgbuild_array_first "$pkgbuild" "sha256sums_aarch64")"
 
 expected_tag="${1:-v${pkgver}}"
 expected_pkgver="${expected_tag#v}"
@@ -35,81 +73,73 @@ require_equal() {
 
 require_file_contains() {
   local file="$1"
-  local pattern="$2"
+  local expected_text="$2"
   local label="$3"
-  if ! grep -Eq "$pattern" "$file"; then
+  if ! grep -Fq -- "$expected_text" "$file"; then
     fail "$label"
+  fi
+}
+
+fetch_url() {
+  local url="$1"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL \
+      --retry 3 \
+      --retry-delay 2 \
+      --connect-timeout 10 \
+      --max-time 60 \
+      "$url"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO- \
+      --tries=3 \
+      --waitretry=2 \
+      --timeout=10 \
+      "$url"
+  else
+    echo "curl or wget is required for AUR checksum validation" >&2
+    exit 1
   fi
 }
 
 fetch_sha256_file() {
   local url="$1"
-  if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$url" | awk '{ print $1; exit }'
-  elif command -v wget >/dev/null 2>&1; then
-    wget -qO- "$url" | awk '{ print $1; exit }'
-  else
-    echo "curl or wget is required for AUR checksum validation" >&2
-    exit 1
-  fi
+  fetch_url "$url" | awk '{ print $1; exit }'
 }
 
 fetch_sha256_body() {
   local url="$1"
-  if command -v curl >/dev/null 2>&1; then
-    if command -v sha256sum >/dev/null 2>&1; then
-      curl -fsSL "$url" | sha256sum | awk '{ print $1; exit }'
-    else
-      curl -fsSL "$url" | shasum -a 256 | awk '{ print $1; exit }'
-    fi
-  elif command -v wget >/dev/null 2>&1; then
-    if command -v sha256sum >/dev/null 2>&1; then
-      wget -qO- "$url" | sha256sum | awk '{ print $1; exit }'
-    else
-      wget -qO- "$url" | shasum -a 256 | awk '{ print $1; exit }'
-    fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    fetch_url "$url" | sha256sum | awk '{ print $1; exit }'
   else
-    echo "curl or wget is required for AUR checksum validation" >&2
-    exit 1
+    fetch_url "$url" | shasum -a 256 | awk '{ print $1; exit }'
   fi
-}
-
-array_has() {
-  local needle="$1"
-  shift
-  local item
-  for item in "$@"; do
-    [[ "$item" == "$needle" ]] && return 0
-  done
-  return 1
 }
 
 require_equal "$pkgname" "modfetch-bin" "pkgname"
 require_equal "$_pkgname" "modfetch" "_pkgname"
 require_equal "$pkgver" "$expected_pkgver" "pkgver"
 require_equal "${pkgrel}" "1" "pkgrel"
-array_has "x86_64" "${arch[@]}" || fail "arch must include x86_64"
-array_has "aarch64" "${arch[@]}" || fail "arch must include aarch64"
-array_has "modfetch" "${provides[@]}" || fail "provides must include modfetch"
-array_has "modfetch" "${conflicts[@]}" || fail "conflicts must include modfetch"
 
-require_equal "${source[0]}" "LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v${pkgver}/LICENSE" "license source"
-require_equal "${source_x86_64[0]}" "modfetch-${pkgver}-linux-amd64::${release_base}/modfetch_linux_amd64" "x86_64 source"
-require_equal "${source_aarch64[0]}" "modfetch-${pkgver}-linux-arm64::${release_base}/modfetch_linux_arm64" "aarch64 source"
+require_file_contains "$pkgbuild" "arch=('x86_64' 'aarch64')" "arch must include x86_64 and aarch64"
+require_file_contains "$pkgbuild" "license=('MIT')" "license must be MIT"
+require_file_contains "$pkgbuild" "provides=('modfetch')" "provides must include modfetch"
+require_file_contains "$pkgbuild" "conflicts=('modfetch')" "conflicts must include modfetch"
+require_file_contains "$pkgbuild" 'source=("LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v${pkgver}/LICENSE")' "license source mismatch"
+require_file_contains "$pkgbuild" 'source_x86_64=("${_pkgname}-${pkgver}-linux-amd64::https://github.com/jxwalker/modfetch/releases/download/v${pkgver}/${_pkgname}_linux_amd64")' "x86_64 source mismatch"
+require_file_contains "$pkgbuild" 'source_aarch64=("${_pkgname}-${pkgver}-linux-arm64::https://github.com/jxwalker/modfetch/releases/download/v${pkgver}/${_pkgname}_linux_arm64")' "aarch64 source mismatch"
+require_file_contains "$pkgbuild" 'install -Dm755 "$binary" "${pkgdir}/usr/bin/${_pkgname}"' "PKGBUILD must install modfetch into /usr/bin"
+require_file_contains "$pkgbuild" 'install -Dm644 "${srcdir}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"' "PKGBUILD must install the license"
 
-require_equal "${sha256sums[0]}" "$(fetch_sha256_body "https://raw.githubusercontent.com/jxwalker/modfetch/v${pkgver}/LICENSE")" "LICENSE checksum"
-require_equal "${sha256sums_x86_64[0]}" "$(fetch_sha256_file "${release_base}/modfetch_linux_amd64.sha256")" "x86_64 checksum"
-require_equal "${sha256sums_aarch64[0]}" "$(fetch_sha256_file "${release_base}/modfetch_linux_arm64.sha256")" "aarch64 checksum"
+require_equal "$pkgbuild_license_sha" "$(fetch_sha256_body "https://raw.githubusercontent.com/jxwalker/modfetch/v${pkgver}/LICENSE")" "LICENSE checksum"
+require_equal "$pkgbuild_x86_sha" "$(fetch_sha256_file "${release_base}/modfetch_linux_amd64.sha256")" "x86_64 checksum"
+require_equal "$pkgbuild_arm_sha" "$(fetch_sha256_file "${release_base}/modfetch_linux_arm64.sha256")" "aarch64 checksum"
 
-require_file_contains "$pkgbuild" 'install -Dm755 "\$binary" "\$\{pkgdir\}/usr/bin/\$\{_pkgname\}"' "PKGBUILD must install modfetch into /usr/bin"
-require_file_contains "$pkgbuild" 'install -Dm644 "\$\{srcdir\}/LICENSE" "\$\{pkgdir\}/usr/share/licenses/\$\{pkgname\}/LICENSE"' "PKGBUILD must install the license"
-
-require_file_contains "$srcinfo" '^pkgbase = modfetch-bin$' ".SRCINFO pkgbase mismatch"
-require_file_contains "$srcinfo" "pkgver = ${pkgver}$" ".SRCINFO pkgver mismatch"
-require_file_contains "$srcinfo" "source_x86_64 = modfetch-${pkgver}-linux-amd64::${release_base}/modfetch_linux_amd64$" ".SRCINFO x86_64 source mismatch"
-require_file_contains "$srcinfo" "sha256sums_x86_64 = ${sha256sums_x86_64[0]}$" ".SRCINFO x86_64 checksum mismatch"
-require_file_contains "$srcinfo" "source_aarch64 = modfetch-${pkgver}-linux-arm64::${release_base}/modfetch_linux_arm64$" ".SRCINFO aarch64 source mismatch"
-require_file_contains "$srcinfo" "sha256sums_aarch64 = ${sha256sums_aarch64[0]}$" ".SRCINFO aarch64 checksum mismatch"
+require_file_contains "$srcinfo" "pkgbase = modfetch-bin" ".SRCINFO pkgbase mismatch"
+require_file_contains "$srcinfo" "pkgver = ${pkgver}" ".SRCINFO pkgver mismatch"
+require_file_contains "$srcinfo" "source_x86_64 = modfetch-${pkgver}-linux-amd64::${release_base}/modfetch_linux_amd64" ".SRCINFO x86_64 source mismatch"
+require_file_contains "$srcinfo" "sha256sums_x86_64 = ${pkgbuild_x86_sha}" ".SRCINFO x86_64 checksum mismatch"
+require_file_contains "$srcinfo" "source_aarch64 = modfetch-${pkgver}-linux-arm64::${release_base}/modfetch_linux_arm64" ".SRCINFO aarch64 source mismatch"
+require_file_contains "$srcinfo" "sha256sums_aarch64 = ${pkgbuild_arm_sha}" ".SRCINFO aarch64 checksum mismatch"
 
 if command -v makepkg >/dev/null 2>&1; then
   tmp_srcinfo="$(mktemp)"

--- a/scripts/check-aur-package.sh
+++ b/scripts/check-aur-package.sh
@@ -142,9 +142,27 @@ require_file_contains "$pkgbuild" 'source_aarch64=("${_pkgname}-${pkgver}-linux-
 require_file_contains "$pkgbuild" 'install -Dm755 "$binary" "${pkgdir}/usr/bin/${_pkgname}"' "PKGBUILD must install modfetch into /usr/bin"
 require_file_contains "$pkgbuild" 'install -Dm644 "${srcdir}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"' "PKGBUILD must install the license"
 
-require_equal "$pkgbuild_license_sha" "$(fetch_sha256_body "https://raw.githubusercontent.com/jxwalker/modfetch/v${pkgver}/LICENSE")" "LICENSE checksum"
-require_equal "$pkgbuild_x86_sha" "$(fetch_sha256_file "${release_base}/modfetch_linux_amd64.sha256")" "x86_64 checksum"
-require_equal "$pkgbuild_arm_sha" "$(fetch_sha256_file "${release_base}/modfetch_linux_arm64.sha256")" "aarch64 checksum"
+fetched_license_sha=""
+fetched_x86_sha=""
+fetched_arm_sha=""
+
+if ! fetched_license_sha="$(fetch_sha256_body "https://raw.githubusercontent.com/jxwalker/modfetch/v${pkgver}/LICENSE")"; then
+  fail "failed to fetch LICENSE checksum"
+else
+  require_equal "$pkgbuild_license_sha" "$fetched_license_sha" "LICENSE checksum"
+fi
+
+if ! fetched_x86_sha="$(fetch_sha256_file "${release_base}/modfetch_linux_amd64.sha256")"; then
+  fail "failed to fetch x86_64 checksum"
+else
+  require_equal "$pkgbuild_x86_sha" "$fetched_x86_sha" "x86_64 checksum"
+fi
+
+if ! fetched_arm_sha="$(fetch_sha256_file "${release_base}/modfetch_linux_arm64.sha256")"; then
+  fail "failed to fetch aarch64 checksum"
+else
+  require_equal "$pkgbuild_arm_sha" "$fetched_arm_sha" "aarch64 checksum"
+fi
 
 require_file_contains "$srcinfo" "pkgbase = modfetch-bin" ".SRCINFO pkgbase mismatch"
 require_file_contains "$srcinfo" "pkgver = ${pkgver}" ".SRCINFO pkgver mismatch"
@@ -155,11 +173,13 @@ require_file_contains "$srcinfo" "sha256sums_aarch64 = ${pkgbuild_arm_sha}" ".SR
 
 if command -v makepkg >/dev/null 2>&1; then
   tmp_srcinfo="$(mktemp)"
+  trap 'rm -f "$tmp_srcinfo"' EXIT
   (cd "$aur_dir" && makepkg --printsrcinfo > "$tmp_srcinfo")
   if ! diff -u "$srcinfo" "$tmp_srcinfo"; then
     fail ".SRCINFO does not match makepkg --printsrcinfo"
   fi
   rm -f "$tmp_srcinfo"
+  trap - EXIT
 else
   echo "makepkg not found; completed portable AUR metadata and checksum validation"
 fi


### PR DESCRIPTION
## Summary
- add staged AUR modfetch-bin PKGBUILD/.SRCINFO metadata for v0.7.0 Linux release binaries
- add a portable AUR validation script that checks PKGBUILD, .SRCINFO, and live GitHub release checksums
- document AUR maintenance and wire the package check into CI

## Validation
- scripts/check-aur-package.sh v0.7.0
- scripts/check-docs-drift.sh
- bash -n scripts/check-aur-package.sh scripts/check-docs-drift.sh scripts/install.sh scripts/release-notes.sh
- git diff --check
- go vet ./...
- go test -count=1 ./...
- make build

Note: makepkg/namcap are not installed on this macOS machine, so local validation used the portable checksum/metadata path. AUR publication itself requires an AUR-registered SSH key; this machine currently fails AUR SSH auth with publickey denied.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->