### PR TITLE
[codex] Add non-interactive TUI snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Added
   published catalog URL to be imported with the same dry-run/conflict handling.
 - Added ModelScope metadata enrichment for `modelscope.cn` model URLs, including
   source detection, API-backed metadata, and best-effort fallback metadata.
+- Added `modfetch tui --snapshot` and `--snapshot --json` for non-interactive
+  downloads, library, and config state reporting.
 
 Docs
 - Documented Arch Linux AUR package maintenance and release checklist coverage.

--- a/README.md
+++ b/README.md
@@ -498,4 +498,4 @@ Roadmap
   - Metadata enrichment from additional registries beyond ModelScope
   - Authenticated and writable remote catalog sync targets
   - User-driven archive format expansion
-  - Non-interactive TUI scripting hooks
+  - Completed: non-interactive TUI snapshots with `modfetch tui --snapshot --json`

--- a/TESTING.md
+++ b/TESTING.md
@@ -41,7 +41,8 @@ go test -count=1 ./internal/tui/... ./cmd/modfetch
 
 These cover navigation, filter persistence, library filters, multi-select bulk
 actions, selected catalog export, settings rendering, config wizard validation,
-and shell completion drift for removed TUI selector flags.
+non-interactive TUI snapshots backed by a real SQLite state database, and shell
+completion drift for removed TUI selector flags.
 
 ## Manual Smoke
 
@@ -58,4 +59,5 @@ For TUI validation:
 
 ```bash
 ./bin/modfetch tui --config ~/.config/modfetch/config.yml
+./bin/modfetch tui --config ~/.config/modfetch/config.yml --snapshot --json
 ```

--- a/WARP.md
+++ b/WARP.md
@@ -12,6 +12,7 @@ Common commands
   - ./bin/modfetch download --config ~/.config/modfetch/config.yml --url 'https://proof.ovh.net/files/1Mb.dat'
   - ./bin/modfetch download --config ~/.config/modfetch/config.yml --url 'hf://gpt2/README.md?rev=main'
   - TUI: ./bin/modfetch tui --config ~/.config/modfetch/config.yml
+  - TUI snapshot: ./bin/modfetch tui --config ~/.config/modfetch/config.yml --snapshot --json
 - Tests
   - All tests: make test (go test ./...)
   - With coverage: go test ./... -cover
@@ -58,7 +59,7 @@ Big-picture architecture
   - internal/classifier detects artifact types (e.g., sd.checkpoint/lora/vae/controlnet, llm.gguf) with optional YAML regex overrides.
   - internal/placer maps files into app directories via placement.mapping; supports symlink, hardlink, or copy per config/general. Placement fails if overwriting different content unless allow_overwrite is true.
 - TUI (internal/tui)
-  - Bubble Tea–based dashboard; v2 adds richer sorting/grouping and theming. Refresh cadence and column mode configurable via ui.* in YAML. See docs/TUI_GUIDE.md.
+  - Bubble Tea–based dashboard plus non-interactive `tui --snapshot`; v2 adds richer sorting/grouping and theming. Refresh cadence and column mode configurable via ui.* in YAML. See docs/TUI_GUIDE.md.
 - Logging and metrics
   - Text or JSON logs with level control; URLs are sanitized to avoid leaking secrets.
   - Optional Prometheus textfile exporter writes counters/gauges to metrics.prometheus_textfile.path.

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -70,7 +70,7 @@ _modfetch_completions()
         status)
             COMPREPLY=( $(compgen -W "--config --log-level --json --only-errors --summary --duplicates" -- "$cur") ) ;;
         tui)
-            COMPREPLY=( $(compgen -W "--config --log-level --json" -- "$cur") ) ;;
+            COMPREPLY=( $(compgen -W "--config --log-level --json --snapshot" -- "$cur") ) ;;
         library)
             if [[ ${cword} -eq 2 ]]; then
                 COMPREPLY=( $(compgen -W "export import scan sync" -- "$cur") )
@@ -156,7 +156,7 @@ _modfetch() {
       _arguments '*:options:(--config --log-level --json --only-errors --summary --duplicates)'
       ;;
     tui)
-      _arguments '*:options:(--config --log-level --json)'
+      _arguments '*:options:(--config --log-level --json --snapshot)'
       ;;
     library)
       if (( CURRENT == 3 )); then
@@ -217,7 +217,8 @@ complete -c modfetch -f -n "__fish_use_subcommand" -a "status" -d "show status"
 complete -c modfetch -n "__fish_seen_subcommand_from status" -l only-errors -d "Only error rows"
 complete -c modfetch -n "__fish_seen_subcommand_from status" -l summary -d "Print totals and errors"
 complete -c modfetch -n "__fish_seen_subcommand_from status" -l duplicates -d "Show duplicate completed downloads"
-complete -c modfetch -f -n "__fish_use_subcommand" -a "tui" -d "dashboard"
+complete -c modfetch -f -n "__fish_use_subcommand" -a "tui" -d "dashboard and snapshots"
+complete -c modfetch -n "__fish_seen_subcommand_from tui" -l snapshot -d "Print state snapshot and exit"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "library" -d "library catalog"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "batch" -d "batch operations"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "version" -d "print version"

--- a/cmd/modfetch/completion_test.go
+++ b/cmd/modfetch/completion_test.go
@@ -23,7 +23,7 @@ func TestCompletionCurrentFlags(t *testing.T) {
 		"place":    {"--dry-run", "--preset", "--list-presets"},
 		"batch":    {"--naming-pattern"},
 		"hostcaps": {"--config", "--list", "--clear", "--clear-all", "--json"},
-		"tui":      {"--json"},
+		"tui":      {"--json", "--snapshot"},
 		"clean":    {"--days", "--dry-run", "--dest", "--include-next-to-dest", "--sidecars"},
 		"library":  {"--target"},
 	}

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -104,7 +104,7 @@ Commands:
   status            Show download status (table or JSON)
   place             Place a file into configured app directories
   verify            Verify SHA256 of a file or all completed downloads
-  tui               Open the interactive terminal dashboard
+  tui               Open the interactive terminal dashboard or print a state snapshot
   library export    Export model library catalog as JSON
   library import    Import model library catalog JSON
   library scan      Scan configured model directories into the library

--- a/cmd/modfetch/tui_cmd.go
+++ b/cmd/modfetch/tui_cmd.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jxwalker/modfetch/internal/config"
@@ -19,7 +22,8 @@ import (
 
 func handleTUI(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("tui", flag.ContinueOnError)
-	common := addCommonConfigLogFlags(fs, "json logs (not used in TUI)")
+	common := addCommonConfigLogFlags(fs, "JSON snapshot output when --snapshot is set")
+	snapshot := fs.Bool("snapshot", false, "print a non-interactive TUI state snapshot and exit")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -30,6 +34,12 @@ func handleTUI(ctx context.Context, args []string) error {
 	// Try to load config. If not found, offer to create via wizard with sensible defaults.
 	c, err := config.Load(resolvedCfgPath)
 	if err != nil {
+		if *snapshot {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("config file not found: %s: %w", resolvedCfgPath, err)
+			}
+			return err
+		}
 		if os.IsNotExist(err) {
 			// Create directory and run wizard
 			if err := os.MkdirAll(filepath.Dir(resolvedCfgPath), 0o755); err != nil {
@@ -74,8 +84,185 @@ func handleTUI(ctx context.Context, args []string) error {
 	}
 	defer func() { _ = st.SQL.Close() }()
 
+	if *snapshot {
+		snap, err := buildTUISnapshot(c, st)
+		if err != nil {
+			return err
+		}
+		if *common.jsonOut {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(snap)
+		}
+		printTUISnapshot(snap)
+		return nil
+	}
+
 	m := tui.New(c, st, version)
 	p := tea.NewProgram(m)
 	_, err = p.Run()
 	return err
+}
+
+type tuiSnapshot struct {
+	Version   string             `json:"version"`
+	Config    tuiSnapshotConfig  `json:"config"`
+	Downloads tuiDownloadSummary `json:"downloads"`
+	Library   tuiLibrarySummary  `json:"library"`
+}
+
+type tuiSnapshotConfig struct {
+	DataRoot      string `json:"data_root"`
+	DownloadRoot  string `json:"download_root"`
+	PlacementMode string `json:"placement_mode"`
+}
+
+type tuiDownloadSummary struct {
+	Total     int            `json:"total"`
+	ByStatus  map[string]int `json:"by_status"`
+	Active    int            `json:"active"`
+	Pending   int            `json:"pending"`
+	Completed int            `json:"completed"`
+	Failed    int            `json:"failed"`
+	ErrorLike int            `json:"error_like"`
+}
+
+type tuiLibrarySummary struct {
+	Total     int            `json:"total"`
+	Favorites int            `json:"favorites"`
+	BySource  map[string]int `json:"by_source"`
+	ByType    map[string]int `json:"by_type"`
+}
+
+func buildTUISnapshot(c *config.Config, st *state.DB) (tuiSnapshot, error) {
+	rows, err := st.ListDownloads()
+	if err != nil {
+		return tuiSnapshot{}, fmt.Errorf("list downloads: %w", err)
+	}
+	metadata, err := st.ListMetadata(state.MetadataFilters{})
+	if err != nil {
+		return tuiSnapshot{}, fmt.Errorf("list library metadata: %w", err)
+	}
+
+	snap := tuiSnapshot{
+		Version: version,
+		Config: tuiSnapshotConfig{
+			DataRoot:      c.General.DataRoot,
+			DownloadRoot:  c.General.DownloadRoot,
+			PlacementMode: c.General.PlacementMode,
+		},
+		Downloads: tuiDownloadSummary{
+			Total:    len(rows),
+			ByStatus: map[string]int{},
+		},
+		Library: tuiLibrarySummary{
+			Total:    len(metadata),
+			BySource: map[string]int{},
+			ByType:   map[string]int{},
+		},
+	}
+
+	for _, row := range rows {
+		status := normalizeSnapshotToken(row.Status)
+		if status == "" {
+			status = "unknown"
+		}
+		snap.Downloads.ByStatus[status]++
+		switch classifyTUIDownloadStatus(status) {
+		case "active":
+			snap.Downloads.Active++
+		case "pending":
+			snap.Downloads.Pending++
+		case "completed":
+			snap.Downloads.Completed++
+		case "failed":
+			snap.Downloads.Failed++
+		}
+		if isTUIErrorLikeStatus(status) {
+			snap.Downloads.ErrorLike++
+		}
+	}
+
+	for _, meta := range metadata {
+		if meta.Favorite {
+			snap.Library.Favorites++
+		}
+		source := normalizeSnapshotToken(meta.Source)
+		if source == "" {
+			source = "unknown"
+		}
+		snap.Library.BySource[source]++
+		modelType := normalizeSnapshotToken(meta.ModelType)
+		if modelType == "" {
+			modelType = "unknown"
+		}
+		snap.Library.ByType[modelType]++
+	}
+
+	return snap, nil
+}
+
+func classifyTUIDownloadStatus(status string) string {
+	switch normalizeSnapshotToken(status) {
+	case "running", "downloading", "active", "retrying":
+		return "active"
+	case "pending", "queued", "planning":
+		return "pending"
+	case "complete", "completed", "verified":
+		return "completed"
+	case "error", "failed", "checksum_mismatch", "verify_failed", "canceled", "cancelled":
+		return "failed"
+	default:
+		return ""
+	}
+}
+
+func isTUIErrorLikeStatus(status string) bool {
+	switch normalizeSnapshotToken(status) {
+	case "error", "failed", "checksum_mismatch", "verify_failed":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeSnapshotToken(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func printTUISnapshot(snap tuiSnapshot) {
+	fmt.Printf("TUI snapshot: downloads=%d active=%d pending=%d completed=%d failed=%d error_like=%d library=%d favorites=%d\n",
+		snap.Downloads.Total,
+		snap.Downloads.Active,
+		snap.Downloads.Pending,
+		snap.Downloads.Completed,
+		snap.Downloads.Failed,
+		snap.Downloads.ErrorLike,
+		snap.Library.Total,
+		snap.Library.Favorites,
+	)
+	fmt.Printf("Config: data_root=%s download_root=%s placement_mode=%s\n",
+		snap.Config.DataRoot,
+		snap.Config.DownloadRoot,
+		snap.Config.PlacementMode,
+	)
+	fmt.Printf("Download statuses: %s\n", formatSnapshotCounts(snap.Downloads.ByStatus))
+	fmt.Printf("Library sources: %s\n", formatSnapshotCounts(snap.Library.BySource))
+	fmt.Printf("Library types: %s\n", formatSnapshotCounts(snap.Library.ByType))
+}
+
+func formatSnapshotCounts(counts map[string]int) string {
+	if len(counts) == 0 {
+		return "none"
+	}
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%d", key, counts[key]))
+	}
+	return strings.Join(parts, " ")
 }

--- a/cmd/modfetch/tui_cmd_test.go
+++ b/cmd/modfetch/tui_cmd_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/config"
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+func TestHandleTUISnapshotJSONUsesRealState(t *testing.T) {
+	cfgPath := seedTUISnapshotState(t)
+
+	out := captureStdout(t, func() {
+		if err := handleTUI(context.Background(), []string{"--config", cfgPath, "--snapshot", "--json"}); err != nil {
+			t.Fatalf("tui snapshot json: %v", err)
+		}
+	})
+
+	var snap tuiSnapshot
+	if err := json.Unmarshal([]byte(out), &snap); err != nil {
+		t.Fatalf("decode snapshot JSON: %v\n%s", err, out)
+	}
+	if snap.Downloads.Total != 4 || snap.Downloads.Active != 1 || snap.Downloads.Pending != 1 || snap.Downloads.Completed != 1 || snap.Downloads.Failed != 1 {
+		t.Fatalf("unexpected download summary: %+v", snap.Downloads)
+	}
+	if snap.Downloads.ErrorLike != 1 || snap.Downloads.ByStatus["error"] != 1 || snap.Downloads.ByStatus["complete"] != 1 {
+		t.Fatalf("unexpected download status counts: %+v", snap.Downloads)
+	}
+	if snap.Library.Total != 2 || snap.Library.Favorites != 1 {
+		t.Fatalf("unexpected library summary: %+v", snap.Library)
+	}
+	if snap.Library.BySource["huggingface"] != 1 || snap.Library.BySource["modelscope"] != 1 {
+		t.Fatalf("unexpected library sources: %+v", snap.Library.BySource)
+	}
+	if snap.Library.ByType["llm"] != 1 || snap.Library.ByType["checkpoint"] != 1 {
+		t.Fatalf("unexpected library types: %+v", snap.Library.ByType)
+	}
+}
+
+func TestHandleTUISnapshotTextUsesRealState(t *testing.T) {
+	cfgPath := seedTUISnapshotState(t)
+
+	out := captureStdout(t, func() {
+		if err := handleTUI(context.Background(), []string{"--config", cfgPath, "--snapshot"}); err != nil {
+			t.Fatalf("tui snapshot text: %v", err)
+		}
+	})
+
+	for _, want := range []string{
+		"TUI snapshot: downloads=4 active=1 pending=1 completed=1 failed=1 error_like=1 library=2 favorites=1",
+		"Download statuses: complete=1 error=1 pending=1 running=1",
+		"Library sources: huggingface=1 modelscope=1",
+		"Library types: checkpoint=1 llm=1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("snapshot text missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestHandleTUISnapshotMissingConfigReturnsCLIError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.yml")
+	err := handleTUI(context.Background(), []string{"--config", missing, "--snapshot"})
+	if err == nil {
+		t.Fatal("expected missing config error")
+	}
+	if !strings.Contains(err.Error(), "config file not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func seedTUISnapshotState(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "cfg")
+	cfgPath := writeLibraryConfig(t, root)
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	db, err := state.Open(cfg)
+	if err != nil {
+		t.Fatalf("open state db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	downloads := []state.DownloadRow{
+		{URL: "https://example.com/pending.gguf", Dest: filepath.Join(root, "downloads", "pending.gguf"), Status: "pending"},
+		{URL: "https://example.com/running.gguf", Dest: filepath.Join(root, "downloads", "running.gguf"), Status: "running"},
+		{URL: "https://example.com/complete.gguf", Dest: filepath.Join(root, "downloads", "complete.gguf"), Status: "complete"},
+		{URL: "https://example.com/error.gguf", Dest: filepath.Join(root, "downloads", "error.gguf"), Status: "error", LastError: "network"},
+	}
+	for _, row := range downloads {
+		if err := db.UpsertDownload(row); err != nil {
+			t.Fatalf("seed download %s: %v", row.URL, err)
+		}
+	}
+
+	metadata := []*state.ModelMetadata{
+		{
+			DownloadURL: "https://example.com/complete.gguf",
+			Dest:        filepath.Join(root, "downloads", "complete.gguf"),
+			ModelName:   "Complete Model",
+			Source:      "huggingface",
+			ModelType:   "LLM",
+			Favorite:    true,
+		},
+		{
+			DownloadURL: "https://example.com/checkpoint.safetensors",
+			Dest:        filepath.Join(root, "downloads", "checkpoint.safetensors"),
+			ModelName:   "Checkpoint Model",
+			Source:      "modelscope",
+			ModelType:   "Checkpoint",
+		},
+	}
+	for _, meta := range metadata {
+		if err := db.UpsertMetadata(meta); err != nil {
+			t.Fatalf("seed metadata %s: %v", meta.DownloadURL, err)
+		}
+	}
+
+	if err := os.MkdirAll(cfg.General.DownloadRoot, 0o755); err != nil {
+		t.Fatalf("create download root: %v", err)
+	}
+	return cfgPath
+}

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -469,11 +469,12 @@ See [CONFIG.md](CONFIG.md) for full configuration reference.
 
 ### tui
 
-Launch the interactive Terminal User Interface.
+Launch the interactive Terminal User Interface, or print a script-friendly
+snapshot of the same downloads, library, and config state.
 
 **Syntax:**
 ```bash
-modfetch tui [--config PATH]
+modfetch tui [--config PATH] [--snapshot] [--json]
 ```
 
 **Examples:**
@@ -484,7 +485,16 @@ modfetch tui
 
 # Use specific config
 modfetch tui --config ~/modfetch/config.yml
+
+# Print a human-readable state snapshot without opening the TUI
+modfetch tui --config ~/modfetch/config.yml --snapshot
+
+# Print a JSON state snapshot for scripts and monitors
+modfetch tui --config ~/modfetch/config.yml --snapshot --json
 ```
+
+`--snapshot` is non-interactive. If the config file is missing, it returns a
+normal CLI error instead of launching the first-run config wizard.
 
 See [TUI Guide](TUI_GUIDE.md) and [TUI Wireframes](TUI_WIREFRAMES.md) for full documentation.
 

--- a/docs/COMPLETIONS.md
+++ b/docs/COMPLETIONS.md
@@ -29,6 +29,7 @@ Notable flags and commands covered
 - --quiet, --json, --log-level
 - --summary-json, --no-resume, --batch-parallel, --naming-pattern, --no-auth-preflight, --dry-run
 - --strict, --force, --quant, --list-quants
+- tui --snapshot for non-interactive state snapshots
 
 Notes
 - The provided completions are lightweight and cover subcommands and common flags. They do not shell out to the binary for dynamic completions.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -167,6 +167,13 @@ The **Terminal User Interface (TUI)** gives you a real-time dashboard for managi
 modfetch tui
 ```
 
+To inspect the same saved state from a script or monitor without opening the
+interactive UI:
+
+```bash
+modfetch tui --snapshot --json
+```
+
 ### Your First Look
 
 ```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -154,7 +154,10 @@ These are useful, but not required for the first v0.7.0 release:
 - Metadata enrichment from additional model registries beyond ModelScope.
 - Authenticated and writable remote catalog sync targets.
 - More archive formats if users report concrete needs.
-- Non-interactive TUI scripting hooks.
+- [DONE] Non-interactive TUI scripting hooks:
+  `modfetch tui --snapshot` exits without launching the Bubble Tea interface
+  and `--snapshot --json` emits script-friendly downloads, library, and config
+  state.
 
 ## Completed Release History
 

--- a/docs/TUI_ANALYSIS_SUMMARY.txt
+++ b/docs/TUI_ANALYSIS_SUMMARY.txt
@@ -5,7 +5,7 @@
 
 PROJECT: modfetch - CLI+TUI for downloading LLM/Stable Diffusion models
 VERSION: v0.7.0
-ANALYSIS DATE: 2026-04-28
+ANALYSIS DATE: 2026-04-29
 
 ================================================================================
 1. CURRENT OVERVIEW
@@ -15,6 +15,8 @@ modfetch now ships one maintained TUI entry point:
 
   Command:
     modfetch tui
+    modfetch tui --snapshot
+    modfetch tui --snapshot --json
 
   Package:
     internal/tui
@@ -25,6 +27,7 @@ modfetch now ships one maintained TUI entry point:
     - Library rendering and filters in internal/tui/library_view.go
     - Library bulk actions in internal/tui/library_actions.go
     - Settings rendering in internal/tui/settings_view.go
+    - Non-interactive snapshot assembly in cmd/modfetch/tui_cmd.go
     - Modal handling in internal/tui/modals.go
     - Shared TUI URL normalization in internal/tui/url_resolution.go
     - UI preference persistence in internal/tui/ui_state.go
@@ -62,6 +65,14 @@ Configuration visibility:
     download settings, and placement rules
   - Token presence and rejection status surfaced in the UI
 
+Non-interactive state reporting:
+  - `modfetch tui --snapshot` prints a text summary and exits
+  - `modfetch tui --snapshot --json` prints script-friendly JSON and exits
+  - Snapshot data comes from the same config file and SQLite state database used
+    by the interactive TUI
+  - Missing config files return CLI errors instead of launching the first-run
+    wizard
+
 ================================================================================
 3. IMPLEMENTATION STATUS
 ================================================================================
@@ -95,6 +106,8 @@ Current TUI test coverage includes:
   - Library selection persistence across filters and tab changes
   - Bulk library actions and selected catalog export
   - Settings rendering
+  - Non-interactive TUI snapshot JSON/text output against a real SQLite state
+    database
   - Inspector behavior
   - UI-state persistence
   - Config wizard validation
@@ -125,7 +138,9 @@ Keep future TUI changes in the current package structure:
 
 The current v0.7.0 TUI is a single, maintained interface with download
 management, library maintenance, settings inspection, bulk operations, and
-state persistence. The older dual-implementation comparison has been superseded
-by the current package layout and test coverage.
+state persistence. Non-interactive snapshot hooks now expose the same persisted
+state for scripts without starting the Bubble Tea program. The older
+dual-implementation comparison has been superseded by the current package
+layout and test coverage.
 
 ================================================================================

--- a/docs/TUI_GUIDE.md
+++ b/docs/TUI_GUIDE.md
@@ -19,6 +19,21 @@ export MODFETCH_CONFIG=~/.config/modfetch/config.yml
 modfetch tui
 ```
 
+## Non-interactive snapshot
+
+Scripts and monitors can inspect the same persisted state without opening the
+interactive Bubble Tea interface:
+
+```bash
+modfetch tui --config /path/to/config.yml --snapshot
+modfetch tui --config /path/to/config.yml --snapshot --json
+```
+
+The snapshot reports download totals by status, active/pending/completed/failed
+rollups, library totals, favorite counts, library sources and model types, and
+the resolved data/download roots. It does not run the first-launch config
+wizard; missing configs return a CLI error.
+
 ## Layout overview
 
 The TUI has **7 tabs** that you can switch between:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -183,6 +183,15 @@ The TUI provides **7 tabs** for managing downloads and your model library:
 - Auto-resolves CivitAI model page URLs
 - Auto-recovery of running downloads on startup
 
+For automation, use the non-interactive snapshot path:
+
+```bash
+modfetch tui --config ~/.config/modfetch/config.yml --snapshot --json
+```
+
+This reports download status totals, library totals, favorite counts, source and
+type counts, and configured roots without opening the TUI.
+
 See the full TUI guide: docs/TUI_GUIDE.md
 
 ## Tips


### PR DESCRIPTION
## Summary
- add `modfetch tui --snapshot` for non-interactive state snapshots
- support `--snapshot --json` with downloads, library, and config state
- update completions, roadmap, changelog, TUI analysis, and user docs

## Validation
- `go test -count=1 ./cmd/modfetch -run 'TestHandleTUI|TestCompletion'`
- `go test -count=1 ./internal/tui/... ./cmd/modfetch`
- `go test -count=1 ./...`
- `go vet ./...`
- `scripts/check-docs-drift.sh`
- `scripts/check-aur-package.sh`
- `make build`
- real binary smoke: temp config + `library scan` + `tui --snapshot --json`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->