### PR TITLE
Add HTTP catalog sync pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Added
   published release checksums.
 - Added `library sync push` and `library sync pull` for `file://` catalog sync
   targets, including dry-run and JSON output support.
+- Added HTTP(S) catalog pull targets for `library sync pull`, allowing a
+  published catalog URL to be imported with the same dry-run/conflict handling.
 
 Docs
 - Documented Arch Linux AUR package maintenance and release checklist coverage.

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ modfetch library export --output modfetch-catalog.json
 modfetch library import --input modfetch-catalog.json --dry-run
 modfetch library sync push --target file:///srv/modfetch/catalog.json
 modfetch library sync pull --target file:///srv/modfetch/catalog.json --dry-run
+modfetch library sync pull --target https://example.com/modfetch-catalog.json --dry-run
 
 # Discover existing local models and remove missing-file metadata
 modfetch library scan --repair-stale
@@ -494,6 +495,6 @@ Roadmap
 - v0.7.x focus:
   - AUR package publication once maintainer SSH auth is available
   - Metadata enrichment from additional registries
-  - Additional remote catalog sync targets beyond `file://`
+  - Authenticated and writable remote catalog sync targets
   - User-driven archive format expansion
   - Non-interactive TUI scripting hooks

--- a/cmd/modfetch/library_cmd.go
+++ b/cmd/modfetch/library_cmd.go
@@ -7,11 +7,13 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/jxwalker/modfetch/internal/catalog"
 	"github.com/jxwalker/modfetch/internal/config"
@@ -114,7 +116,7 @@ func handleLibrarySync(ctx context.Context, args []string) error {
 func handleLibrarySyncPush(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("library sync push", flag.ContinueOnError)
 	common := addCommonConfigLogFlags(fs, "print sync push result as JSON")
-	target := fs.String("target", "", "sync target URI or path; file:// targets are supported")
+	target := fs.String("target", "", "sync target URI or path; file:// targets and plain paths are supported")
 	dryRun := fs.Bool("dry-run", false, "report without writing the target catalog")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -164,7 +166,7 @@ func handleLibrarySyncPush(ctx context.Context, args []string) error {
 func handleLibrarySyncPull(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("library sync pull", flag.ContinueOnError)
 	common := addCommonConfigLogFlags(fs, "print sync pull result as JSON")
-	target := fs.String("target", "", "sync target URI or path; file:// targets are supported")
+	target := fs.String("target", "", "sync target URI or path; file://, http://, https://, and plain paths are supported")
 	dryRun := fs.Bool("dry-run", false, "report changes without writing to the library")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -172,22 +174,18 @@ func handleLibrarySyncPull(ctx context.Context, args []string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	targetPath, err := fileSyncTargetPath(*target)
+	r, closeFn, err := syncTargetReader(ctx, *target)
 	if err != nil {
 		return err
 	}
+	defer closeFn()
 	db, err := openLibraryDB(*common.configPath)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = db.Close() }()
 
-	f, err := os.Open(targetPath)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
-	result, err := catalog.Import(db, f, catalog.ImportOptions{DryRun: *dryRun})
+	result, err := catalog.Import(db, r, catalog.ImportOptions{DryRun: *dryRun})
 	if err != nil {
 		return err
 	}
@@ -365,12 +363,55 @@ func outputWriter(path string) (io.Writer, func(), error) {
 	return f, func() { _ = f.Close() }, nil
 }
 
+func syncTargetReader(ctx context.Context, target string) (io.Reader, func(), error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return nil, func() {}, errors.New("library sync requires --target")
+	}
+	if !isURITarget(target) || strings.HasPrefix(strings.ToLower(target), "file:") {
+		path, err := fileSyncTargetPath(target)
+		if err != nil {
+			return nil, func() {}, err
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, func() {}, err
+		}
+		return f, func() { _ = f.Close() }, nil
+	}
+	u, err := url.Parse(target)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("parse sync target: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, func() {}, fmt.Errorf("unsupported sync target scheme %q; pull supports file://, http://, and https://", u.Scheme)
+	}
+	if u.Fragment != "" {
+		return nil, func() {}, errors.New("HTTP sync target must not include a fragment")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("create sync request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("fetch sync target: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		_ = resp.Body.Close()
+		return nil, func() {}, fmt.Errorf("fetch sync target: HTTP %s", resp.Status)
+	}
+	return resp.Body, func() { _ = resp.Body.Close() }, nil
+}
+
 func fileSyncTargetPath(target string) (string, error) {
 	target = strings.TrimSpace(target)
 	if target == "" {
 		return "", errors.New("library sync requires --target")
 	}
-	if !strings.Contains(target, "://") && !strings.HasPrefix(strings.ToLower(target), "file:") {
+	if !isURITarget(target) && !strings.HasPrefix(strings.ToLower(target), "file:") {
 		return filepath.Clean(target), nil
 	}
 	u, err := url.Parse(target)
@@ -398,6 +439,10 @@ func fileSyncTargetPath(target string) (string, error) {
 		return "", fmt.Errorf("decode file sync target path: %w", err)
 	}
 	return filepath.Clean(filepath.FromSlash(decodedPath)), nil
+}
+
+func isURITarget(target string) bool {
+	return strings.Contains(target, "://")
 }
 
 func writeCatalogFile(path string, cat *catalog.Catalog) error {

--- a/cmd/modfetch/library_cmd_test.go
+++ b/cmd/modfetch/library_cmd_test.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -210,6 +212,86 @@ func TestHandleLibrarySyncRejectsUnsupportedTarget(t *testing.T) {
 	err := handleLibrary(context.Background(), []string{"sync", "push", "--config", cfgPath, "--target", "https://example.com/catalog.json"})
 	if err == nil || !strings.Contains(err.Error(), "unsupported sync target scheme") {
 		t.Fatalf("expected unsupported target scheme error, got %v", err)
+	}
+}
+
+func TestHandleLibrarySyncPullHTTPTarget(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeLibraryConfig(t, filepath.Join(dir, "cfg"))
+	payload, err := json.Marshal(map[string]any{
+		"app":             "modfetch",
+		"catalog_version": 1,
+		"models": []map[string]any{{
+			"metadata": map[string]any{
+				"download_url": "https://example.com/http-synced.gguf",
+				"dest":         filepath.Join(dir, "downloads", "http-synced.gguf"),
+				"model_name":   "HTTP Synced Model",
+				"source":       "direct",
+				"favorite":     true,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method %s", r.Method)
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Errorf("unexpected accept header %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	if err := handleLibrary(context.Background(), []string{"sync", "pull", "--config", cfgPath, "--target", server.URL, "--dry-run"}); err != nil {
+		t.Fatalf("library sync pull HTTP dry-run: %v", err)
+	}
+	db, err := state.Open(&config.Config{General: config.General{
+		DataRoot:     filepath.Join(dir, "cfg", "data"),
+		DownloadRoot: filepath.Join(dir, "cfg", "downloads"),
+	}})
+	if err != nil {
+		t.Fatalf("open db after dry-run: %v", err)
+	}
+	if meta, err := db.GetMetadata("https://example.com/http-synced.gguf"); !errors.Is(err, sql.ErrNoRows) || meta != nil {
+		t.Fatalf("dry-run should not write HTTP metadata, meta=%+v err=%v", meta, err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db after dry-run: %v", err)
+	}
+
+	if err := handleLibrary(context.Background(), []string{"sync", "pull", "--config", cfgPath, "--target", server.URL}); err != nil {
+		t.Fatalf("library sync pull HTTP: %v", err)
+	}
+	db, err = state.Open(&config.Config{General: config.General{
+		DataRoot:     filepath.Join(dir, "cfg", "data"),
+		DownloadRoot: filepath.Join(dir, "cfg", "downloads"),
+	}})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	meta, err := db.GetMetadata("https://example.com/http-synced.gguf")
+	if err != nil {
+		t.Fatalf("get HTTP synced metadata: %v", err)
+	}
+	if meta.ModelName != "HTTP Synced Model" || !meta.Favorite {
+		t.Fatalf("unexpected HTTP metadata: %+v", meta)
+	}
+}
+
+func TestHandleLibrarySyncPullHTTPStatusError(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeLibraryConfig(t, filepath.Join(dir, "cfg"))
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	err := handleLibrary(context.Background(), []string{"sync", "pull", "--config", cfgPath, "--target", server.URL})
+	if err == nil || !strings.Contains(err.Error(), "HTTP 404") {
+		t.Fatalf("expected HTTP 404 sync error, got %v", err)
 	}
 }
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -179,6 +179,9 @@ modfetch library sync push --target file:///srv/modfetch/catalog.json
 
 # Preview pulling updates from a filesystem sync target
 modfetch library sync pull --target file:///srv/modfetch/catalog.json --dry-run
+
+# Preview pulling updates from a published HTTP(S) catalog
+modfetch library sync pull --target https://example.com/modfetch-catalog.json --dry-run
 ```
 
 `library scan` recognizes `.gguf`, `.ggml`, `.safetensors`, `.ckpt`, `.pt`,
@@ -205,13 +208,14 @@ Import is idempotent:
 - destination collisions with a different source URL are reported as `conflict`
 
 Sync targets build on the same catalog schema and import conflict behavior.
-`library sync push` writes the current catalog to a target, and
-`library sync pull` imports from that target. The first supported target is
-`file://`, which is useful for shared folders, mounted drives, and locally
-validated sync workflows. Plain filesystem paths are also accepted.
+`library sync push` writes the current catalog to a local target, and
+`library sync pull` imports from a local or remote target. Push supports
+`file://` and plain filesystem paths, which are useful for shared folders,
+mounted drives, and locally validated sync workflows. Pull supports those local
+targets plus read-only `http://` and `https://` catalog URLs.
 
 Sync options:
-- `--target URI` - sync target URI or path; `file://` targets are supported
+- `--target URI` - sync target URI or path
 - `--dry-run` - for `push`, report without writing the target; for `pull`, report
   import changes without writing to the local library
 - `--json` - print the push or pull result as JSON

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -379,6 +379,7 @@ modfetch library import --input modfetch-catalog.json --dry-run
 modfetch library import --input modfetch-catalog.json
 modfetch library sync push --target file:///srv/modfetch/catalog.json
 modfetch library sync pull --target file:///srv/modfetch/catalog.json --dry-run
+modfetch library sync pull --target https://example.com/modfetch-catalog.json --dry-run
 ```
 
 The JSON catalog includes:
@@ -391,11 +392,13 @@ Import dry-run reports the planned `create`, `update`, `skip`, and `conflict`
 counts without writing. Re-importing the same catalog is idempotent and reports
 unchanged entries as skips.
 
-For repeatable backups or shared-machine handoff, use `library sync`. The first
-sync target is `file://`, so it works with shared folders, mounted storage, and
-local filesystem paths while preserving the same conflict checks as import.
-`sync push --dry-run` reports the target and model count without writing, and
-`sync pull --dry-run` reports import actions without changing the local database.
+For repeatable backups or shared-machine handoff, use `library sync`. Push
+supports `file://` and plain local paths, so it works with shared folders,
+mounted storage, and local filesystem paths. Pull supports those same local
+targets plus read-only HTTP(S) catalog URLs. All pull targets preserve the same
+conflict checks as import. `sync push --dry-run` reports the target and model
+count without writing, and `sync pull --dry-run` reports import actions without
+changing the local database.
 
 ## Metadata Sources
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -457,6 +457,7 @@ modfetch download --url 'https://...' --summary-json
 modfetch library export --output modfetch-catalog.json
 modfetch library sync push --target file:///srv/modfetch/catalog.json
 modfetch library sync pull --target file:///srv/modfetch/catalog.json --dry-run
+modfetch library sync pull --target https://example.com/modfetch-catalog.json --dry-run
 ```
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -145,8 +145,11 @@ These are useful, but not required for the first v0.7.0 release:
 - [DONE] Remote catalog sync foundation:
   `library sync push/pull --target file://...` reuses the portable catalog
   schema for shared folders, mounted drives, and local filesystem sync tests.
+- [DONE] Read-only remote catalog pull:
+  `library sync pull --target https://...` imports published catalogs with the
+  same dry-run and conflict handling as local catalog imports.
 - Metadata enrichment from additional model registries.
-- Additional remote catalog sync targets beyond `file://`.
+- Authenticated and writable remote catalog sync targets.
 - More archive formats if users report concrete needs.
 - Non-interactive TUI scripting hooks.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -146,8 +146,10 @@ modfetch library sync push --config ~/.config/modfetch/config.yml \
   --target file:///srv/modfetch/catalog.json
 modfetch library sync pull --config ~/.config/modfetch/config.yml \
   --target file:///srv/modfetch/catalog.json --dry-run
+modfetch library sync pull --config ~/.config/modfetch/config.yml \
+  --target https://example.com/modfetch-catalog.json --dry-run
 
-The first supported sync target is `file://`. Plain filesystem paths are accepted too, which is useful for mounted shares or a local backup directory.
+Push supports `file://` and plain filesystem paths, which is useful for mounted shares or a local backup directory. Pull supports those local targets plus read-only HTTP(S) catalog URLs.
 
 ### TUI dashboard
 


### PR DESCRIPTION
## Summary
- add read-only HTTP(S) targets for `library sync pull`
- keep `library sync push` scoped to file/plain-path targets
- document local vs remote target support and mark read-only remote catalog pull done on the roadmap

## Validation
- `scripts/check-docs-drift.sh`
- `scripts/check-aur-package.sh`
- `env GOCACHE="/Users/james/Documents/dev/modfetch/.cache/go-build" GOMODCACHE="/Users/james/Documents/dev/modfetch/.cache/go-mod" go test -count=1 ./...`
- `env GOCACHE="/Users/james/Documents/dev/modfetch/.cache/go-build" GOMODCACHE="/Users/james/Documents/dev/modfetch/.cache/go-mod" go vet ./...`
- `make build`
- real CLI smoke with temp SQLite state, temp catalog, local HTTP server, `sync pull --dry-run`, `sync pull`, and catalog export verification
- `git diff --check`
- `rg -n "TODO|FIXME" README.md TESTING.md WARP.md docs cmd internal packaging scripts` (no matches)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->