### PR TITLE
Add ModelScope metadata enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Added
   targets, including dry-run and JSON output support.
 - Added HTTP(S) catalog pull targets for `library sync pull`, allowing a
   published catalog URL to be imported with the same dry-run/conflict handling.
+- Added ModelScope metadata enrichment for `modelscope.cn` model URLs, including
+  source detection, API-backed metadata, and best-effort fallback metadata.
 
 Docs
 - Documented Arch Linux AUR package maintenance and release checklist coverage.

--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ Roadmap
 - See docs/ROADMAP.md for the active, prioritized roadmap
 - v0.7.x focus:
   - AUR package publication once maintainer SSH auth is available
-  - Metadata enrichment from additional registries
+  - Metadata enrichment from additional registries beyond ModelScope
   - Authenticated and writable remote catalog sync targets
   - User-driven archive format expansion
   - Non-interactive TUI scripting hooks

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # modfetch
 
-> **Fast, resilient downloads for AI models** • Download, verify, and organize LLM and Stable Diffusion models from HuggingFace and CivitAI
+> **Fast, resilient downloads for AI models** • Download, verify, and organize LLM and Stable Diffusion models from HuggingFace, CivitAI, and ModelScope
 
 ```
 ╔═══════════════════════════════════════════════════════════╗
@@ -42,11 +42,12 @@
 
 ### 📚 Model Library
 - **Browse and search** all your downloaded models
-- **Rich metadata** from HuggingFace and CivitAI APIs
+- **Rich metadata** from HuggingFace, CivitAI, and ModelScope APIs
 - **Favorites system** to mark important models
 - **Directory scanner** to discover existing models (10-100x faster with indexes)
 - **Detailed view** with specs, descriptions, tags, and links
 - **Filter by type and source** (LLM, LoRA, VAE, Checkpoint, etc.)
+- **ModelScope source support** with API-backed enrichment; see the [Library Guide](docs/LIBRARY.md#modelscope)
 
 ### 🎯 Organization
 - **Automatic placement** into app directories
@@ -476,7 +477,7 @@ Project layout
 - internal/resolver: hf:// and civitai:// resolvers
 - internal/placer: placement engine
 - internal/scanner: directory scanner for model discovery
-- internal/metadata: metadata fetchers for HuggingFace and CivitAI
+- internal/metadata: metadata fetchers for HuggingFace, CivitAI, and ModelScope
 - internal/tui: TUI models (Library, Scanner, Settings, Downloads)
 - internal/state: SQLite state DB with indexed metadata storage
 - internal/metrics: Prometheus textfile metrics

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -210,6 +210,7 @@ Press `F`, choose `Source`, and press `Enter` to cycle through known sources:
 **Supported sources:**
 - `huggingface` - Models from HuggingFace Hub
 - `civitai` - Models from CivitAI
+- `modelscope` - Models from ModelScope
 - `local` - Locally scanned models
 - `direct` - Direct URL downloads
 
@@ -442,9 +443,22 @@ For models downloaded from CivitAI:
 - Set `CIVITAI_TOKEN` environment variable for NSFW/restricted content
 - Token checked in Settings tab
 
+### ModelScope
+
+For models downloaded from ModelScope:
+
+**API Endpoint:** `https://modelscope.cn/api/v1/models/{owner}/{name}`
+
+**Fetched metadata:**
+- Model name, ID, description, license, and tags
+- Author and model page links
+- Download count when reported by the API
+- Model type inferred from tasks, tags, or filename
+- Quantization and file format inferred from resolved filenames
+
 ### Direct Downloads
 
-For direct URL downloads (non-HuggingFace, non-CivitAI):
+For direct URL downloads (non-HuggingFace, non-CivitAI, non-ModelScope):
 
 **Basic metadata only:**
 - URL as source
@@ -532,7 +546,11 @@ For large libraries (1000+ models):
    - Check API status
    - Ensure model ID is valid
 
-3. **For local scans:**
+3. **For ModelScope models:**
+   - Check API status at https://modelscope.cn
+   - Verify the URL uses `/models/{owner}/{name}`
+
+4. **For local scans:**
    - Metadata is limited to filename parsing
    - Rename files to include quantization (e.g., `model.Q4_K_M.gguf`)
    - Include parameter count in filename (e.g., `llama-7b.gguf`)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -148,7 +148,10 @@ These are useful, but not required for the first v0.7.0 release:
 - [DONE] Read-only remote catalog pull:
   `library sync pull --target https://...` imports published catalogs with the
   same dry-run and conflict handling as local catalog imports.
-- Metadata enrichment from additional model registries.
+- [DONE] ModelScope metadata enrichment:
+  ModelScope URLs are recognized as `modelscope` sources and enrich library
+  records from the ModelScope model API with best-effort offline fallback.
+- Metadata enrichment from additional model registries beyond ModelScope.
 - Authenticated and writable remote catalog sync targets.
 - More archive formats if users report concrete needs.
 - Non-interactive TUI scripting hooks.

--- a/internal/metadata/fetcher.go
+++ b/internal/metadata/fetcher.go
@@ -45,6 +45,7 @@ func NewRegistry() *Registry {
 	// Register default fetchers
 	r.Register(NewHuggingFaceFetcher(client))
 	r.Register(NewCivitAIFetcher(client))
+	r.Register(NewModelScopeFetcher(client))
 
 	return r
 }

--- a/internal/metadata/fetcher_test.go
+++ b/internal/metadata/fetcher_test.go
@@ -219,6 +219,11 @@ func TestRegistry_FetchMetadata(t *testing.T) {
 			wantSource: "civitai",
 		},
 		{
+			name:       "ModelScope URL",
+			url:        "https://modelscope.cn/models/qwen/Qwen2.5-7B-Instruct/resolve/master/model.gguf",
+			wantSource: "modelscope",
+		},
+		{
 			name:       "Direct URL",
 			url:        "https://example.com/model.gguf",
 			wantSource: "direct",

--- a/internal/metadata/modelscope.go
+++ b/internal/metadata/modelscope.go
@@ -58,7 +58,7 @@ func (f *ModelScopeFetcher) FetchMetadata(ctx context.Context, rawURL string) (*
 	if resp.StatusCode != http.StatusOK {
 		return f.basicMetadata(rawURL, modelID, owner, repo, revision, filename), nil
 	}
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
 	if err != nil {
 		return f.basicMetadata(rawURL, modelID, owner, repo, revision, filename), nil
 	}
@@ -96,7 +96,7 @@ func (f *ModelScopeFetcher) FetchMetadata(ctx context.Context, rawURL string) (*
 	}
 	meta.Quantization = ExtractQuantization(filename)
 	if filename != "" {
-		meta.FileFormat = strings.TrimPrefix(strings.ToLower(filepath.Ext(filename)), ".")
+		meta.FileFormat = strings.ToLower(filepath.Ext(filename))
 	}
 	return meta, nil
 }
@@ -114,7 +114,7 @@ func (f *ModelScopeFetcher) basicMetadata(rawURL, modelID, owner, repo, revision
 		HomepageURL:  fmt.Sprintf("https://modelscope.cn/models/%s", modelID),
 		ModelType:    inferModelType(filename, nil),
 		Quantization: ExtractQuantization(filename),
-		FileFormat:   strings.TrimPrefix(strings.ToLower(filepath.Ext(filename)), "."),
+		FileFormat:   strings.ToLower(filepath.Ext(filename)),
 		CreatedAt:    time.Now(),
 		UpdatedAt:    time.Now(),
 	}

--- a/internal/metadata/modelscope.go
+++ b/internal/metadata/modelscope.go
@@ -1,0 +1,240 @@
+package metadata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+type ModelScopeFetcher struct {
+	client *http.Client
+}
+
+func NewModelScopeFetcher(client *http.Client) *ModelScopeFetcher {
+	return &ModelScopeFetcher{client: client}
+}
+
+func (f *ModelScopeFetcher) Source() string {
+	return "modelscope"
+}
+
+func (f *ModelScopeFetcher) CanHandle(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return host == "modelscope.cn" || strings.HasSuffix(host, ".modelscope.cn")
+}
+
+func (f *ModelScopeFetcher) FetchMetadata(ctx context.Context, rawURL string) (*state.ModelMetadata, error) {
+	modelID, owner, repo, revision, filename, err := parseModelScopeURL(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	apiURL := fmt.Sprintf("https://modelscope.cn/api/v1/models/%s", modelID)
+	if revision != "" {
+		apiURL += "?Revision=" + url.QueryEscape(revision)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return f.basicMetadata(rawURL, modelID, owner, repo, revision, filename), nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return f.basicMetadata(rawURL, modelID, owner, repo, revision, filename), nil
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return f.basicMetadata(rawURL, modelID, owner, repo, revision, filename), nil
+	}
+
+	var apiResp modelScopeModelResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil || !apiResp.Success || apiResp.Code != http.StatusOK {
+		return f.basicMetadata(rawURL, modelID, owner, repo, revision, filename), nil
+	}
+
+	data := apiResp.Data
+	meta := &state.ModelMetadata{
+		DownloadURL:   rawURL,
+		ModelName:     firstNonEmpty(mapString(data, "Name"), mapString(data, "ModelName"), repo),
+		ModelID:       firstNonEmpty(mapString(data, "Id"), mapString(data, "ModelId"), modelID),
+		Version:       revision,
+		Source:        "modelscope",
+		Description:   truncateString(mapString(data, "Description"), 5000),
+		Author:        firstNonEmpty(mapString(data, "Owner"), mapString(data, "Author"), owner),
+		AuthorURL:     fmt.Sprintf("https://modelscope.cn/profile/%s", owner),
+		License:       mapString(data, "License"),
+		Tags:          mapStringSlice(data, "Tags"),
+		RepoURL:       fmt.Sprintf("https://modelscope.cn/models/%s", modelID),
+		HomepageURL:   fmt.Sprintf("https://modelscope.cn/models/%s", modelID),
+		ThumbnailURL:  firstNonEmpty(mapString(data, "ModelCover"), mapString(data, "Cover")),
+		DownloadCount: mapInt(data, "Downloads"),
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+	if meta.ModelName == "" {
+		meta.ModelName = repo
+	}
+	meta.ModelType = inferModelType(filename, meta.Tags)
+	if meta.ModelType == "Unknown" {
+		meta.ModelType = modelScopeTaskType(data)
+	}
+	meta.Quantization = ExtractQuantization(filename)
+	if filename != "" {
+		meta.FileFormat = strings.TrimPrefix(strings.ToLower(filepath.Ext(filename)), ".")
+	}
+	return meta, nil
+}
+
+func (f *ModelScopeFetcher) basicMetadata(rawURL, modelID, owner, repo, revision, filename string) *state.ModelMetadata {
+	return &state.ModelMetadata{
+		DownloadURL:  rawURL,
+		ModelName:    repo,
+		ModelID:      modelID,
+		Version:      revision,
+		Source:       "modelscope",
+		Author:       owner,
+		AuthorURL:    fmt.Sprintf("https://modelscope.cn/profile/%s", owner),
+		RepoURL:      fmt.Sprintf("https://modelscope.cn/models/%s", modelID),
+		HomepageURL:  fmt.Sprintf("https://modelscope.cn/models/%s", modelID),
+		ModelType:    inferModelType(filename, nil),
+		Quantization: ExtractQuantization(filename),
+		FileFormat:   strings.TrimPrefix(strings.ToLower(filepath.Ext(filename)), "."),
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+}
+
+type modelScopeModelResponse struct {
+	Code    int            `json:"Code"`
+	Success bool           `json:"Success"`
+	Message string         `json:"Message"`
+	Data    map[string]any `json:"Data"`
+}
+
+func parseModelScopeURL(rawURL string) (modelID, owner, repo, revision, filename string, err error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", "", "", "", "", fmt.Errorf("parse ModelScope URL: %w", err)
+	}
+	parts := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
+	for i := 0; i+2 < len(parts); i++ {
+		if parts[i] != "models" {
+			continue
+		}
+		owner, err = url.PathUnescape(parts[i+1])
+		if err != nil {
+			return "", "", "", "", "", fmt.Errorf("decode ModelScope owner: %w", err)
+		}
+		repo, err = url.PathUnescape(parts[i+2])
+		if err != nil {
+			return "", "", "", "", "", fmt.Errorf("decode ModelScope repo: %w", err)
+		}
+		if i+5 < len(parts) && parts[i+3] == "resolve" {
+			revision, err = url.PathUnescape(parts[i+4])
+			if err != nil {
+				return "", "", "", "", "", fmt.Errorf("decode ModelScope revision: %w", err)
+			}
+			filename, err = url.PathUnescape(strings.Join(parts[i+5:], "/"))
+			if err != nil {
+				return "", "", "", "", "", fmt.Errorf("decode ModelScope filename: %w", err)
+			}
+		}
+		return owner + "/" + repo, owner, repo, revision, filename, nil
+	}
+	return "", "", "", "", "", fmt.Errorf("invalid ModelScope URL format")
+}
+
+func mapString(data map[string]any, key string) string {
+	if value, ok := data[key]; ok {
+		if s, ok := value.(string); ok {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
+}
+
+func mapStringSlice(data map[string]any, key string) []string {
+	value, ok := data[key]
+	if !ok {
+		return nil
+	}
+	switch v := value.(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok && strings.TrimSpace(s) != "" {
+				out = append(out, strings.TrimSpace(s))
+			}
+		}
+		return out
+	case string:
+		if strings.TrimSpace(v) == "" {
+			return nil
+		}
+		parts := strings.Split(v, ",")
+		out := make([]string, 0, len(parts))
+		for _, part := range parts {
+			if part = strings.TrimSpace(part); part != "" {
+				out = append(out, part)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func mapInt(data map[string]any, key string) int {
+	switch v := data[key].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	default:
+		return 0
+	}
+}
+
+func modelScopeTaskType(data map[string]any) string {
+	tasks := mapStringSlice(data, "Tasks")
+	for _, task := range tasks {
+		task = strings.ToLower(task)
+		if strings.Contains(task, "text-generation") || strings.Contains(task, "chat") || strings.Contains(task, "llm") {
+			return "LLM"
+		}
+		if strings.Contains(task, "text-to-image") || strings.Contains(task, "image-generation") {
+			return "Checkpoint"
+		}
+		if strings.Contains(task, "embedding") {
+			return "Embedding"
+		}
+	}
+	return "Unknown"
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/metadata/modelscope.go
+++ b/internal/metadata/modelscope.go
@@ -32,7 +32,11 @@ func (f *ModelScopeFetcher) CanHandle(rawURL string) bool {
 		return false
 	}
 	host := strings.ToLower(u.Hostname())
-	return host == "modelscope.cn" || strings.HasSuffix(host, ".modelscope.cn")
+	if host != "modelscope.cn" && !strings.HasSuffix(host, ".modelscope.cn") {
+		return false
+	}
+	_, _, _, _, _, err = parseModelScopeURL(rawURL)
+	return err == nil
 }
 
 func (f *ModelScopeFetcher) FetchMetadata(ctx context.Context, rawURL string) (*state.ModelMetadata, error) {
@@ -41,13 +45,10 @@ func (f *ModelScopeFetcher) FetchMetadata(ctx context.Context, rawURL string) (*
 		return nil, err
 	}
 
-	apiURL := fmt.Sprintf("https://modelscope.cn/api/v1/models/%s", modelID)
-	if revision != "" {
-		apiURL += "?Revision=" + url.QueryEscape(revision)
-	}
+	apiURL := modelScopeAPIURL(owner, repo, revision)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+		return f.basicMetadata(rawURL, modelID, owner, repo, revision, filename), nil
 	}
 	resp, err := f.client.Do(req)
 	if err != nil {
@@ -77,11 +78,11 @@ func (f *ModelScopeFetcher) FetchMetadata(ctx context.Context, rawURL string) (*
 		Source:        "modelscope",
 		Description:   truncateString(mapString(data, "Description"), 5000),
 		Author:        firstNonEmpty(mapString(data, "Owner"), mapString(data, "Author"), owner),
-		AuthorURL:     fmt.Sprintf("https://modelscope.cn/profile/%s", owner),
+		AuthorURL:     modelScopeProfileURL(owner),
 		License:       mapString(data, "License"),
 		Tags:          mapStringSlice(data, "Tags"),
-		RepoURL:       fmt.Sprintf("https://modelscope.cn/models/%s", modelID),
-		HomepageURL:   fmt.Sprintf("https://modelscope.cn/models/%s", modelID),
+		RepoURL:       modelScopeModelURL(owner, repo),
+		HomepageURL:   modelScopeModelURL(owner, repo),
 		ThumbnailURL:  firstNonEmpty(mapString(data, "ModelCover"), mapString(data, "Cover")),
 		DownloadCount: mapInt(data, "Downloads"),
 		CreatedAt:     time.Now(),
@@ -109,9 +110,9 @@ func (f *ModelScopeFetcher) basicMetadata(rawURL, modelID, owner, repo, revision
 		Version:      revision,
 		Source:       "modelscope",
 		Author:       owner,
-		AuthorURL:    fmt.Sprintf("https://modelscope.cn/profile/%s", owner),
-		RepoURL:      fmt.Sprintf("https://modelscope.cn/models/%s", modelID),
-		HomepageURL:  fmt.Sprintf("https://modelscope.cn/models/%s", modelID),
+		AuthorURL:    modelScopeProfileURL(owner),
+		RepoURL:      modelScopeModelURL(owner, repo),
+		HomepageURL:  modelScopeModelURL(owner, repo),
 		ModelType:    inferModelType(filename, nil),
 		Quantization: ExtractQuantization(filename),
 		FileFormat:   strings.ToLower(filepath.Ext(filename)),
@@ -158,6 +159,39 @@ func parseModelScopeURL(rawURL string) (modelID, owner, repo, revision, filename
 		return owner + "/" + repo, owner, repo, revision, filename, nil
 	}
 	return "", "", "", "", "", fmt.Errorf("invalid ModelScope URL format")
+}
+
+func modelScopeAPIURL(owner, repo, revision string) string {
+	u := url.URL{
+		Scheme:  "https",
+		Host:    "modelscope.cn",
+		Path:    "/api/v1/models/" + owner + "/" + repo,
+		RawPath: "/api/v1/models/" + url.PathEscape(owner) + "/" + url.PathEscape(repo),
+	}
+	if revision != "" {
+		q := u.Query()
+		q.Set("Revision", revision)
+		u.RawQuery = q.Encode()
+	}
+	return u.String()
+}
+
+func modelScopeModelURL(owner, repo string) string {
+	return (&url.URL{
+		Scheme:  "https",
+		Host:    "modelscope.cn",
+		Path:    "/models/" + owner + "/" + repo,
+		RawPath: "/models/" + url.PathEscape(owner) + "/" + url.PathEscape(repo),
+	}).String()
+}
+
+func modelScopeProfileURL(owner string) string {
+	return (&url.URL{
+		Scheme:  "https",
+		Host:    "modelscope.cn",
+		Path:    "/profile/" + owner,
+		RawPath: "/profile/" + url.PathEscape(owner),
+	}).String()
 }
 
 func mapString(data map[string]any, key string) string {

--- a/internal/metadata/modelscope_test.go
+++ b/internal/metadata/modelscope_test.go
@@ -27,6 +27,11 @@ func TestModelScopeFetcherCanHandle(t *testing.T) {
 			url:  "https://huggingface.co/qwen/Qwen2.5-7B-Instruct",
 			want: false,
 		},
+		{
+			name: "ModelScope non-model URL",
+			url:  "https://modelscope.cn/docs",
+			want: false,
+		},
 	}
 
 	f := NewModelScopeFetcher(&http.Client{})
@@ -83,6 +88,9 @@ func TestModelScopeFetcherFetchMetadataSuccess(t *testing.T) {
 	if meta.ModelName != "Qwen2.5-7B-Instruct" || meta.Author != "qwen" {
 		t.Fatalf("unexpected identity metadata: %+v", meta)
 	}
+	if meta.RepoURL != "https://modelscope.cn/models/qwen/Qwen2.5-7B-Instruct" || meta.AuthorURL != "https://modelscope.cn/profile/qwen" {
+		t.Fatalf("unexpected links: %+v", meta)
+	}
 	if meta.ModelType != "LLM" || meta.Quantization != "Q4_K_M" || meta.FileFormat != ".gguf" {
 		t.Fatalf("unexpected model specs: %+v", meta)
 	}
@@ -115,5 +123,14 @@ func TestParseModelScopeURL(t *testing.T) {
 	}
 	if modelID != "qwen/Qwen2.5-7B-Instruct" || owner != "qwen" || repo != "Qwen2.5-7B-Instruct" || revision != "master" || filename != "path/to/model.gguf" {
 		t.Fatalf("unexpected parse result: %q %q %q %q %q", modelID, owner, repo, revision, filename)
+	}
+}
+
+func TestModelScopeURLBuildersEscapeSegments(t *testing.T) {
+	if got := modelScopeAPIURL("owner name", "repo/name", "release/1"); got != "https://modelscope.cn/api/v1/models/owner%20name/repo%2Fname?Revision=release%2F1" {
+		t.Fatalf("modelScopeAPIURL() = %q", got)
+	}
+	if got := modelScopeModelURL("owner name", "repo/name"); got != "https://modelscope.cn/models/owner%20name/repo%2Fname" {
+		t.Fatalf("modelScopeModelURL() = %q", got)
 	}
 }

--- a/internal/metadata/modelscope_test.go
+++ b/internal/metadata/modelscope_test.go
@@ -83,7 +83,7 @@ func TestModelScopeFetcherFetchMetadataSuccess(t *testing.T) {
 	if meta.ModelName != "Qwen2.5-7B-Instruct" || meta.Author != "qwen" {
 		t.Fatalf("unexpected identity metadata: %+v", meta)
 	}
-	if meta.ModelType != "LLM" || meta.Quantization != "Q4_K_M" || meta.FileFormat != "gguf" {
+	if meta.ModelType != "LLM" || meta.Quantization != "Q4_K_M" || meta.FileFormat != ".gguf" {
 		t.Fatalf("unexpected model specs: %+v", meta)
 	}
 	if meta.DownloadCount != 4200 || meta.License != "apache-2.0" {
@@ -103,7 +103,7 @@ func TestModelScopeFetcherAPIFailureFallsBack(t *testing.T) {
 	if meta.Source != "modelscope" || meta.ModelID != "qwen/Qwen2.5-7B-Instruct" {
 		t.Fatalf("unexpected fallback metadata: %+v", meta)
 	}
-	if meta.Quantization != "Q5_K_M" || meta.FileFormat != "gguf" {
+	if meta.Quantization != "Q5_K_M" || meta.FileFormat != ".gguf" {
 		t.Fatalf("unexpected fallback file metadata: %+v", meta)
 	}
 }

--- a/internal/metadata/modelscope_test.go
+++ b/internal/metadata/modelscope_test.go
@@ -1,0 +1,119 @@
+package metadata
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestModelScopeFetcherCanHandle(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{
+			name: "ModelScope model URL",
+			url:  "https://modelscope.cn/models/qwen/Qwen2.5-7B-Instruct",
+			want: true,
+		},
+		{
+			name: "ModelScope www model URL",
+			url:  "https://www.modelscope.cn/models/qwen/Qwen2.5-7B-Instruct/resolve/master/model.gguf",
+			want: true,
+		},
+		{
+			name: "Hugging Face URL",
+			url:  "https://huggingface.co/qwen/Qwen2.5-7B-Instruct",
+			want: false,
+		},
+	}
+
+	f := NewModelScopeFetcher(&http.Client{})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := f.CanHandle(tt.url); got != tt.want {
+				t.Fatalf("CanHandle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModelScopeFetcherFetchMetadataSuccess(t *testing.T) {
+	response := `{
+		"Code": 200,
+		"Success": true,
+		"Message": "OK",
+		"Data": {
+			"Id": "qwen/Qwen2.5-7B-Instruct",
+			"Name": "Qwen2.5-7B-Instruct",
+			"Description": "Instruction tuned Qwen model",
+			"Owner": "qwen",
+			"License": "apache-2.0",
+			"Tags": ["llm", "text-generation"],
+			"Tasks": ["text-generation"],
+			"Downloads": 4200,
+			"ModelCover": "https://modelscope.cn/cover.png"
+		}
+	}`
+	client := routedHTTPClient(t, "modelscope.cn", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/models/qwen/Qwen2.5-7B-Instruct" {
+			t.Errorf("unexpected ModelScope API path: %s", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusBadRequest)
+			return
+		}
+		if r.URL.Query().Get("Revision") != "master" {
+			t.Errorf("unexpected revision query: %s", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(response))
+	}))
+
+	f := NewModelScopeFetcher(client)
+	meta, err := f.FetchMetadata(context.Background(), "https://modelscope.cn/models/qwen/Qwen2.5-7B-Instruct/resolve/master/qwen2.5.Q4_K_M.gguf")
+	if err != nil {
+		t.Fatalf("FetchMetadata() error = %v", err)
+	}
+	if meta.Source != "modelscope" {
+		t.Fatalf("Source = %q, want modelscope", meta.Source)
+	}
+	if meta.ModelID != "qwen/Qwen2.5-7B-Instruct" {
+		t.Fatalf("ModelID = %q", meta.ModelID)
+	}
+	if meta.ModelName != "Qwen2.5-7B-Instruct" || meta.Author != "qwen" {
+		t.Fatalf("unexpected identity metadata: %+v", meta)
+	}
+	if meta.ModelType != "LLM" || meta.Quantization != "Q4_K_M" || meta.FileFormat != "gguf" {
+		t.Fatalf("unexpected model specs: %+v", meta)
+	}
+	if meta.DownloadCount != 4200 || meta.License != "apache-2.0" {
+		t.Fatalf("unexpected registry metadata: %+v", meta)
+	}
+}
+
+func TestModelScopeFetcherAPIFailureFallsBack(t *testing.T) {
+	client := routedHTTPClient(t, "modelscope.cn", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	f := NewModelScopeFetcher(client)
+	meta, err := f.FetchMetadata(context.Background(), "https://modelscope.cn/models/qwen/Qwen2.5-7B-Instruct/resolve/master/qwen2.5.Q5_K_M.gguf")
+	if err != nil {
+		t.Fatalf("FetchMetadata() should fall back on API failure, got %v", err)
+	}
+	if meta.Source != "modelscope" || meta.ModelID != "qwen/Qwen2.5-7B-Instruct" {
+		t.Fatalf("unexpected fallback metadata: %+v", meta)
+	}
+	if meta.Quantization != "Q5_K_M" || meta.FileFormat != "gguf" {
+		t.Fatalf("unexpected fallback file metadata: %+v", meta)
+	}
+}
+
+func TestParseModelScopeURL(t *testing.T) {
+	modelID, owner, repo, revision, filename, err := parseModelScopeURL("https://modelscope.cn/models/qwen/Qwen2.5-7B-Instruct/resolve/master/path/to/model.gguf")
+	if err != nil {
+		t.Fatalf("parseModelScopeURL() error = %v", err)
+	}
+	if modelID != "qwen/Qwen2.5-7B-Instruct" || owner != "qwen" || repo != "Qwen2.5-7B-Instruct" || revision != "master" || filename != "path/to/model.gguf" {
+		t.Fatalf("unexpected parse result: %q %q %q %q %q", modelID, owner, repo, revision, filename)
+	}
+}


### PR DESCRIPTION
## Summary
- add a ModelScope metadata fetcher for `modelscope.cn/models/{owner}/{name}` URLs
- register ModelScope in the default metadata registry with API-backed enrichment and best-effort fallback metadata
- document `modelscope` as a library source and mark the ModelScope roadmap item done

## Validation
- `scripts/check-docs-drift.sh`
- `scripts/check-aur-package.sh`
- `env GOCACHE="/Users/james/Documents/dev/modfetch/.cache/go-build" GOMODCACHE="/Users/james/Documents/dev/modfetch/.cache/go-mod" go test -count=1 ./internal/metadata`
- `env GOCACHE="/Users/james/Documents/dev/modfetch/.cache/go-build" GOMODCACHE="/Users/james/Documents/dev/modfetch/.cache/go-mod" go test -count=1 ./...`
- `env GOCACHE="/Users/james/Documents/dev/modfetch/.cache/go-build" GOMODCACHE="/Users/james/Documents/dev/modfetch/.cache/go-mod" go vet ./...`
- `make build`
- `git diff --check`
- `rg -n "TODO|FIXME" README.md TESTING.md WARP.md docs cmd internal packaging scripts` (no matches)

## Notes
- ModelScope endpoint shape follows the official ModelScope Hub API implementation: `GET /api/v1/models/{owner}/{name}`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->