### PR TITLE
Add file-backed library catalog sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Added
   binaries.
 - Added portable AUR package validation that checks `PKGBUILD`, `.SRCINFO`, and
   published release checksums.
+- Added `library sync push` and `library sync pull` for `file://` catalog sync
+  targets, including dry-run and JSON output support.
 
 Docs
 - Documented Arch Linux AUR package maintenance and release checklist coverage.

--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ modfetch download --batch jobs.yml --place
 # Back up or migrate your model library catalog
 modfetch library export --output modfetch-catalog.json
 modfetch library import --input modfetch-catalog.json --dry-run
+modfetch library sync push --target file:///srv/modfetch/catalog.json
+modfetch library sync pull --target file:///srv/modfetch/catalog.json --dry-run
 
 # Discover existing local models and remove missing-file metadata
 modfetch library scan --repair-stale
@@ -492,6 +494,6 @@ Roadmap
 - v0.7.x focus:
   - AUR package publication once maintainer SSH auth is available
   - Metadata enrichment from additional registries
-  - Remote catalog sync targets
+  - Additional remote catalog sync targets beyond `file://`
   - User-driven archive format expansion
   - Non-interactive TUI scripting hooks

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -73,7 +73,7 @@ _modfetch_completions()
             COMPREPLY=( $(compgen -W "--config --log-level --json" -- "$cur") ) ;;
         library)
             if [[ ${cword} -eq 2 ]]; then
-                COMPREPLY=( $(compgen -W "export import scan" -- "$cur") )
+                COMPREPLY=( $(compgen -W "export import scan sync" -- "$cur") )
                 return
             fi
             case ${words[2]} in
@@ -83,6 +83,12 @@ _modfetch_completions()
                     COMPREPLY=( $(compgen -W "--config --log-level --json --input --dry-run" -- "$cur") ) ;;
                 scan)
                     COMPREPLY=( $(compgen -W "--config --log-level --json --dir --workers --repair-stale --no-progress" -- "$cur") ) ;;
+                sync)
+                    if [[ ${cword} -eq 3 ]]; then
+                        COMPREPLY=( $(compgen -W "push pull" -- "$cur") )
+                    else
+                        COMPREPLY=( $(compgen -W "--config --log-level --json --target --dry-run" -- "$cur") )
+                    fi ;;
                 *) ;;
             esac ;;
         clean)
@@ -154,7 +160,7 @@ _modfetch() {
       ;;
     library)
       if (( CURRENT == 3 )); then
-        _arguments '*:subcommands:(export import scan)'
+        _arguments '*:subcommands:(export import scan sync)'
       else
         case $words[3] in
           export)
@@ -165,6 +171,13 @@ _modfetch() {
             ;;
           scan)
             _arguments '*:options:(--config --log-level --json --dir --workers --repair-stale --no-progress)'
+            ;;
+          sync)
+            if (( CURRENT == 4 )); then
+              _arguments '*:subcommands:(push pull)'
+            else
+              _arguments '*:options:(--config --log-level --json --target --dry-run)'
+            fi
             ;;
         esac
       fi
@@ -255,6 +268,7 @@ complete -c modfetch -n "__fish_seen_subcommand_from download" -l list-quants -d
 complete -c modfetch -n "__fish_seen_subcommand_from library" -a "export" -d "Export model catalog"
 complete -c modfetch -n "__fish_seen_subcommand_from library" -a "import" -d "Import model catalog"
 complete -c modfetch -n "__fish_seen_subcommand_from library" -a "scan" -d "Scan model directories"
+complete -c modfetch -n "__fish_seen_subcommand_from library" -a "sync" -d "Sync model catalog"
 complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from export" -l format -d "Catalog format"
 complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from export" -l output -d "Output catalog path"
 complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from import" -l input -d "Input catalog path"
@@ -263,6 +277,10 @@ complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_su
 complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from scan" -l workers -d "Scanner worker count"
 complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from scan" -l repair-stale -d "Remove metadata for missing files"
 complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from scan" -l no-progress -d "Disable progress output"
+complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from sync" -a "push" -d "Push catalog to target"
+complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from sync" -a "pull" -d "Pull catalog from target"
+complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from sync" -l target -d "Catalog sync target"
+complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from sync" -l dry-run -d "Report without writing"
 complete -c modfetch -n "__fish_seen_subcommand_from dedupe" -l mode -d "hardlink|symlink"
 complete -c modfetch -n "__fish_seen_subcommand_from dedupe" -l dry-run -d "Show dedupe changes without modifying files"
 # batch import flags

--- a/cmd/modfetch/completion_test.go
+++ b/cmd/modfetch/completion_test.go
@@ -25,6 +25,7 @@ func TestCompletionCurrentFlags(t *testing.T) {
 		"hostcaps": {"--config", "--list", "--clear", "--clear-all", "--json"},
 		"tui":      {"--json"},
 		"clean":    {"--days", "--dry-run", "--dest", "--include-next-to-dest", "--sidecars"},
+		"library":  {"--target"},
 	}
 
 	for name, script := range completionScripts() {
@@ -60,12 +61,15 @@ func TestCompletionNestedSubcommandFlags(t *testing.T) {
 		case "bash":
 			assertContains(t, name, "config", configSection, "case ${words[2]}", "validate)", "wizard)", "--strict", "--out")
 			assertContains(t, name, "batch", batchSection, "case ${words[2]}", "import)", "--naming-pattern")
+			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "--target")
 		case "zsh":
 			assertContains(t, name, "config", configSection, "case $words[3]", "validate)", "wizard)", "--strict", "--out")
 			assertContains(t, name, "batch", batchSection, "case $words[3]", "import)", "--naming-pattern")
+			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "--target")
 		case "fish":
 			assertContains(t, name, "config", configSection, "and __fish_seen_subcommand_from validate", "and __fish_seen_subcommand_from wizard", "-l strict", "-l out")
 			assertContains(t, name, "batch", batchSection, "and __fish_seen_subcommand_from import", "-l naming-pattern")
+			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "-l target")
 		}
 	}
 }

--- a/cmd/modfetch/completion_test.go
+++ b/cmd/modfetch/completion_test.go
@@ -61,15 +61,15 @@ func TestCompletionNestedSubcommandFlags(t *testing.T) {
 		case "bash":
 			assertContains(t, name, "config", configSection, "case ${words[2]}", "validate)", "wizard)", "--strict", "--out")
 			assertContains(t, name, "batch", batchSection, "case ${words[2]}", "import)", "--naming-pattern")
-			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "--target")
+			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "--target", "--dry-run")
 		case "zsh":
 			assertContains(t, name, "config", configSection, "case $words[3]", "validate)", "wizard)", "--strict", "--out")
 			assertContains(t, name, "batch", batchSection, "case $words[3]", "import)", "--naming-pattern")
-			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "--target")
+			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "--target", "--dry-run")
 		case "fish":
 			assertContains(t, name, "config", configSection, "and __fish_seen_subcommand_from validate", "and __fish_seen_subcommand_from wizard", "-l strict", "-l out")
 			assertContains(t, name, "batch", batchSection, "and __fish_seen_subcommand_from import", "-l naming-pattern")
-			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "-l target")
+			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "-l target", "-l dry-run")
 		}
 	}
 }

--- a/cmd/modfetch/library_cmd.go
+++ b/cmd/modfetch/library_cmd.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/jxwalker/modfetch/internal/catalog"
@@ -369,12 +370,12 @@ func fileSyncTargetPath(target string) (string, error) {
 	if target == "" {
 		return "", errors.New("library sync requires --target")
 	}
+	if !strings.Contains(target, "://") && !strings.HasPrefix(strings.ToLower(target), "file:") {
+		return filepath.Clean(target), nil
+	}
 	u, err := url.Parse(target)
 	if err != nil {
 		return "", fmt.Errorf("parse sync target: %w", err)
-	}
-	if u.Scheme == "" {
-		return filepath.Clean(target), nil
 	}
 	if u.Scheme != "file" {
 		return "", fmt.Errorf("unsupported sync target scheme %q; only file:// is supported", u.Scheme)
@@ -385,10 +386,18 @@ func fileSyncTargetPath(target string) (string, error) {
 	if u.Host != "" && u.Host != "localhost" {
 		return "", fmt.Errorf("unsupported file sync target host %q", u.Host)
 	}
-	if u.Path == "" {
+	targetPath := u.EscapedPath()
+	if targetPath == "" && u.Opaque != "" {
+		targetPath = u.Opaque
+	}
+	if targetPath == "" {
 		return "", errors.New("file sync target path is empty")
 	}
-	return filepath.Clean(filepath.FromSlash(u.Path)), nil
+	decodedPath, err := url.PathUnescape(targetPath)
+	if err != nil {
+		return "", fmt.Errorf("decode file sync target path: %w", err)
+	}
+	return filepath.Clean(filepath.FromSlash(decodedPath)), nil
 }
 
 func writeCatalogFile(path string, cat *catalog.Catalog) error {
@@ -406,6 +415,10 @@ func writeCatalogFile(path string, cat *catalog.Catalog) error {
 	tmpPath := tmp.Name()
 	defer func() { _ = os.Remove(tmpPath) }()
 
+	if err := tmp.Chmod(catalogTargetMode(path)); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("set catalog permissions: %w", err)
+	}
 	enc := json.NewEncoder(tmp)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(cat); err != nil {
@@ -415,8 +428,33 @@ func writeCatalogFile(path string, cat *catalog.Catalog) error {
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("close catalog: %w", err)
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := replaceCatalogFile(tmpPath, path); err != nil {
+		return err
+	}
+	return nil
+}
+
+func catalogTargetMode(path string) os.FileMode {
+	info, err := os.Stat(path)
+	if err == nil {
+		return info.Mode().Perm()
+	}
+	return 0o644
+}
+
+func replaceCatalogFile(tmpPath, path string) error {
+	if err := os.Rename(tmpPath, path); err == nil {
+		return nil
+	} else if runtime.GOOS != "windows" {
 		return fmt.Errorf("replace catalog target: %w", err)
+	} else if _, statErr := os.Stat(path); statErr != nil {
+		return fmt.Errorf("replace catalog target: %w", err)
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("remove existing catalog target: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replace catalog target after removing existing file: %w", err)
 	}
 	return nil
 }

--- a/cmd/modfetch/library_cmd.go
+++ b/cmd/modfetch/library_cmd.go
@@ -7,7 +7,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/jxwalker/modfetch/internal/catalog"
@@ -18,7 +20,7 @@ import (
 
 func handleLibrary(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		return errors.New("library subcommand required: export, import, or scan")
+		return errors.New("library subcommand required: export, import, scan, or sync")
 	}
 	switch args[0] {
 	case "export":
@@ -27,6 +29,8 @@ func handleLibrary(ctx context.Context, args []string) error {
 		return handleLibraryImport(ctx, args[1:])
 	case "scan":
 		return handleLibraryScan(ctx, args[1:])
+	case "sync":
+		return handleLibrarySync(ctx, args[1:])
 	default:
 		return fmt.Errorf("unknown library subcommand: %s", args[0])
 	}
@@ -89,7 +93,116 @@ func handleLibraryImport(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	return printCatalogImportResult(result, *common.jsonOut)
+}
+
+func handleLibrarySync(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return errors.New("library sync subcommand required: push or pull")
+	}
+	switch args[0] {
+	case "push":
+		return handleLibrarySyncPush(ctx, args[1:])
+	case "pull":
+		return handleLibrarySyncPull(ctx, args[1:])
+	default:
+		return fmt.Errorf("unknown library sync subcommand: %s", args[0])
+	}
+}
+
+func handleLibrarySyncPush(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("library sync push", flag.ContinueOnError)
+	common := addCommonConfigLogFlags(fs, "print sync push result as JSON")
+	target := fs.String("target", "", "sync target URI or path; file:// targets are supported")
+	dryRun := fs.Bool("dry-run", false, "report without writing the target catalog")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	targetPath, err := fileSyncTargetPath(*target)
+	if err != nil {
+		return err
+	}
+	db, err := openLibraryDB(*common.configPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	cat, err := catalog.Build(db)
+	if err != nil {
+		return err
+	}
+	if !*dryRun {
+		if err := writeCatalogFile(targetPath, cat); err != nil {
+			return err
+		}
+	}
+	result := librarySyncPushResult{
+		Action: "push",
+		Target: *target,
+		Path:   targetPath,
+		Models: len(cat.Models),
+		DryRun: *dryRun,
+	}
 	if *common.jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+	if *dryRun {
+		fmt.Printf("Sync push dry-run: target=%s models=%d\n", targetPath, len(cat.Models))
+	} else {
+		fmt.Printf("Sync push complete: target=%s models=%d\n", targetPath, len(cat.Models))
+	}
+	return nil
+}
+
+func handleLibrarySyncPull(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("library sync pull", flag.ContinueOnError)
+	common := addCommonConfigLogFlags(fs, "print sync pull result as JSON")
+	target := fs.String("target", "", "sync target URI or path; file:// targets are supported")
+	dryRun := fs.Bool("dry-run", false, "report changes without writing to the library")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	targetPath, err := fileSyncTargetPath(*target)
+	if err != nil {
+		return err
+	}
+	db, err := openLibraryDB(*common.configPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	f, err := os.Open(targetPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	result, err := catalog.Import(db, f, catalog.ImportOptions{DryRun: *dryRun})
+	if err != nil {
+		return err
+	}
+	return printCatalogImportResult(result, *common.jsonOut)
+}
+
+type librarySyncPushResult struct {
+	Action string `json:"action"`
+	Target string `json:"target"`
+	Path   string `json:"path"`
+	Models int    `json:"models"`
+	DryRun bool   `json:"dry_run"`
+}
+
+func printCatalogImportResult(result *catalog.ImportResult, jsonOut bool) error {
+	if jsonOut {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(result); err != nil {
@@ -249,6 +362,63 @@ func outputWriter(path string) (io.Writer, func(), error) {
 		return nil, func() {}, err
 	}
 	return f, func() { _ = f.Close() }, nil
+}
+
+func fileSyncTargetPath(target string) (string, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", errors.New("library sync requires --target")
+	}
+	u, err := url.Parse(target)
+	if err != nil {
+		return "", fmt.Errorf("parse sync target: %w", err)
+	}
+	if u.Scheme == "" {
+		return filepath.Clean(target), nil
+	}
+	if u.Scheme != "file" {
+		return "", fmt.Errorf("unsupported sync target scheme %q; only file:// is supported", u.Scheme)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return "", errors.New("file sync target must not include query or fragment")
+	}
+	if u.Host != "" && u.Host != "localhost" {
+		return "", fmt.Errorf("unsupported file sync target host %q", u.Host)
+	}
+	if u.Path == "" {
+		return "", errors.New("file sync target path is empty")
+	}
+	return filepath.Clean(filepath.FromSlash(u.Path)), nil
+}
+
+func writeCatalogFile(path string, cat *catalog.Catalog) error {
+	if path == "" {
+		return errors.New("catalog target path is empty")
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create catalog target directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".modfetch-catalog-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp catalog: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	enc := json.NewEncoder(tmp)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(cat); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write catalog: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close catalog: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replace catalog target: %w", err)
+	}
+	return nil
 }
 
 func inputReader(path string) (io.Reader, func(), error) {

--- a/cmd/modfetch/library_cmd_test.go
+++ b/cmd/modfetch/library_cmd_test.go
@@ -140,10 +140,13 @@ func TestHandleLibrarySyncPushPullFileTarget(t *testing.T) {
 		t.Fatalf("close source db: %v", err)
 	}
 
-	targetPath := filepath.Join(dir, "remote", "catalog.json")
+	targetPath := filepath.Join(dir, "remote", "catalog with space.json")
 	targetURI := fileURI(targetPath)
 	if err := handleLibrary(context.Background(), []string{"sync", "push", "--config", sourceCfg, "--target", targetURI}); err != nil {
 		t.Fatalf("library sync push: %v", err)
+	}
+	if err := handleLibrary(context.Background(), []string{"sync", "push", "--config", sourceCfg, "--target", targetURI}); err != nil {
+		t.Fatalf("library sync push replacing existing target: %v", err)
 	}
 	if _, err := os.Stat(targetPath); err != nil {
 		t.Fatalf("expected sync target catalog: %v", err)
@@ -207,6 +210,17 @@ func TestHandleLibrarySyncRejectsUnsupportedTarget(t *testing.T) {
 	err := handleLibrary(context.Background(), []string{"sync", "push", "--config", cfgPath, "--target", "https://example.com/catalog.json"})
 	if err == nil || !strings.Contains(err.Error(), "unsupported sync target scheme") {
 		t.Fatalf("expected unsupported target scheme error, got %v", err)
+	}
+}
+
+func TestFileSyncTargetPathTreatsDriveLetterAsPlainPath(t *testing.T) {
+	target := `C:\backup\catalog.json`
+	got, err := fileSyncTargetPath(target)
+	if err != nil {
+		t.Fatalf("fileSyncTargetPath: %v", err)
+	}
+	if want := filepath.Clean(target); got != want {
+		t.Fatalf("fileSyncTargetPath() = %q, want %q", got, want)
 	}
 }
 

--- a/cmd/modfetch/library_cmd_test.go
+++ b/cmd/modfetch/library_cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -116,6 +117,99 @@ func TestHandleLibraryImportJSONReturnsErrorOnConflicts(t *testing.T) {
 	}
 }
 
+func TestHandleLibrarySyncPushPullFileTarget(t *testing.T) {
+	dir := t.TempDir()
+	sourceCfg := writeLibraryConfig(t, filepath.Join(dir, "source"))
+	source, err := state.Open(&config.Config{General: config.General{
+		DataRoot:     filepath.Join(dir, "source", "data"),
+		DownloadRoot: filepath.Join(dir, "source", "downloads"),
+	}})
+	if err != nil {
+		t.Fatalf("open source db: %v", err)
+	}
+	if err := source.UpsertMetadata(&state.ModelMetadata{
+		DownloadURL: "https://example.com/synced.gguf",
+		Dest:        filepath.Join(dir, "source", "downloads", "synced.gguf"),
+		ModelName:   "Synced Model",
+		Source:      "direct",
+		Favorite:    true,
+	}); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	if err := source.Close(); err != nil {
+		t.Fatalf("close source db: %v", err)
+	}
+
+	targetPath := filepath.Join(dir, "remote", "catalog.json")
+	targetURI := fileURI(targetPath)
+	if err := handleLibrary(context.Background(), []string{"sync", "push", "--config", sourceCfg, "--target", targetURI}); err != nil {
+		t.Fatalf("library sync push: %v", err)
+	}
+	if _, err := os.Stat(targetPath); err != nil {
+		t.Fatalf("expected sync target catalog: %v", err)
+	}
+
+	targetCfg := writeLibraryConfig(t, filepath.Join(dir, "target"))
+	if err := handleLibrary(context.Background(), []string{"sync", "pull", "--config", targetCfg, "--target", targetURI, "--dry-run"}); err != nil {
+		t.Fatalf("library sync pull dry-run: %v", err)
+	}
+	targetDB, err := state.Open(&config.Config{General: config.General{
+		DataRoot:     filepath.Join(dir, "target", "data"),
+		DownloadRoot: filepath.Join(dir, "target", "downloads"),
+	}})
+	if err != nil {
+		t.Fatalf("open target db after dry-run: %v", err)
+	}
+	if meta, err := targetDB.GetMetadata("https://example.com/synced.gguf"); !errors.Is(err, sql.ErrNoRows) || meta != nil {
+		t.Fatalf("dry-run should not write metadata, meta=%+v err=%v", meta, err)
+	}
+	if err := targetDB.Close(); err != nil {
+		t.Fatalf("close target db after dry-run: %v", err)
+	}
+
+	if err := handleLibrary(context.Background(), []string{"sync", "pull", "--config", targetCfg, "--target", targetURI}); err != nil {
+		t.Fatalf("library sync pull: %v", err)
+	}
+	targetDB, err = state.Open(&config.Config{General: config.General{
+		DataRoot:     filepath.Join(dir, "target", "data"),
+		DownloadRoot: filepath.Join(dir, "target", "downloads"),
+	}})
+	if err != nil {
+		t.Fatalf("open target db: %v", err)
+	}
+	defer func() { _ = targetDB.Close() }()
+	meta, err := targetDB.GetMetadata("https://example.com/synced.gguf")
+	if err != nil {
+		t.Fatalf("get synced metadata: %v", err)
+	}
+	if meta.ModelName != "Synced Model" || !meta.Favorite {
+		t.Fatalf("unexpected synced metadata: %+v", meta)
+	}
+}
+
+func TestHandleLibrarySyncPushDryRunDoesNotWriteTarget(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeLibraryConfig(t, filepath.Join(dir, "cfg"))
+	targetPath := filepath.Join(dir, "remote", "catalog.json")
+
+	if err := handleLibrary(context.Background(), []string{"sync", "push", "--config", cfgPath, "--target", fileURI(targetPath), "--dry-run"}); err != nil {
+		t.Fatalf("library sync push dry-run: %v", err)
+	}
+	if _, err := os.Stat(targetPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("dry-run should not write target, err=%v", err)
+	}
+}
+
+func TestHandleLibrarySyncRejectsUnsupportedTarget(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeLibraryConfig(t, filepath.Join(dir, "cfg"))
+
+	err := handleLibrary(context.Background(), []string{"sync", "push", "--config", cfgPath, "--target", "https://example.com/catalog.json"})
+	if err == nil || !strings.Contains(err.Error(), "unsupported sync target scheme") {
+		t.Fatalf("expected unsupported target scheme error, got %v", err)
+	}
+}
+
 func TestHandleLibraryScanConfiguredDirectory(t *testing.T) {
 	dir := t.TempDir()
 	cfgRoot := filepath.Join(dir, "cfg")
@@ -210,4 +304,8 @@ func writeLibraryConfig(t *testing.T, root string) string {
 		t.Fatal(err)
 	}
 	return cfgPath
+}
+
+func fileURI(path string) string {
+	return (&url.URL{Scheme: "file", Path: path}).String()
 }

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -108,6 +108,7 @@ Commands:
   library export    Export model library catalog as JSON
   library import    Import model library catalog JSON
   library scan      Scan configured model directories into the library
+  library sync      Push or pull a catalog through a sync target
   batch import      Import URLs from a text file and produce a YAML batch
   version           Print version
   help              Show this help

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -35,6 +35,7 @@ modfetch verify --all              # Verify all downloads
 modfetch place --path FILE         # Place model into app
 modfetch clean --days 7            # Clean old partials
 modfetch library export --output catalog.json
+modfetch library sync push --target file:///srv/modfetch/catalog.json
 modfetch library scan --repair-stale
 modfetch config validate           # Validate config
 modfetch tui                       # Launch visual TUI
@@ -172,6 +173,12 @@ modfetch library import --input modfetch-catalog.json --dry-run
 
 # Import catalog entries and print a machine-readable summary
 modfetch library import --input modfetch-catalog.json --json
+
+# Push the current catalog to a filesystem sync target
+modfetch library sync push --target file:///srv/modfetch/catalog.json
+
+# Preview pulling updates from a filesystem sync target
+modfetch library sync pull --target file:///srv/modfetch/catalog.json --dry-run
 ```
 
 `library scan` recognizes `.gguf`, `.ggml`, `.safetensors`, `.ckpt`, `.pt`,
@@ -196,6 +203,18 @@ Import is idempotent:
 - new entries are reported as `create`
 - changed entries with the same source URL are reported as `update`
 - destination collisions with a different source URL are reported as `conflict`
+
+Sync targets build on the same catalog schema and import conflict behavior.
+`library sync push` writes the current catalog to a target, and
+`library sync pull` imports from that target. The first supported target is
+`file://`, which is useful for shared folders, mounted drives, and locally
+validated sync workflows. Plain filesystem paths are also accepted.
+
+Sync options:
+- `--target URI` - sync target URI or path; `file://` targets are supported
+- `--dry-run` - for `push`, report without writing the target; for `pull`, report
+  import changes without writing to the local library
+- `--json` - print the push or pull result as JSON
 
 ### dedupe
 

--- a/docs/COMPLETIONS.md
+++ b/docs/COMPLETIONS.md
@@ -32,4 +32,5 @@ Notable flags and commands covered
 
 Notes
 - The provided completions are lightweight and cover subcommands and common flags. They do not shell out to the binary for dynamic completions.
-- Regenerate completions after new releases to pick up added flags/commands.
+- Regenerate completions after new releases to pick up added flags/commands,
+  including nested library commands such as `library sync push/pull`.

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -377,6 +377,8 @@ copying the SQLite state database directly.
 modfetch library export --format json --output modfetch-catalog.json
 modfetch library import --input modfetch-catalog.json --dry-run
 modfetch library import --input modfetch-catalog.json
+modfetch library sync push --target file:///srv/modfetch/catalog.json
+modfetch library sync pull --target file:///srv/modfetch/catalog.json --dry-run
 ```
 
 The JSON catalog includes:
@@ -388,6 +390,12 @@ The JSON catalog includes:
 Import dry-run reports the planned `create`, `update`, `skip`, and `conflict`
 counts without writing. Re-importing the same catalog is idempotent and reports
 unchanged entries as skips.
+
+For repeatable backups or shared-machine handoff, use `library sync`. The first
+sync target is `file://`, so it works with shared folders, mounted storage, and
+local filesystem paths while preserving the same conflict checks as import.
+`sync push --dry-run` reports the target and model count without writing, and
+`sync pull --dry-run` reports import actions without changing the local database.
 
 ## Metadata Sources
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -452,6 +452,11 @@ modfetch download --url 'hf://gpt2/README.md?rev=main' --dry-run
 
 # JSON output for scripting
 modfetch download --url 'https://...' --summary-json
+
+# Back up and sync the library catalog
+modfetch library export --output modfetch-catalog.json
+modfetch library sync push --target file:///srv/modfetch/catalog.json
+modfetch library sync pull --target file:///srv/modfetch/catalog.json --dry-run
 ```
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -142,8 +142,11 @@ These are useful, but not required for the first v0.7.0 release:
   package metadata and validation are staged in `packaging/aur/`; AUR
   publication is pending a maintainer AUR account with an AUR-registered SSH
   public key.
+- [DONE] Remote catalog sync foundation:
+  `library sync push/pull --target file://...` reuses the portable catalog
+  schema for shared folders, mounted drives, and local filesystem sync tests.
 - Metadata enrichment from additional model registries.
-- Remote catalog sync targets.
+- Additional remote catalog sync targets beyond `file://`.
 - More archive formats if users report concrete needs.
 - Non-interactive TUI scripting hooks.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -128,6 +128,27 @@ Use --dry-run to preview without writing.
 
 See docs/PLACEMENT.md and docs/RESOLVERS.md for details and examples.
 
+### Library backup and sync
+
+Export a portable catalog from your local library:
+
+modfetch library export --config ~/.config/modfetch/config.yml \
+  --output modfetch-catalog.json
+
+Preview an import before writing to your local library:
+
+modfetch library import --config ~/.config/modfetch/config.yml \
+  --input modfetch-catalog.json --dry-run
+
+Push or pull the same catalog through a sync target:
+
+modfetch library sync push --config ~/.config/modfetch/config.yml \
+  --target file:///srv/modfetch/catalog.json
+modfetch library sync pull --config ~/.config/modfetch/config.yml \
+  --target file:///srv/modfetch/catalog.json --dry-run
+
+The first supported sync target is `file://`. Plain filesystem paths are accepted too, which is useful for mounted shares or a local backup directory.
+
 ### TUI dashboard
 
 modfetch tui --config ~/.config/modfetch/config.yml


### PR DESCRIPTION
## Summary
- add `modfetch library sync push/pull` with `file://` and plain-path catalog targets
- reuse catalog import/export behavior for pull conflict handling, JSON output, and dry-run safety
- update completions, CLI/user/library/quickstart docs, changelog, and roadmap

## Validation
- `scripts/check-docs-drift.sh`
- `scripts/check-aur-package.sh`
- `env GOCACHE="/Users/james/Documents/dev/modfetch/.cache/go-build" GOMODCACHE="/Users/james/Documents/dev/modfetch/.cache/go-mod" go test -count=1 ./...`
- `env GOCACHE="/Users/james/Documents/dev/modfetch/.cache/go-build" GOMODCACHE="/Users/james/Documents/dev/modfetch/.cache/go-mod" go vet ./...`
- `make build`
- real CLI smoke with temp config, temp SQLite state, temp model file, `library scan`, `sync push`, `sync pull --dry-run`, and dry-run push no-write check
- `git diff --check`
- `rg -n "TODO|FIXME" README.md TESTING.md WARP.md docs cmd internal packaging scripts` (no matches)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->