### PR TITLE
[codex] Add authenticated HTTP catalog sync push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Added
   targets, including dry-run and JSON output support.
 - Added HTTP(S) catalog pull targets for `library sync pull`, allowing a
   published catalog URL to be imported with the same dry-run/conflict handling.
+- Added HTTP(S) catalog push targets for `library sync push`, with optional
+  bearer auth from `--token-env` for both push and pull.
 - Added ModelScope metadata enrichment for `modelscope.cn` model URLs, including
   source detection, API-backed metadata, and best-effort fallback metadata.
 - Added `modfetch tui --snapshot` and `--snapshot --json` for non-interactive

--- a/README.md
+++ b/README.md
@@ -496,6 +496,6 @@ Roadmap
 - v0.7.x focus:
   - AUR package publication once maintainer SSH auth is available
   - Metadata enrichment from additional registries beyond ModelScope
-  - Authenticated and writable remote catalog sync targets
+  - Completed: authenticated HTTP(S) catalog sync push/pull
   - User-driven archive format expansion
   - Completed: non-interactive TUI snapshots with `modfetch tui --snapshot --json`

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The modfetch TUI provides a beautiful, full-featured interface for managing your
 
 ✅ **Production Ready:** Core download, verify, and TUI features are stable
 
-🚀 **Active Development:** AUR publication, catalog sync targets, and metadata enrichment
+🚀 **Active Development:** AUR publication and metadata enrichment
 
 📖 **Documentation:** Comprehensive guides with visual examples
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -42,7 +42,9 @@ go test -count=1 ./internal/tui/... ./cmd/modfetch
 These cover navigation, filter persistence, library filters, multi-select bulk
 actions, selected catalog export, settings rendering, config wizard validation,
 non-interactive TUI snapshots backed by a real SQLite state database, and shell
-completion drift for removed TUI selector flags.
+completion drift for removed TUI selector flags. The command package tests also
+exercise HTTP(S) catalog sync push/pull with real `httptest` servers and bearer
+headers.
 
 ## Manual Smoke
 

--- a/WARP.md
+++ b/WARP.md
@@ -13,6 +13,7 @@ Common commands
   - ./bin/modfetch download --config ~/.config/modfetch/config.yml --url 'hf://gpt2/README.md?rev=main'
   - TUI: ./bin/modfetch tui --config ~/.config/modfetch/config.yml
   - TUI snapshot: ./bin/modfetch tui --config ~/.config/modfetch/config.yml --snapshot --json
+  - Catalog sync push: ./bin/modfetch library sync push --config ~/.config/modfetch/config.yml --target https://example.com/modfetch-catalog.json --token-env MODFETCH_SYNC_TOKEN
 - Tests
   - All tests: make test (go test ./...)
   - With coverage: go test ./... -cover

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -87,7 +87,7 @@ _modfetch_completions()
                     if [[ ${cword} -eq 3 ]]; then
                         COMPREPLY=( $(compgen -W "push pull" -- "$cur") )
                     else
-                        COMPREPLY=( $(compgen -W "--config --log-level --json --target --dry-run" -- "$cur") )
+                        COMPREPLY=( $(compgen -W "--config --log-level --json --target --dry-run --token-env" -- "$cur") )
                     fi ;;
                 *) ;;
             esac ;;
@@ -176,7 +176,7 @@ _modfetch() {
             if (( CURRENT == 4 )); then
               _arguments '*:subcommands:(push pull)'
             else
-              _arguments '*:options:(--config --log-level --json --target --dry-run)'
+              _arguments '*:options:(--config --log-level --json --target --dry-run --token-env)'
             fi
             ;;
         esac
@@ -282,6 +282,7 @@ complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_su
 complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from sync" -a "pull" -d "Pull catalog from target"
 complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from sync" -l target -d "Catalog sync target"
 complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from sync" -l dry-run -d "Report without writing"
+complete -c modfetch -n "__fish_seen_subcommand_from library; and __fish_seen_subcommand_from sync" -l token-env -d "Bearer token environment variable"
 complete -c modfetch -n "__fish_seen_subcommand_from dedupe" -l mode -d "hardlink|symlink"
 complete -c modfetch -n "__fish_seen_subcommand_from dedupe" -l dry-run -d "Show dedupe changes without modifying files"
 # batch import flags

--- a/cmd/modfetch/completion_test.go
+++ b/cmd/modfetch/completion_test.go
@@ -61,15 +61,15 @@ func TestCompletionNestedSubcommandFlags(t *testing.T) {
 		case "bash":
 			assertContains(t, name, "config", configSection, "case ${words[2]}", "validate)", "wizard)", "--strict", "--out")
 			assertContains(t, name, "batch", batchSection, "case ${words[2]}", "import)", "--naming-pattern")
-			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "--target", "--dry-run")
+			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "--target", "--dry-run", "--token-env")
 		case "zsh":
 			assertContains(t, name, "config", configSection, "case $words[3]", "validate)", "wizard)", "--strict", "--out")
 			assertContains(t, name, "batch", batchSection, "case $words[3]", "import)", "--naming-pattern")
-			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "--target", "--dry-run")
+			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "--target", "--dry-run", "--token-env")
 		case "fish":
 			assertContains(t, name, "config", configSection, "and __fish_seen_subcommand_from validate", "and __fish_seen_subcommand_from wizard", "-l strict", "-l out")
 			assertContains(t, name, "batch", batchSection, "and __fish_seen_subcommand_from import", "-l naming-pattern")
-			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "-l target", "-l dry-run")
+			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "-l target", "-l dry-run", "-l token-env")
 		}
 	}
 }

--- a/cmd/modfetch/library_cmd.go
+++ b/cmd/modfetch/library_cmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -116,16 +117,13 @@ func handleLibrarySync(ctx context.Context, args []string) error {
 func handleLibrarySyncPush(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("library sync push", flag.ContinueOnError)
 	common := addCommonConfigLogFlags(fs, "print sync push result as JSON")
-	target := fs.String("target", "", "sync target URI or path; file:// targets and plain paths are supported")
+	target := fs.String("target", "", "sync target URI or path; file://, http://, https://, and plain paths are supported")
 	dryRun := fs.Bool("dry-run", false, "report without writing the target catalog")
+	tokenEnv := fs.String("token-env", "MODFETCH_SYNC_TOKEN", "environment variable containing a bearer token for HTTP(S) sync targets")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if err := ctx.Err(); err != nil {
-		return err
-	}
-	targetPath, err := fileSyncTargetPath(*target)
-	if err != nil {
 		return err
 	}
 	db, err := openLibraryDB(*common.configPath)
@@ -138,17 +136,28 @@ func handleLibrarySyncPush(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if !*dryRun {
-		if err := writeCatalogFile(targetPath, cat); err != nil {
-			return err
-		}
-	}
 	result := librarySyncPushResult{
 		Action: "push",
 		Target: *target,
-		Path:   targetPath,
 		Models: len(cat.Models),
 		DryRun: *dryRun,
+	}
+	if !*dryRun {
+		outcome, err := writeCatalogSyncTarget(ctx, *target, cat, *tokenEnv)
+		if err != nil {
+			return err
+		}
+		result.Path = outcome.Path
+		result.Method = outcome.Method
+		result.Status = outcome.Status
+		result.Authenticated = outcome.Authenticated
+	} else {
+		outcome, err := describeCatalogSyncTarget(*target)
+		if err != nil {
+			return err
+		}
+		result.Path = outcome.Path
+		result.Method = outcome.Method
 	}
 	if *common.jsonOut {
 		enc := json.NewEncoder(os.Stdout)
@@ -156,9 +165,9 @@ func handleLibrarySyncPush(ctx context.Context, args []string) error {
 		return enc.Encode(result)
 	}
 	if *dryRun {
-		fmt.Printf("Sync push dry-run: target=%s models=%d\n", targetPath, len(cat.Models))
+		fmt.Printf("Sync push dry-run: target=%s models=%d\n", result.DisplayTarget(), len(cat.Models))
 	} else {
-		fmt.Printf("Sync push complete: target=%s models=%d\n", targetPath, len(cat.Models))
+		fmt.Printf("Sync push complete: target=%s models=%d\n", result.DisplayTarget(), len(cat.Models))
 	}
 	return nil
 }
@@ -168,13 +177,14 @@ func handleLibrarySyncPull(ctx context.Context, args []string) error {
 	common := addCommonConfigLogFlags(fs, "print sync pull result as JSON")
 	target := fs.String("target", "", "sync target URI or path; file://, http://, https://, and plain paths are supported")
 	dryRun := fs.Bool("dry-run", false, "report changes without writing to the library")
+	tokenEnv := fs.String("token-env", "MODFETCH_SYNC_TOKEN", "environment variable containing a bearer token for HTTP(S) sync targets")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	r, closeFn, err := syncTargetReader(ctx, *target)
+	r, closeFn, err := syncTargetReader(ctx, *target, *tokenEnv)
 	if err != nil {
 		return err
 	}
@@ -193,11 +203,21 @@ func handleLibrarySyncPull(ctx context.Context, args []string) error {
 }
 
 type librarySyncPushResult struct {
-	Action string `json:"action"`
-	Target string `json:"target"`
-	Path   string `json:"path"`
-	Models int    `json:"models"`
-	DryRun bool   `json:"dry_run"`
+	Action        string `json:"action"`
+	Target        string `json:"target"`
+	Path          string `json:"path,omitempty"`
+	Method        string `json:"method,omitempty"`
+	Status        string `json:"status,omitempty"`
+	Models        int    `json:"models"`
+	DryRun        bool   `json:"dry_run"`
+	Authenticated bool   `json:"authenticated,omitempty"`
+}
+
+func (r librarySyncPushResult) DisplayTarget() string {
+	if r.Path != "" {
+		return r.Path
+	}
+	return r.Target
 }
 
 func printCatalogImportResult(result *catalog.ImportResult, jsonOut bool) error {
@@ -363,7 +383,7 @@ func outputWriter(path string) (io.Writer, func(), error) {
 	return f, func() { _ = f.Close() }, nil
 }
 
-func syncTargetReader(ctx context.Context, target string) (io.Reader, func(), error) {
+func syncTargetReader(ctx context.Context, target, tokenEnv string) (io.Reader, func(), error) {
 	target = strings.TrimSpace(target)
 	if target == "" {
 		return nil, func() {}, errors.New("library sync requires --target")
@@ -394,6 +414,9 @@ func syncTargetReader(ctx context.Context, target string) (io.Reader, func(), er
 		return nil, func() {}, fmt.Errorf("create sync request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
+	if _, err := addBearerAuthFromEnv(req, tokenEnv); err != nil {
+		return nil, func() {}, err
+	}
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -404,6 +427,96 @@ func syncTargetReader(ctx context.Context, target string) (io.Reader, func(), er
 		return nil, func() {}, fmt.Errorf("fetch sync target: HTTP %s", resp.Status)
 	}
 	return resp.Body, func() { _ = resp.Body.Close() }, nil
+}
+
+type catalogSyncWriteOutcome struct {
+	Path          string
+	Method        string
+	Status        string
+	Authenticated bool
+}
+
+func writeCatalogSyncTarget(ctx context.Context, target string, cat *catalog.Catalog, tokenEnv string) (catalogSyncWriteOutcome, error) {
+	outcome, err := describeCatalogSyncTarget(target)
+	if err != nil {
+		return outcome, err
+	}
+	if outcome.Method == "file" {
+		if err := writeCatalogFile(outcome.Path, cat); err != nil {
+			return outcome, err
+		}
+		return outcome, nil
+	}
+
+	var body bytes.Buffer
+	enc := json.NewEncoder(&body)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(cat); err != nil {
+		return outcome, fmt.Errorf("encode catalog: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, target, &body)
+	if err != nil {
+		return outcome, fmt.Errorf("create sync push request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	authenticated, err := addBearerAuthFromEnv(req, tokenEnv)
+	if err != nil {
+		return outcome, err
+	}
+	outcome.Authenticated = authenticated
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return outcome, fmt.Errorf("push sync target: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	outcome.Status = resp.Status
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return outcome, fmt.Errorf("push sync target: HTTP %s", resp.Status)
+	}
+	return outcome, nil
+}
+
+func describeCatalogSyncTarget(target string) (catalogSyncWriteOutcome, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return catalogSyncWriteOutcome{}, errors.New("library sync requires --target")
+	}
+	if !isURITarget(target) || strings.HasPrefix(strings.ToLower(target), "file:") {
+		path, err := fileSyncTargetPath(target)
+		if err != nil {
+			return catalogSyncWriteOutcome{}, err
+		}
+		return catalogSyncWriteOutcome{Path: path, Method: "file"}, nil
+	}
+	u, err := url.Parse(target)
+	if err != nil {
+		return catalogSyncWriteOutcome{}, fmt.Errorf("parse sync target: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return catalogSyncWriteOutcome{}, fmt.Errorf("unsupported sync target scheme %q; push supports file://, http://, and https://", u.Scheme)
+	}
+	if u.Fragment != "" {
+		return catalogSyncWriteOutcome{}, errors.New("HTTP sync target must not include a fragment")
+	}
+	return catalogSyncWriteOutcome{Method: http.MethodPut}, nil
+}
+
+func addBearerAuthFromEnv(req *http.Request, tokenEnv string) (bool, error) {
+	tokenEnv = strings.TrimSpace(tokenEnv)
+	if tokenEnv == "" {
+		return false, nil
+	}
+	token := strings.TrimSpace(os.Getenv(tokenEnv))
+	if token == "" {
+		if tokenEnv == "MODFETCH_SYNC_TOKEN" {
+			return false, nil
+		}
+		return false, fmt.Errorf("sync token environment variable %s is not set", tokenEnv)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	return true, nil
 }
 
 func fileSyncTargetPath(target string) (string, error) {

--- a/cmd/modfetch/library_cmd.go
+++ b/cmd/modfetch/library_cmd.go
@@ -254,7 +254,30 @@ const (
 	allowInsecureSyncHTTPEnv = "MODFETCH_ALLOW_INSECURE_HTTP"
 )
 
-var syncHTTPClient = &http.Client{Timeout: 30 * time.Second}
+var syncHTTPClient = &http.Client{
+	Timeout:       30 * time.Second,
+	CheckRedirect: checkSyncRedirect,
+}
+
+func checkSyncRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+	first := via[0]
+	if first.Method != http.MethodGet && first.Method != http.MethodHead {
+		return errors.New("refusing to redirect non-GET sync request")
+	}
+	if first.Header.Get("Authorization") == "" {
+		return nil
+	}
+	if first.URL == nil || req.URL == nil {
+		return errors.New("refusing to redirect authenticated sync request without a URL")
+	}
+	if !strings.EqualFold(first.URL.Scheme, req.URL.Scheme) || !strings.EqualFold(first.URL.Host, req.URL.Host) {
+		return errors.New("refusing to redirect authenticated sync request across scheme or host")
+	}
+	return nil
+}
 
 func (f *stringListFlag) String() string {
 	return strings.Join(*f, ",")

--- a/cmd/modfetch/library_cmd.go
+++ b/cmd/modfetch/library_cmd.go
@@ -249,6 +249,13 @@ func printCatalogImportResult(result *catalog.ImportResult, jsonOut bool) error 
 
 type stringListFlag []string
 
+const (
+	defaultSyncTokenEnv      = "MODFETCH_SYNC_TOKEN"
+	allowInsecureSyncHTTPEnv = "MODFETCH_ALLOW_INSECURE_HTTP"
+)
+
+var syncHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
 func (f *stringListFlag) String() string {
 	return strings.Join(*f, ",")
 }
@@ -417,14 +424,14 @@ func syncTargetReader(ctx context.Context, target, tokenEnv string) (io.Reader, 
 	if _, err := addBearerAuthFromEnv(req, tokenEnv); err != nil {
 		return nil, func() {}, err
 	}
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := syncHTTPClient.Do(req)
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("fetch sync target: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		statusErr := httpStatusError("fetch sync target", resp)
 		_ = resp.Body.Close()
-		return nil, func() {}, fmt.Errorf("fetch sync target: HTTP %s", resp.Status)
+		return nil, func() {}, statusErr
 	}
 	return resp.Body, func() { _ = resp.Body.Close() }, nil
 }
@@ -437,6 +444,7 @@ type catalogSyncWriteOutcome struct {
 }
 
 func writeCatalogSyncTarget(ctx context.Context, target string, cat *catalog.Catalog, tokenEnv string) (catalogSyncWriteOutcome, error) {
+	target = strings.TrimSpace(target)
 	outcome, err := describeCatalogSyncTarget(target)
 	if err != nil {
 		return outcome, err
@@ -450,7 +458,6 @@ func writeCatalogSyncTarget(ctx context.Context, target string, cat *catalog.Cat
 
 	var body bytes.Buffer
 	enc := json.NewEncoder(&body)
-	enc.SetIndent("", "  ")
 	if err := enc.Encode(cat); err != nil {
 		return outcome, fmt.Errorf("encode catalog: %w", err)
 	}
@@ -465,15 +472,14 @@ func writeCatalogSyncTarget(ctx context.Context, target string, cat *catalog.Cat
 		return outcome, err
 	}
 	outcome.Authenticated = authenticated
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := syncHTTPClient.Do(req)
 	if err != nil {
 		return outcome, fmt.Errorf("push sync target: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	outcome.Status = resp.Status
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return outcome, fmt.Errorf("push sync target: HTTP %s", resp.Status)
+		return outcome, httpStatusError("push sync target", resp)
 	}
 	return outcome, nil
 }
@@ -510,13 +516,27 @@ func addBearerAuthFromEnv(req *http.Request, tokenEnv string) (bool, error) {
 	}
 	token := strings.TrimSpace(os.Getenv(tokenEnv))
 	if token == "" {
-		if tokenEnv == "MODFETCH_SYNC_TOKEN" {
+		if tokenEnv == defaultSyncTokenEnv {
 			return false, nil
 		}
 		return false, fmt.Errorf("sync token environment variable %s is not set", tokenEnv)
 	}
+	if req.URL == nil || req.URL.Scheme != "https" {
+		if strings.TrimSpace(os.Getenv(allowInsecureSyncHTTPEnv)) != "1" {
+			return false, fmt.Errorf("refusing to send bearer auth to a non-HTTPS sync target; set %s=1 to allow local or otherwise trusted HTTP sync", allowInsecureSyncHTTPEnv)
+		}
+	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	return true, nil
+}
+
+func httpStatusError(action string, resp *http.Response) error {
+	detailBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	detail := strings.TrimSpace(string(detailBytes))
+	if detail == "" {
+		return fmt.Errorf("%s: HTTP %s", action, resp.Status)
+	}
+	return fmt.Errorf("%s: HTTP %s: %s", action, resp.Status, detail)
 }
 
 func fileSyncTargetPath(target string) (string, error) {

--- a/cmd/modfetch/library_cmd.go
+++ b/cmd/modfetch/library_cmd.go
@@ -184,16 +184,16 @@ func handleLibrarySyncPull(ctx context.Context, args []string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	r, closeFn, err := syncTargetReader(ctx, *target, *tokenEnv)
-	if err != nil {
-		return err
-	}
-	defer closeFn()
 	db, err := openLibraryDB(*common.configPath)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = db.Close() }()
+	r, closeFn, err := syncTargetReader(ctx, *target, *tokenEnv)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
 
 	result, err := catalog.Import(db, r, catalog.ImportOptions{DryRun: *dryRun})
 	if err != nil {

--- a/cmd/modfetch/library_cmd.go
+++ b/cmd/modfetch/library_cmd.go
@@ -119,13 +119,14 @@ func handleLibrarySyncPush(ctx context.Context, args []string) error {
 	common := addCommonConfigLogFlags(fs, "print sync push result as JSON")
 	target := fs.String("target", "", "sync target URI or path; file://, http://, https://, and plain paths are supported")
 	dryRun := fs.Bool("dry-run", false, "report without writing the target catalog")
-	tokenEnv := fs.String("token-env", "MODFETCH_SYNC_TOKEN", "environment variable containing a bearer token for HTTP(S) sync targets")
+	tokenEnv := fs.String("token-env", defaultSyncTokenEnv, "environment variable containing a bearer token for HTTP(S) sync targets")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	syncTarget := strings.TrimSpace(*target)
 	db, err := openLibraryDB(*common.configPath)
 	if err != nil {
 		return err
@@ -138,12 +139,12 @@ func handleLibrarySyncPush(ctx context.Context, args []string) error {
 	}
 	result := librarySyncPushResult{
 		Action: "push",
-		Target: *target,
+		Target: syncTarget,
 		Models: len(cat.Models),
 		DryRun: *dryRun,
 	}
 	if !*dryRun {
-		outcome, err := writeCatalogSyncTarget(ctx, *target, cat, *tokenEnv)
+		outcome, err := writeCatalogSyncTarget(ctx, syncTarget, cat, *tokenEnv)
 		if err != nil {
 			return err
 		}
@@ -152,7 +153,7 @@ func handleLibrarySyncPush(ctx context.Context, args []string) error {
 		result.Status = outcome.Status
 		result.Authenticated = outcome.Authenticated
 	} else {
-		outcome, err := describeCatalogSyncTarget(*target)
+		outcome, err := describeCatalogSyncTarget(syncTarget)
 		if err != nil {
 			return err
 		}
@@ -177,19 +178,20 @@ func handleLibrarySyncPull(ctx context.Context, args []string) error {
 	common := addCommonConfigLogFlags(fs, "print sync pull result as JSON")
 	target := fs.String("target", "", "sync target URI or path; file://, http://, https://, and plain paths are supported")
 	dryRun := fs.Bool("dry-run", false, "report changes without writing to the library")
-	tokenEnv := fs.String("token-env", "MODFETCH_SYNC_TOKEN", "environment variable containing a bearer token for HTTP(S) sync targets")
+	tokenEnv := fs.String("token-env", defaultSyncTokenEnv, "environment variable containing a bearer token for HTTP(S) sync targets")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	syncTarget := strings.TrimSpace(*target)
 	db, err := openLibraryDB(*common.configPath)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = db.Close() }()
-	r, closeFn, err := syncTargetReader(ctx, *target, *tokenEnv)
+	r, closeFn, err := syncTargetReader(ctx, syncTarget, *tokenEnv)
 	if err != nil {
 		return err
 	}
@@ -273,10 +275,40 @@ func checkSyncRedirect(req *http.Request, via []*http.Request) error {
 	if first.URL == nil || req.URL == nil {
 		return errors.New("refusing to redirect authenticated sync request without a URL")
 	}
-	if !strings.EqualFold(first.URL.Scheme, req.URL.Scheme) || !strings.EqualFold(first.URL.Host, req.URL.Host) {
+	if !sameNormalizedOrigin(first.URL, req.URL) {
 		return errors.New("refusing to redirect authenticated sync request across scheme or host")
 	}
 	return nil
+}
+
+func sameNormalizedOrigin(a, b *url.URL) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if !strings.EqualFold(a.Scheme, b.Scheme) {
+		return false
+	}
+	if !strings.EqualFold(a.Hostname(), b.Hostname()) {
+		return false
+	}
+	return effectiveURLPort(a) == effectiveURLPort(b)
+}
+
+func effectiveURLPort(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	if port := u.Port(); port != "" {
+		return port
+	}
+	switch {
+	case strings.EqualFold(u.Scheme, "http"):
+		return "80"
+	case strings.EqualFold(u.Scheme, "https"):
+		return "443"
+	default:
+		return ""
+	}
 }
 
 func (f *stringListFlag) String() string {

--- a/cmd/modfetch/library_cmd_test.go
+++ b/cmd/modfetch/library_cmd_test.go
@@ -444,6 +444,21 @@ func TestHandleLibrarySyncPullHTTPStatusError(t *testing.T) {
 	}
 }
 
+func TestHandleLibrarySyncPullInvalidConfigDoesNotContactHTTPTarget(t *testing.T) {
+	missingCfg := filepath.Join(t.TempDir(), "missing.yml")
+	t.Setenv("MODFETCH_TEST_SYNC_TOKEN", "secret-token")
+	t.Setenv("MODFETCH_ALLOW_INSECURE_HTTP", "1")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("invalid config should fail before contacting HTTP target")
+	}))
+	defer server.Close()
+
+	err := handleLibrary(context.Background(), []string{"sync", "pull", "--config", missingCfg, "--target", server.URL, "--token-env", "MODFETCH_TEST_SYNC_TOKEN"})
+	if err == nil || !strings.Contains(err.Error(), "config file not found") {
+		t.Fatalf("expected config error before HTTP request, got %v", err)
+	}
+}
+
 func TestCheckSyncRedirectRejectsUnsafeRedirects(t *testing.T) {
 	putReq, err := http.NewRequest(http.MethodPut, "https://sync.example/catalog.json", nil)
 	if err != nil {

--- a/cmd/modfetch/library_cmd_test.go
+++ b/cmd/modfetch/library_cmd_test.go
@@ -444,6 +444,49 @@ func TestHandleLibrarySyncPullHTTPStatusError(t *testing.T) {
 	}
 }
 
+func TestCheckSyncRedirectRejectsUnsafeRedirects(t *testing.T) {
+	putReq, err := http.NewRequest(http.MethodPut, "https://sync.example/catalog.json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nextReq, err := http.NewRequest(http.MethodGet, "https://sync.example/catalog.json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkSyncRedirect(nextReq, []*http.Request{putReq}); err == nil || !strings.Contains(err.Error(), "non-GET") {
+		t.Fatalf("expected non-GET redirect rejection, got %v", err)
+	}
+
+	authReq, err := http.NewRequest(http.MethodGet, "https://sync.example/catalog.json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authReq.Header.Set("Authorization", "Bearer token")
+	downgradeReq, err := http.NewRequest(http.MethodGet, "http://sync.example/catalog.json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkSyncRedirect(downgradeReq, []*http.Request{authReq}); err == nil || !strings.Contains(err.Error(), "scheme or host") {
+		t.Fatalf("expected authenticated downgrade rejection, got %v", err)
+	}
+
+	crossHostReq, err := http.NewRequest(http.MethodGet, "https://other.example/catalog.json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkSyncRedirect(crossHostReq, []*http.Request{authReq}); err == nil || !strings.Contains(err.Error(), "scheme or host") {
+		t.Fatalf("expected authenticated cross-host rejection, got %v", err)
+	}
+
+	sameHostReq, err := http.NewRequest(http.MethodGet, "https://sync.example/next.json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkSyncRedirect(sameHostReq, []*http.Request{authReq}); err != nil {
+		t.Fatalf("same-host authenticated redirect should be allowed: %v", err)
+	}
+}
+
 func TestFileSyncTargetPathTreatsDriveLetterAsPlainPath(t *testing.T) {
 	target := `C:\backup\catalog.json`
 	got, err := fileSyncTargetPath(target)

--- a/cmd/modfetch/library_cmd_test.go
+++ b/cmd/modfetch/library_cmd_test.go
@@ -205,11 +205,91 @@ func TestHandleLibrarySyncPushDryRunDoesNotWriteTarget(t *testing.T) {
 	}
 }
 
+func TestHandleLibrarySyncPushHTTPTargetWithBearerToken(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeLibraryConfig(t, filepath.Join(dir, "cfg"))
+	db, err := state.Open(&config.Config{General: config.General{
+		DataRoot:     filepath.Join(dir, "cfg", "data"),
+		DownloadRoot: filepath.Join(dir, "cfg", "downloads"),
+	}})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.UpsertMetadata(&state.ModelMetadata{
+		DownloadURL: "https://example.com/http-pushed.gguf",
+		Dest:        filepath.Join(dir, "cfg", "downloads", "http-pushed.gguf"),
+		ModelName:   "HTTP Pushed Model",
+		Source:      "direct",
+	}); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	t.Setenv("MODFETCH_TEST_SYNC_TOKEN", "secret-token")
+	var received bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = true
+		if r.Method != http.MethodPut {
+			t.Errorf("unexpected method %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret-token" {
+			t.Errorf("unexpected authorization header %q", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("unexpected content-type %q", got)
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode pushed catalog: %v", err)
+		}
+		if payload["app"] != "modfetch" {
+			t.Errorf("unexpected catalog app %v", payload["app"])
+		}
+		models, ok := payload["models"].([]any)
+		if !ok || len(models) != 1 {
+			t.Errorf("unexpected catalog models %v", payload["models"])
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	out := captureStdout(t, func() {
+		if err := handleLibrary(context.Background(), []string{"sync", "push", "--config", cfgPath, "--target", server.URL, "--token-env", "MODFETCH_TEST_SYNC_TOKEN", "--json"}); err != nil {
+			t.Fatalf("library sync push HTTP: %v", err)
+		}
+	})
+	if !received {
+		t.Fatal("expected HTTP sync target to receive a request")
+	}
+	var result librarySyncPushResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode sync push result: %v\n%s", err, out)
+	}
+	if result.Method != http.MethodPut || result.Status != "201 Created" || !result.Authenticated || result.Models != 1 {
+		t.Fatalf("unexpected sync push result: %+v", result)
+	}
+}
+
+func TestHandleLibrarySyncPushHTTPDryRunDoesNotContactTarget(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeLibraryConfig(t, filepath.Join(dir, "cfg"))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("dry-run should not contact HTTP target")
+	}))
+	defer server.Close()
+
+	if err := handleLibrary(context.Background(), []string{"sync", "push", "--config", cfgPath, "--target", server.URL, "--dry-run"}); err != nil {
+		t.Fatalf("library sync push HTTP dry-run: %v", err)
+	}
+}
+
 func TestHandleLibrarySyncRejectsUnsupportedTarget(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := writeLibraryConfig(t, filepath.Join(dir, "cfg"))
 
-	err := handleLibrary(context.Background(), []string{"sync", "push", "--config", cfgPath, "--target", "https://example.com/catalog.json"})
+	err := handleLibrary(context.Background(), []string{"sync", "push", "--config", cfgPath, "--target", "s3://example/catalog.json"})
 	if err == nil || !strings.Contains(err.Error(), "unsupported sync target scheme") {
 		t.Fatalf("expected unsupported target scheme error, got %v", err)
 	}
@@ -279,6 +359,56 @@ func TestHandleLibrarySyncPullHTTPTarget(t *testing.T) {
 		t.Fatalf("get HTTP synced metadata: %v", err)
 	}
 	if meta.ModelName != "HTTP Synced Model" || !meta.Favorite {
+		t.Fatalf("unexpected HTTP metadata: %+v", meta)
+	}
+}
+
+func TestHandleLibrarySyncPullHTTPTargetWithBearerToken(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeLibraryConfig(t, filepath.Join(dir, "cfg"))
+	payload, err := json.Marshal(map[string]any{
+		"app":             "modfetch",
+		"catalog_version": 1,
+		"models": []map[string]any{{
+			"metadata": map[string]any{
+				"download_url": "https://example.com/auth-http-synced.gguf",
+				"dest":         filepath.Join(dir, "downloads", "auth-http-synced.gguf"),
+				"model_name":   "Auth HTTP Synced Model",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("MODFETCH_TEST_SYNC_TOKEN", "secret-token")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret-token" {
+			t.Errorf("unexpected authorization header %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	if err := handleLibrary(context.Background(), []string{"sync", "pull", "--config", cfgPath, "--target", server.URL, "--token-env", "MODFETCH_TEST_SYNC_TOKEN"}); err != nil {
+		t.Fatalf("library sync pull HTTP with token: %v", err)
+	}
+	db, err := state.Open(&config.Config{General: config.General{
+		DataRoot:     filepath.Join(dir, "cfg", "data"),
+		DownloadRoot: filepath.Join(dir, "cfg", "downloads"),
+	}})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	meta, err := db.GetMetadata("https://example.com/auth-http-synced.gguf")
+	if err != nil {
+		t.Fatalf("get HTTP synced metadata: %v", err)
+	}
+	if meta.ModelName != "Auth HTTP Synced Model" {
 		t.Fatalf("unexpected HTTP metadata: %+v", meta)
 	}
 }

--- a/cmd/modfetch/library_cmd_test.go
+++ b/cmd/modfetch/library_cmd_test.go
@@ -205,7 +205,7 @@ func TestHandleLibrarySyncPushDryRunDoesNotWriteTarget(t *testing.T) {
 	}
 }
 
-func TestHandleLibrarySyncPushHTTPTargetWithBearerToken(t *testing.T) {
+func TestHandleLibrarySyncPushHTTPTargetWithDefaultBearerToken(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := writeLibraryConfig(t, filepath.Join(dir, "cfg"))
 	db, err := state.Open(&config.Config{General: config.General{
@@ -227,10 +227,11 @@ func TestHandleLibrarySyncPushHTTPTargetWithBearerToken(t *testing.T) {
 		t.Fatalf("close db: %v", err)
 	}
 
-	t.Setenv("MODFETCH_TEST_SYNC_TOKEN", "secret-token")
-	var received bool
+	t.Setenv("MODFETCH_SYNC_TOKEN", "secret-token")
+	t.Setenv("MODFETCH_ALLOW_INSECURE_HTTP", "1")
+	received := make(chan struct{}, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		received = true
+		received <- struct{}{}
 		if r.Method != http.MethodPut {
 			t.Errorf("unexpected method %s", r.Method)
 		}
@@ -256,11 +257,13 @@ func TestHandleLibrarySyncPushHTTPTargetWithBearerToken(t *testing.T) {
 	defer server.Close()
 
 	out := captureStdout(t, func() {
-		if err := handleLibrary(context.Background(), []string{"sync", "push", "--config", cfgPath, "--target", server.URL, "--token-env", "MODFETCH_TEST_SYNC_TOKEN", "--json"}); err != nil {
+		if err := handleLibrary(context.Background(), []string{"sync", "push", "--config", cfgPath, "--target", server.URL, "--json"}); err != nil {
 			t.Fatalf("library sync push HTTP: %v", err)
 		}
 	})
-	if !received {
+	select {
+	case <-received:
+	default:
 		t.Fatal("expected HTTP sync target to receive a request")
 	}
 	var result librarySyncPushResult
@@ -269,6 +272,21 @@ func TestHandleLibrarySyncPushHTTPTargetWithBearerToken(t *testing.T) {
 	}
 	if result.Method != http.MethodPut || result.Status != "201 Created" || !result.Authenticated || result.Models != 1 {
 		t.Fatalf("unexpected sync push result: %+v", result)
+	}
+}
+
+func TestHandleLibrarySyncPushHTTPRefusesBearerTokenWithoutTLS(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeLibraryConfig(t, filepath.Join(dir, "cfg"))
+	t.Setenv("MODFETCH_SYNC_TOKEN", "secret-token")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("insecure bearer auth should fail before contacting HTTP target")
+	}))
+	defer server.Close()
+
+	err := handleLibrary(context.Background(), []string{"sync", "push", "--config", cfgPath, "--target", server.URL})
+	if err == nil || !strings.Contains(err.Error(), "refusing to send bearer auth to a non-HTTPS sync target") {
+		t.Fatalf("expected insecure bearer auth error, got %v", err)
 	}
 }
 
@@ -381,6 +399,7 @@ func TestHandleLibrarySyncPullHTTPTargetWithBearerToken(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("MODFETCH_TEST_SYNC_TOKEN", "secret-token")
+	t.Setenv("MODFETCH_ALLOW_INSECURE_HTTP", "1")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("unexpected method %s", r.Method)

--- a/cmd/modfetch/library_cmd_test.go
+++ b/cmd/modfetch/library_cmd_test.go
@@ -256,8 +256,9 @@ func TestHandleLibrarySyncPushHTTPTargetWithDefaultBearerToken(t *testing.T) {
 	}))
 	defer server.Close()
 
+	targetWithWhitespace := "  " + server.URL + "  "
 	out := captureStdout(t, func() {
-		if err := handleLibrary(context.Background(), []string{"sync", "push", "--config", cfgPath, "--target", server.URL, "--json"}); err != nil {
+		if err := handleLibrary(context.Background(), []string{"sync", "push", "--config", cfgPath, "--target", targetWithWhitespace, "--json"}); err != nil {
 			t.Fatalf("library sync push HTTP: %v", err)
 		}
 	})
@@ -272,6 +273,9 @@ func TestHandleLibrarySyncPushHTTPTargetWithDefaultBearerToken(t *testing.T) {
 	}
 	if result.Method != http.MethodPut || result.Status != "201 Created" || !result.Authenticated || result.Models != 1 {
 		t.Fatalf("unexpected sync push result: %+v", result)
+	}
+	if result.Target != server.URL {
+		t.Fatalf("sync push result target = %q, want %q", result.Target, server.URL)
 	}
 }
 
@@ -300,6 +304,20 @@ func TestHandleLibrarySyncPushHTTPDryRunDoesNotContactTarget(t *testing.T) {
 
 	if err := handleLibrary(context.Background(), []string{"sync", "push", "--config", cfgPath, "--target", server.URL, "--dry-run"}); err != nil {
 		t.Fatalf("library sync push HTTP dry-run: %v", err)
+	}
+}
+
+func TestHandleLibrarySyncPushHTTPStatusErrorIncludesBody(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeLibraryConfig(t, filepath.Join(dir, "cfg"))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "catalog rejected", http.StatusTeapot)
+	}))
+	defer server.Close()
+
+	err := handleLibrary(context.Background(), []string{"sync", "push", "--config", cfgPath, "--target", server.URL})
+	if err == nil || !strings.Contains(err.Error(), "HTTP 418") || !strings.Contains(err.Error(), "catalog rejected") {
+		t.Fatalf("expected HTTP status and body in sync push error, got %v", err)
 	}
 }
 
@@ -499,6 +517,14 @@ func TestCheckSyncRedirectRejectsUnsafeRedirects(t *testing.T) {
 	}
 	if err := checkSyncRedirect(sameHostReq, []*http.Request{authReq}); err != nil {
 		t.Fatalf("same-host authenticated redirect should be allowed: %v", err)
+	}
+
+	defaultPortReq, err := http.NewRequest(http.MethodGet, "https://sync.example:443/next.json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkSyncRedirect(defaultPortReq, []*http.Request{authReq}); err != nil {
+		t.Fatalf("same-origin authenticated redirect with explicit default port should be allowed: %v", err)
 	}
 }
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -725,7 +725,7 @@ fi
 | `HF_TOKEN` | HuggingFace API token |
 | `CIVITAI_TOKEN` | CivitAI API token |
 | `MODFETCH_SYNC_TOKEN` | Default bearer token env var used by `--token-env` for HTTP(S) `library sync` targets |
-| `MODFETCH_ALLOW_INSECURE_HTTP` | Set to `1` only to allow bearer auth over trusted plain-HTTP sync targets |
+| `MODFETCH_ALLOW_INSECURE_HTTP` | Set to `1` only to allow bearer auth over trusted plain HTTP sync targets |
 
 **Example:**
 ```bash

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -218,6 +218,8 @@ Sync targets build on the same catalog schema and import conflict behavior.
 using `PUT`. Pull supports those local targets plus `http://` and `https://`
 catalog URLs. HTTP(S) push and pull can add `Authorization: Bearer ...` from an
 environment variable without storing secrets in the config file.
+Bearer tokens are only sent to HTTPS targets unless
+`MODFETCH_ALLOW_INSECURE_HTTP=1` is set for trusted local HTTP test endpoints.
 
 Sync options:
 - `--target URI` - sync target URI or path
@@ -722,12 +724,15 @@ fi
 | `MODFETCH_CONFIG` | Default config file path |
 | `HF_TOKEN` | HuggingFace API token |
 | `CIVITAI_TOKEN` | CivitAI API token |
+| `MODFETCH_SYNC_TOKEN` | Default bearer token env var used by `--token-env` for HTTP(S) `library sync` targets |
+| `MODFETCH_ALLOW_INSECURE_HTTP` | Set to `1` only to allow bearer auth over trusted plain-HTTP sync targets |
 
 **Example:**
 ```bash
 export MODFETCH_CONFIG=~/.config/modfetch/config.yml
 export HF_TOKEN="hf_..."
 export CIVITAI_TOKEN="..."
+export MODFETCH_SYNC_TOKEN="..."
 
 modfetch download --url 'hf://private/repo/model.gguf'
 ```

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -177,11 +177,15 @@ modfetch library import --input modfetch-catalog.json --json
 # Push the current catalog to a filesystem sync target
 modfetch library sync push --target file:///srv/modfetch/catalog.json
 
+# Push the current catalog to an HTTP(S) target with bearer auth
+export MODFETCH_SYNC_TOKEN="..."
+modfetch library sync push --target https://example.com/modfetch-catalog.json --token-env MODFETCH_SYNC_TOKEN
+
 # Preview pulling updates from a filesystem sync target
 modfetch library sync pull --target file:///srv/modfetch/catalog.json --dry-run
 
-# Preview pulling updates from a published HTTP(S) catalog
-modfetch library sync pull --target https://example.com/modfetch-catalog.json --dry-run
+# Preview pulling updates from a published or authenticated HTTP(S) catalog
+modfetch library sync pull --target https://example.com/modfetch-catalog.json --token-env MODFETCH_SYNC_TOKEN --dry-run
 ```
 
 `library scan` recognizes `.gguf`, `.ggml`, `.safetensors`, `.ckpt`, `.pt`,
@@ -208,16 +212,19 @@ Import is idempotent:
 - destination collisions with a different source URL are reported as `conflict`
 
 Sync targets build on the same catalog schema and import conflict behavior.
-`library sync push` writes the current catalog to a local target, and
+`library sync push` writes the current catalog to a local or remote target, and
 `library sync pull` imports from a local or remote target. Push supports
-`file://` and plain filesystem paths, which are useful for shared folders,
-mounted drives, and locally validated sync workflows. Pull supports those local
-targets plus read-only `http://` and `https://` catalog URLs.
+`file://`, plain filesystem paths, and writable `http://` or `https://` targets
+using `PUT`. Pull supports those local targets plus `http://` and `https://`
+catalog URLs. HTTP(S) push and pull can add `Authorization: Bearer ...` from an
+environment variable without storing secrets in the config file.
 
 Sync options:
 - `--target URI` - sync target URI or path
 - `--dry-run` - for `push`, report without writing the target; for `pull`, report
   import changes without writing to the local library
+- `--token-env NAME` - read a bearer token for HTTP(S) targets from this
+  environment variable; defaults to `MODFETCH_SYNC_TOKEN` when set
 - `--json` - print the push or pull result as JSON
 
 ### dedupe

--- a/docs/COMPLETIONS.md
+++ b/docs/COMPLETIONS.md
@@ -29,6 +29,7 @@ Notable flags and commands covered
 - --quiet, --json, --log-level
 - --summary-json, --no-resume, --batch-parallel, --naming-pattern, --no-auth-preflight, --dry-run
 - --strict, --force, --quant, --list-quants
+- library sync --target, --dry-run, --token-env
 - tui --snapshot for non-interactive state snapshots
 
 Notes

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -79,6 +79,8 @@ Strict validation is intended as a v1.0 readiness check. Regular validation rema
   - `CIVITAI_TOKEN`: CivitAI token (Bearer), used when sources.civitai.enabled is true
   - `MODFETCH_SYNC_TOKEN`: optional bearer token for HTTP(S) `library sync`
     targets; override the env name with `--token-env`
+  - `MODFETCH_ALLOW_INSECURE_HTTP=1`: opt in to sending sync bearer auth over
+    trusted plain-HTTP endpoints, primarily for local testing
 - Do not print secrets back to the terminal; export them in your shell profile or a secure env file
 
 ## Resolver cache

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -80,7 +80,7 @@ Strict validation is intended as a v1.0 readiness check. Regular validation rema
   - `MODFETCH_SYNC_TOKEN`: optional bearer token for HTTP(S) `library sync`
     targets; override the env name with `--token-env`
   - `MODFETCH_ALLOW_INSECURE_HTTP=1`: opt in to sending sync bearer auth over
-    trusted plain-HTTP endpoints, primarily for local testing
+    trusted plain HTTP endpoints, primarily for local testing
 - Do not print secrets back to the terminal; export them in your shell profile or a secure env file
 
 ## Resolver cache

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -76,7 +76,9 @@ Strict validation is intended as a v1.0 readiness check. Regular validation rema
 ## Tokens / environment variables
 - Set in environment, not in YAML:
   - `HF_TOKEN`: Hugging Face token (Bearer), used when sources.huggingface.enabled is true
-- `CIVITAI_TOKEN`: CivitAI token (Bearer), used when sources.civitai.enabled is true
+  - `CIVITAI_TOKEN`: CivitAI token (Bearer), used when sources.civitai.enabled is true
+  - `MODFETCH_SYNC_TOKEN`: optional bearer token for HTTP(S) `library sync`
+    targets; override the env name with `--token-env`
 - Do not print secrets back to the terminal; export them in your shell profile or a secure env file
 
 ## Resolver cache

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -380,7 +380,9 @@ modfetch library import --input modfetch-catalog.json --dry-run
 modfetch library import --input modfetch-catalog.json
 modfetch library sync push --target file:///srv/modfetch/catalog.json
 modfetch library sync pull --target file:///srv/modfetch/catalog.json --dry-run
-modfetch library sync pull --target https://example.com/modfetch-catalog.json --dry-run
+export MODFETCH_SYNC_TOKEN="..."
+modfetch library sync push --target https://example.com/modfetch-catalog.json --token-env MODFETCH_SYNC_TOKEN
+modfetch library sync pull --target https://example.com/modfetch-catalog.json --token-env MODFETCH_SYNC_TOKEN --dry-run
 ```
 
 The JSON catalog includes:
@@ -394,12 +396,15 @@ counts without writing. Re-importing the same catalog is idempotent and reports
 unchanged entries as skips.
 
 For repeatable backups or shared-machine handoff, use `library sync`. Push
-supports `file://` and plain local paths, so it works with shared folders,
-mounted storage, and local filesystem paths. Pull supports those same local
-targets plus read-only HTTP(S) catalog URLs. All pull targets preserve the same
+supports `file://`, plain local paths, and writable HTTP(S) endpoints using
+`PUT`, so it works with shared folders, mounted storage, local filesystem paths,
+and simple catalog services. Pull supports those same local targets plus
+HTTP(S) catalog URLs. HTTP(S) sync can read a bearer token from
+`--token-env NAME` without storing secrets in the config file; the default env
+name is `MODFETCH_SYNC_TOKEN` when set. All pull targets preserve the same
 conflict checks as import. `sync push --dry-run` reports the target and model
-count without writing, and `sync pull --dry-run` reports import actions without
-changing the local database.
+count without writing or contacting HTTP targets, and `sync pull --dry-run`
+reports import actions without changing the local database.
 
 ## Metadata Sources
 

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -401,10 +401,12 @@ supports `file://`, plain local paths, and writable HTTP(S) endpoints using
 and simple catalog services. Pull supports those same local targets plus
 HTTP(S) catalog URLs. HTTP(S) sync can read a bearer token from
 `--token-env NAME` without storing secrets in the config file; the default env
-name is `MODFETCH_SYNC_TOKEN` when set. All pull targets preserve the same
-conflict checks as import. `sync push --dry-run` reports the target and model
-count without writing or contacting HTTP targets, and `sync pull --dry-run`
-reports import actions without changing the local database.
+name is `MODFETCH_SYNC_TOKEN` when set. Bearer auth is sent only to HTTPS
+targets unless `MODFETCH_ALLOW_INSECURE_HTTP=1` is set for trusted local HTTP
+testing. All pull targets preserve the same conflict checks as import. `sync
+push --dry-run` reports the target and model count without writing or contacting
+HTTP targets, and `sync pull --dry-run` reports import actions without changing
+the local database.
 
 ## Metadata Sources
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -152,7 +152,9 @@ These are useful, but not required for the first v0.7.0 release:
   ModelScope URLs are recognized as `modelscope` sources and enrich library
   records from the ModelScope model API with best-effort offline fallback.
 - Metadata enrichment from additional model registries beyond ModelScope.
-- Authenticated and writable remote catalog sync targets.
+- [DONE] Authenticated and writable remote catalog sync targets:
+  HTTP(S) sync targets can use bearer tokens from `--token-env`, and
+  `library sync push --target https://...` publishes catalogs with `PUT`.
 - More archive formats if users report concrete needs.
 - [DONE] Non-interactive TUI scripting hooks:
   `modfetch tui --snapshot` exits without launching the Bubble Tea interface


### PR DESCRIPTION
## Summary
- add HTTP(S) `library sync push` using PUT
- add `--token-env` bearer auth support for HTTP(S) sync push and pull
- update completions, roadmap, changelog, config, CLI, and library docs

## Validation
- `go test -count=1 ./cmd/modfetch -run 'TestHandleLibrarySync|TestCompletion'`
- `go test -count=1 ./...`
- `go vet ./...`
- `scripts/check-docs-drift.sh`
- `scripts/check-aur-package.sh`
- `make build`
- real binary smoke: temp config + `library scan` + local auth-required HTTP PUT target

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->