### PR TITLE
feat: add Ollama metadata enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 Added
+- Added Ollama Library metadata enrichment for `ollama.com/library/...` URLs,
+  including page-backed descriptions, download counts, size tags, and fallback
+  metadata when the page cannot be fetched.
 - Added AUR `modfetch-bin` packaging metadata for the published Linux release
   binaries.
 - Added portable AUR package validation that checks `PKGBUILD`, `.SRCINFO`, and

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # modfetch
 
-> **Fast, resilient downloads for AI models** • Download, verify, and organize LLM and Stable Diffusion models from HuggingFace, CivitAI, and ModelScope
+> **Fast, resilient downloads for AI models** • Download, verify, and organize LLM and Stable Diffusion models from HuggingFace, CivitAI, ModelScope, and Ollama Library pages
 
 ```
 ╔═══════════════════════════════════════════════════════════╗
@@ -42,12 +42,12 @@
 
 ### 📚 Model Library
 - **Browse and search** all your downloaded models
-- **Rich metadata** from HuggingFace, CivitAI, and ModelScope APIs
+- **Rich metadata** from HuggingFace, CivitAI, ModelScope APIs, and Ollama Library pages
 - **Favorites system** to mark important models
 - **Directory scanner** to discover existing models (10-100x faster with indexes)
 - **Detailed view** with specs, descriptions, tags, and links
 - **Filter by type and source** (LLM, LoRA, VAE, Checkpoint, etc.)
-- **ModelScope source support** with API-backed enrichment; see the [Library Guide](docs/LIBRARY.md#modelscope)
+- **ModelScope and Ollama source support** with registry-backed enrichment; see the [Library Guide](docs/LIBRARY.md#metadata-sources)
 
 ### 🎯 Organization
 - **Automatic placement** into app directories
@@ -477,7 +477,7 @@ Project layout
 - internal/resolver: hf:// and civitai:// resolvers
 - internal/placer: placement engine
 - internal/scanner: directory scanner for model discovery
-- internal/metadata: metadata fetchers for HuggingFace, CivitAI, and ModelScope
+- internal/metadata: metadata fetchers for HuggingFace, CivitAI, ModelScope, and Ollama
 - internal/tui: TUI models (Library, Scanner, Settings, Downloads)
 - internal/state: SQLite state DB with indexed metadata storage
 - internal/metrics: Prometheus textfile metrics
@@ -495,7 +495,7 @@ Roadmap
 - See docs/ROADMAP.md for the active, prioritized roadmap
 - v0.7.x focus:
   - AUR package publication once maintainer SSH auth is available
-  - Metadata enrichment from additional registries beyond ModelScope
+  - Completed: Ollama Library metadata enrichment beyond ModelScope
   - Completed: authenticated HTTP(S) catalog sync push/pull
   - User-driven archive format expansion
   - Completed: non-interactive TUI snapshots with `modfetch tui --snapshot --json`

--- a/TESTING.md
+++ b/TESTING.md
@@ -46,6 +46,9 @@ completion drift for removed TUI selector flags. The command package tests also
 exercise HTTP(S) catalog sync push/pull with real `httptest` servers and bearer
 headers.
 
+The metadata package exercises registry fetchers against local HTTP/TLS servers,
+including Hugging Face, CivitAI, ModelScope, and Ollama Library behavior.
+
 ## Manual Smoke
 
 After `make build`, verify non-gated behavior with a public URL:

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -211,6 +211,7 @@ Press `F`, choose `Source`, and press `Enter` to cycle through known sources:
 - `huggingface` - Models from HuggingFace Hub
 - `civitai` - Models from CivitAI
 - `modelscope` - Models from ModelScope
+- `ollama` - Models from Ollama Library pages
 - `local` - Locally scanned models
 - `direct` - Direct URL downloads
 
@@ -463,9 +464,22 @@ For models downloaded from ModelScope:
 - Model type inferred from tasks, tags, or filename
 - Quantization and file format inferred from resolved filenames
 
+### Ollama Library
+
+For models tracked from Ollama Library pages:
+
+**Metadata page:** `https://ollama.com/library/{model}`
+
+**Fetched metadata:**
+- Model name, description, and library page link
+- Download count when reported by the page
+- Available parameter-size tags when shown on the page
+- Version tag from URLs such as `https://ollama.com/library/llama3.2:1b`
+- Source: `ollama`
+
 ### Direct Downloads
 
-For direct URL downloads (non-HuggingFace, non-CivitAI, non-ModelScope):
+For direct URL downloads (non-HuggingFace, non-CivitAI, non-ModelScope, non-Ollama):
 
 **Basic metadata only:**
 - URL as source
@@ -557,7 +571,11 @@ For large libraries (1000+ models):
    - Check API status at https://modelscope.cn
    - Verify the URL uses `/models/{owner}/{name}`
 
-4. **For local scans:**
+4. **For Ollama Library pages:**
+   - Verify the URL uses `https://ollama.com/library/{model}`
+   - Tagged pages such as `https://ollama.com/library/llama3.2:1b` store the tag as the version
+
+5. **For local scans:**
    - Metadata is limited to filename parsing
    - Rename files to include quantization (e.g., `model.Q4_K_M.gguf`)
    - Include parameter count in filename (e.g., `llama-7b.gguf`)
@@ -592,13 +610,11 @@ Add personal notes and ratings:
 2. Notes and ratings are stored per-model
 3. Searchable via the main search function
 
-### Bulk Operations (Future Enhancement)
+### Bulk Operations
 
-Planned features:
-- Bulk favorite/unfavorite
-- Bulk tagging
-- Export library to CSV/JSON
-- Import from external catalogs
+Available bulk actions include retry, staged-data delete, verify, place,
+favorite/unfavorite, and selected catalog export. Destructive actions show a
+confirmation summary before they run.
 
 ### Integration with Download Manager
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -151,7 +151,9 @@ These are useful, but not required for the first v0.7.0 release:
 - [DONE] ModelScope metadata enrichment:
   ModelScope URLs are recognized as `modelscope` sources and enrich library
   records from the ModelScope model API with best-effort offline fallback.
-- Metadata enrichment from additional model registries beyond ModelScope.
+- [DONE] Ollama Library metadata enrichment beyond ModelScope:
+  `ollama.com/library/...` pages are recognized as `ollama` sources and enrich
+  library records with page metadata plus best-effort fallback.
 - [DONE] Authenticated and writable remote catalog sync targets:
   HTTP(S) sync targets can use bearer tokens from `--token-env`, and
   `library sync push --target https://...` publishes catalogs with `PUT`.

--- a/internal/metadata/fetcher.go
+++ b/internal/metadata/fetcher.go
@@ -46,6 +46,7 @@ func NewRegistry() *Registry {
 	r.Register(NewHuggingFaceFetcher(client))
 	r.Register(NewCivitAIFetcher(client))
 	r.Register(NewModelScopeFetcher(client))
+	r.Register(NewOllamaFetcher(client))
 
 	return r
 }

--- a/internal/metadata/ollama.go
+++ b/internal/metadata/ollama.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -65,7 +64,7 @@ func (f *OllamaFetcher) FetchMetadata(ctx context.Context, rawURL string) (*stat
 	}
 	meta.Description = truncateString(firstNonEmpty(metaContent(page, "description"), metaContent(page, "og:description")), 5000)
 	meta.ThumbnailURL = metaContent(page, "og:image")
-	meta.DownloadCount = parseCompactCount(firstNonEmpty(textForAttr(page, "x-test-pull-count"), textForAttr(page, "data-pull-count")))
+	meta.DownloadCount = parseCompactCount(pullCountText(page))
 	meta.Tags = appendUniqueStrings(meta.Tags, sizeTags(page)...)
 	return meta, nil
 }
@@ -115,14 +114,25 @@ func parseOllamaLibraryURL(rawURL string) (model, tag string, err error) {
 	}
 	model = strings.TrimSpace(model)
 	tag = strings.TrimSpace(tag)
-	if model == "" {
+	if invalidOllamaModelSpec(model) {
 		return "", "", fmt.Errorf("invalid Ollama library URL format")
 	}
 	return model, tag, nil
 }
 
 func ollamaLibraryURL(model string) string {
-	return (&url.URL{Scheme: "https", Host: "ollama.com", Path: path.Join("/library", model)}).String()
+	return "https://ollama.com/library/" + url.PathEscape(model)
+}
+
+func invalidOllamaModelSpec(model string) bool {
+	model = strings.TrimSpace(model)
+	lower := strings.ToLower(model)
+	return model == "" ||
+		model == "." ||
+		model == ".." ||
+		strings.Contains(model, "/") ||
+		strings.Contains(lower, "%2f") ||
+		strings.Contains(model, "..")
 }
 
 var (
@@ -131,6 +141,7 @@ var (
 	singleAttrRe = regexp.MustCompile(`(?is)([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*'([^']*)'`)
 	titleRe      = regexp.MustCompile(`(?is)<title[^>]*>(.*?)</title>`)
 	spanRe       = regexp.MustCompile(`(?is)<span([^>]*)>(.*?)</span>`)
+	pullCountRe  = regexp.MustCompile(`(?is)([0-9][0-9.,]*\s*[KMB]?)\s*</span>\s*<span[^>]*>\s*Downloads\b`)
 	tagStripRe   = regexp.MustCompile(`(?is)<[^>]*>`)
 )
 
@@ -175,10 +186,21 @@ func textForAttr(page, attr string) string {
 	return ""
 }
 
+func pullCountText(page string) string {
+	if count := firstNonEmpty(textForAttr(page, "data-pull-count"), textForAttr(page, "x-test-pull-count")); count != "" {
+		return count
+	}
+	match := pullCountRe.FindStringSubmatch(page)
+	if len(match) >= 2 {
+		return cleanHTMLText(match[1])
+	}
+	return ""
+}
+
 func sizeTags(page string) []string {
 	tags := []string{}
 	for _, match := range spanRe.FindAllStringSubmatch(page, -1) {
-		if len(match) < 3 || !hasHTMLAttr(match[1], "x-test-size") {
+		if len(match) < 3 || (!hasHTMLAttr(match[1], "data-size") && !hasHTMLAttr(match[1], "x-test-size")) {
 			continue
 		}
 		if tag := cleanHTMLText(match[2]); tag != "" {
@@ -189,8 +211,15 @@ func sizeTags(page string) []string {
 }
 
 func hasHTMLAttr(attrs, attr string) bool {
-	re := regexp.MustCompile(fmt.Sprintf(`(?is)(?:^|\s)%s(?:\s|=|$)`, regexp.QuoteMeta(attr)))
-	return re.MatchString(attrs)
+	attr = strings.ToLower(strings.TrimSpace(attr))
+	for _, field := range strings.Fields(attrs) {
+		name, _, _ := strings.Cut(field, "=")
+		name = strings.Trim(strings.TrimSpace(name), `/"'`)
+		if strings.EqualFold(name, attr) {
+			return true
+		}
+	}
+	return false
 }
 
 func cleanHTMLText(value string) string {

--- a/internal/metadata/ollama.go
+++ b/internal/metadata/ollama.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -20,6 +21,9 @@ type OllamaFetcher struct {
 }
 
 func NewOllamaFetcher(client *http.Client) *OllamaFetcher {
+	if client == nil {
+		client = http.DefaultClient
+	}
 	return &OllamaFetcher{client: client}
 }
 
@@ -70,6 +74,7 @@ func (f *OllamaFetcher) FetchMetadata(ctx context.Context, rawURL string) (*stat
 }
 
 func (f *OllamaFetcher) basicMetadata(rawURL, model, tag string) *state.ModelMetadata {
+	now := time.Now()
 	tags := []string{"ollama"}
 	if tag != "" {
 		tags = append(tags, tag)
@@ -85,8 +90,8 @@ func (f *OllamaFetcher) basicMetadata(rawURL, model, tag string) *state.ModelMet
 		HomepageURL: ollamaLibraryURL(model),
 		ModelType:   "LLM",
 		FileFormat:  "ollama",
-		CreatedAt:   time.Now(),
-		UpdatedAt:   time.Now(),
+		CreatedAt:   now,
+		UpdatedAt:   now,
 	}
 }
 
@@ -249,7 +254,12 @@ func parseCompactCount(value string) int {
 	if err != nil {
 		return 0
 	}
-	return int(count * multiplier)
+	result := math.Round(count * multiplier)
+	maxInt := float64(int(^uint(0) >> 1))
+	if result > maxInt {
+		return int(maxInt)
+	}
+	return int(result)
 }
 
 func appendUniqueStrings(values []string, additions ...string) []string {

--- a/internal/metadata/ollama.go
+++ b/internal/metadata/ollama.go
@@ -1,0 +1,238 @@
+package metadata
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+type OllamaFetcher struct {
+	client *http.Client
+}
+
+func NewOllamaFetcher(client *http.Client) *OllamaFetcher {
+	return &OllamaFetcher{client: client}
+}
+
+func (f *OllamaFetcher) Source() string {
+	return "ollama"
+}
+
+func (f *OllamaFetcher) CanHandle(rawURL string) bool {
+	_, _, err := parseOllamaLibraryURL(rawURL)
+	return err == nil
+}
+
+func (f *OllamaFetcher) FetchMetadata(ctx context.Context, rawURL string) (*state.ModelMetadata, error) {
+	model, tag, err := parseOllamaLibraryURL(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ollamaLibraryURL(model), nil)
+	if err != nil {
+		return f.basicMetadata(rawURL, model, tag), nil
+	}
+	req.Header.Set("Accept", "text/html,application/xhtml+xml")
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return f.basicMetadata(rawURL, model, tag), nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return f.basicMetadata(rawURL, model, tag), nil
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return f.basicMetadata(rawURL, model, tag), nil
+	}
+
+	page := string(body)
+	meta := f.basicMetadata(rawURL, model, tag)
+	if title := firstNonEmpty(metaContent(page, "og:title"), htmlTitle(page)); title != "" {
+		meta.ModelName = title
+	}
+	meta.Description = truncateString(firstNonEmpty(metaContent(page, "description"), metaContent(page, "og:description")), 5000)
+	meta.ThumbnailURL = metaContent(page, "og:image")
+	meta.DownloadCount = parseCompactCount(firstNonEmpty(textForAttr(page, "x-test-pull-count"), textForAttr(page, "data-pull-count")))
+	meta.Tags = appendUniqueStrings(meta.Tags, sizeTags(page)...)
+	return meta, nil
+}
+
+func (f *OllamaFetcher) basicMetadata(rawURL, model, tag string) *state.ModelMetadata {
+	tags := []string{"ollama"}
+	if tag != "" {
+		tags = append(tags, tag)
+	}
+	return &state.ModelMetadata{
+		DownloadURL: rawURL,
+		ModelName:   model,
+		ModelID:     "ollama/" + model,
+		Version:     tag,
+		Source:      "ollama",
+		Tags:        tags,
+		RepoURL:     ollamaLibraryURL(model),
+		HomepageURL: ollamaLibraryURL(model),
+		ModelType:   "LLM",
+		FileFormat:  "ollama",
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+}
+
+func parseOllamaLibraryURL(rawURL string) (model, tag string, err error) {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return "", "", fmt.Errorf("parse Ollama URL: %w", err)
+	}
+	host := strings.ToLower(u.Hostname())
+	if host != "ollama.com" && !strings.HasSuffix(host, ".ollama.com") {
+		return "", "", fmt.Errorf("invalid Ollama host")
+	}
+	parts := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
+	if len(parts) < 2 || parts[0] != "library" || parts[1] == "" || parts[1] == "tags" {
+		return "", "", fmt.Errorf("invalid Ollama library URL format")
+	}
+	modelSpec, err := url.PathUnescape(parts[1])
+	if err != nil {
+		return "", "", fmt.Errorf("decode Ollama model: %w", err)
+	}
+	if strings.Contains(modelSpec, ":") {
+		model, tag, _ = strings.Cut(modelSpec, ":")
+	} else {
+		model = modelSpec
+	}
+	model = strings.TrimSpace(model)
+	tag = strings.TrimSpace(tag)
+	if model == "" {
+		return "", "", fmt.Errorf("invalid Ollama library URL format")
+	}
+	return model, tag, nil
+}
+
+func ollamaLibraryURL(model string) string {
+	return (&url.URL{Scheme: "https", Host: "ollama.com", Path: path.Join("/library", model)}).String()
+}
+
+var (
+	metaTagRe    = regexp.MustCompile(`(?is)<meta\s+[^>]*>`)
+	doubleAttrRe = regexp.MustCompile(`(?is)([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*"([^"]*)"`)
+	singleAttrRe = regexp.MustCompile(`(?is)([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*'([^']*)'`)
+	titleRe      = regexp.MustCompile(`(?is)<title[^>]*>(.*?)</title>`)
+	spanRe       = regexp.MustCompile(`(?is)<span([^>]*)>(.*?)</span>`)
+	tagStripRe   = regexp.MustCompile(`(?is)<[^>]*>`)
+)
+
+func metaContent(page, name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	for _, tag := range metaTagRe.FindAllString(page, -1) {
+		attrs := htmlAttrs(tag)
+		if strings.EqualFold(attrs["name"], name) || strings.EqualFold(attrs["property"], name) {
+			return cleanHTMLText(attrs["content"])
+		}
+	}
+	return ""
+}
+
+func htmlAttrs(tag string) map[string]string {
+	attrs := map[string]string{}
+	for _, re := range []*regexp.Regexp{doubleAttrRe, singleAttrRe} {
+		for _, match := range re.FindAllStringSubmatch(tag, -1) {
+			if len(match) == 3 {
+				attrs[strings.ToLower(match[1])] = html.UnescapeString(match[2])
+			}
+		}
+	}
+	return attrs
+}
+
+func htmlTitle(page string) string {
+	match := titleRe.FindStringSubmatch(page)
+	if len(match) < 2 {
+		return ""
+	}
+	return cleanHTMLText(match[1])
+}
+
+func textForAttr(page, attr string) string {
+	for _, match := range spanRe.FindAllStringSubmatch(page, -1) {
+		if len(match) < 3 || !hasHTMLAttr(match[1], attr) {
+			continue
+		}
+		return cleanHTMLText(match[2])
+	}
+	return ""
+}
+
+func sizeTags(page string) []string {
+	tags := []string{}
+	for _, match := range spanRe.FindAllStringSubmatch(page, -1) {
+		if len(match) < 3 || !hasHTMLAttr(match[1], "x-test-size") {
+			continue
+		}
+		if tag := cleanHTMLText(match[2]); tag != "" {
+			tags = append(tags, strings.ToLower(tag))
+		}
+	}
+	return tags
+}
+
+func hasHTMLAttr(attrs, attr string) bool {
+	re := regexp.MustCompile(fmt.Sprintf(`(?is)(?:^|\s)%s(?:\s|=|$)`, regexp.QuoteMeta(attr)))
+	return re.MatchString(attrs)
+}
+
+func cleanHTMLText(value string) string {
+	value = tagStripRe.ReplaceAllString(value, "")
+	value = html.UnescapeString(value)
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func parseCompactCount(value string) int {
+	value = strings.TrimSpace(strings.ToUpper(strings.ReplaceAll(value, ",", "")))
+	if value == "" {
+		return 0
+	}
+	multiplier := 1.0
+	switch {
+	case strings.HasSuffix(value, "K"):
+		multiplier = 1_000
+		value = strings.TrimSuffix(value, "K")
+	case strings.HasSuffix(value, "M"):
+		multiplier = 1_000_000
+		value = strings.TrimSuffix(value, "M")
+	case strings.HasSuffix(value, "B"):
+		multiplier = 1_000_000_000
+		value = strings.TrimSuffix(value, "B")
+	}
+	count, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+	if err != nil {
+		return 0
+	}
+	return int(count * multiplier)
+}
+
+func appendUniqueStrings(values []string, additions ...string) []string {
+	seen := make(map[string]bool, len(values)+len(additions))
+	out := make([]string, 0, len(values)+len(additions))
+	for _, value := range append(values, additions...) {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[strings.ToLower(value)] {
+			continue
+		}
+		seen[strings.ToLower(value)] = true
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/metadata/ollama_test.go
+++ b/internal/metadata/ollama_test.go
@@ -1,0 +1,124 @@
+package metadata
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestOllamaFetcherCanHandle(t *testing.T) {
+	f := NewOllamaFetcher(&http.Client{})
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "library model", url: "https://ollama.com/library/llama3.2", want: true},
+		{name: "library tag", url: "https://ollama.com/library/llama3.2:1b", want: true},
+		{name: "tags page ignored", url: "https://ollama.com/library/llama3.2/tags", want: true},
+		{name: "other host", url: "https://example.com/library/llama3.2", want: false},
+		{name: "ollama docs", url: "https://ollama.com/download", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := f.CanHandle(tt.url); got != tt.want {
+				t.Fatalf("CanHandle(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOllamaFetcherFetchMetadataSuccess(t *testing.T) {
+	client := routedHTTPClient(t, "ollama.com", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/library/llama3.2" {
+			t.Errorf("unexpected Ollama page path: %s", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(`<!doctype html>
+<html>
+<head>
+  <title>ignored title</title>
+  <meta property="og:title" content="llama3.2" />
+  <meta name="description" content="Meta&#39;s Llama 3.2 goes small with 1B and 3B models." />
+  <meta property="og:image" content="https://ollama.com/public/og.png" />
+</head>
+<body>
+  <span x-test-pull-count>67.2M</span>
+  <span x-test-size>1b</span>
+  <span x-test-size>3b</span>
+</body>
+</html>`))
+	}))
+
+	f := NewOllamaFetcher(client)
+	meta, err := f.FetchMetadata(context.Background(), "https://ollama.com/library/llama3.2:1b")
+	if err != nil {
+		t.Fatalf("FetchMetadata: %v", err)
+	}
+	if meta.Source != "ollama" || meta.ModelName != "llama3.2" || meta.ModelID != "ollama/llama3.2" {
+		t.Fatalf("unexpected identity metadata: %+v", meta)
+	}
+	if meta.Version != "1b" {
+		t.Fatalf("Version = %q, want 1b", meta.Version)
+	}
+	if meta.Description != "Meta's Llama 3.2 goes small with 1B and 3B models." {
+		t.Fatalf("Description = %q", meta.Description)
+	}
+	if meta.DownloadCount != 67_200_000 {
+		t.Fatalf("DownloadCount = %d, want 67200000", meta.DownloadCount)
+	}
+	for _, want := range []string{"ollama", "1b", "3b"} {
+		if !containsStringFold(meta.Tags, want) {
+			t.Fatalf("Tags = %v, missing %q", meta.Tags, want)
+		}
+	}
+	if meta.ModelType != "LLM" || meta.FileFormat != "ollama" {
+		t.Fatalf("unexpected type metadata: %+v", meta)
+	}
+}
+
+func TestOllamaFetcherFallsBackOnHTTPFailure(t *testing.T) {
+	client := routedHTTPClient(t, "ollama.com", http.NotFoundHandler())
+	f := NewOllamaFetcher(client)
+	meta, err := f.FetchMetadata(context.Background(), "https://ollama.com/library/qwen2.5")
+	if err != nil {
+		t.Fatalf("FetchMetadata should fall back on HTTP failure: %v", err)
+	}
+	if meta.Source != "ollama" || meta.ModelName != "qwen2.5" || meta.HomepageURL != "https://ollama.com/library/qwen2.5" {
+		t.Fatalf("unexpected fallback metadata: %+v", meta)
+	}
+}
+
+func TestRegistryIncludesOllamaFetcher(t *testing.T) {
+	registry := NewRegistry()
+	if !registry.CanHandle("https://ollama.com/library/llama3.2") {
+		t.Fatal("registry should handle Ollama library URLs")
+	}
+}
+
+func TestParseCompactCount(t *testing.T) {
+	tests := map[string]int{
+		"67.2M": 67_200_000,
+		"120K":  120_000,
+		"1,250": 1_250,
+		"2B":    2_000_000_000,
+		"bad":   0,
+	}
+	for input, want := range tests {
+		if got := parseCompactCount(input); got != want {
+			t.Fatalf("parseCompactCount(%q) = %d, want %d", input, got, want)
+		}
+	}
+}
+
+func containsStringFold(values []string, want string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/metadata/ollama_test.go
+++ b/internal/metadata/ollama_test.go
@@ -29,6 +29,13 @@ func TestOllamaFetcherCanHandle(t *testing.T) {
 	}
 }
 
+func TestNewOllamaFetcherDefaultsNilClient(t *testing.T) {
+	f := NewOllamaFetcher(nil)
+	if f.client == nil {
+		t.Fatal("NewOllamaFetcher(nil) should default to a non-nil HTTP client")
+	}
+}
+
 func TestOllamaFetcherFetchMetadataSuccess(t *testing.T) {
 	client := routedHTTPClient(t, "ollama.com", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/library/llama3.2" {
@@ -127,6 +134,7 @@ func TestRegistryIncludesOllamaFetcher(t *testing.T) {
 func TestParseCompactCount(t *testing.T) {
 	tests := map[string]int{
 		"67.2M": 67_200_000,
+		"1.2K":  1_200,
 		"120K":  120_000,
 		"1,250": 1_250,
 		"2B":    2_000_000_000,

--- a/internal/metadata/ollama_test.go
+++ b/internal/metadata/ollama_test.go
@@ -46,9 +46,9 @@ func TestOllamaFetcherFetchMetadataSuccess(t *testing.T) {
   <meta property="og:image" content="https://ollama.com/public/og.png" />
 </head>
 <body>
-  <span x-test-pull-count>67.2M</span>
-  <span x-test-size>1b</span>
-  <span x-test-size>3b</span>
+  <span data-pull-count>67.2M</span>
+  <span data-size>1b</span>
+  <span data-size>3b</span>
 </body>
 </html>`))
 	}))
@@ -80,6 +80,16 @@ func TestOllamaFetcherFetchMetadataSuccess(t *testing.T) {
 	}
 }
 
+func TestOllamaFetcherParsesLiveStyleAttributes(t *testing.T) {
+	page := `<span x-test-pull-count>42K</span><span>Downloads</span><span x-test-size>7b</span>`
+	if got := parseCompactCount(pullCountText(page)); got != 42_000 {
+		t.Fatalf("live-style pull count = %d, want 42000", got)
+	}
+	if tags := sizeTags(page); len(tags) != 1 || tags[0] != "7b" {
+		t.Fatalf("live-style size tags = %v, want [7b]", tags)
+	}
+}
+
 func TestOllamaFetcherFallsBackOnHTTPFailure(t *testing.T) {
 	client := routedHTTPClient(t, "ollama.com", http.NotFoundHandler())
 	f := NewOllamaFetcher(client)
@@ -89,6 +99,21 @@ func TestOllamaFetcherFallsBackOnHTTPFailure(t *testing.T) {
 	}
 	if meta.Source != "ollama" || meta.ModelName != "qwen2.5" || meta.HomepageURL != "https://ollama.com/library/qwen2.5" {
 		t.Fatalf("unexpected fallback metadata: %+v", meta)
+	}
+}
+
+func TestParseOllamaLibraryURLRejectsTraversal(t *testing.T) {
+	tests := []string{
+		"https://ollama.com/library/..%2Fdownload",
+		"https://ollama.com/library/%2E",
+		"https://ollama.com/library/%2E%2E",
+		"https://ollama.com/library/model..name",
+		"https://ollama.com/library/model%252Fname",
+	}
+	for _, rawURL := range tests {
+		if _, _, err := parseOllamaLibraryURL(rawURL); err == nil {
+			t.Fatalf("parseOllamaLibraryURL(%q) should reject traversal model", rawURL)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an Ollama Library metadata fetcher for ollama.com/library URLs
- enrich Ollama rows with page descriptions, download counts, size tags, tagged-version fallback metadata, and source=ollama
- update roadmap/library docs and clear stale bulk-operation wording

## Validation
- go test -count=1 ./internal/metadata
- go test -count=1 ./...
- go vet ./...
- scripts/check-docs-drift.sh
- scripts/check-aur-package.sh
- git diff --check
- rg -n "TODO|FIXME" cmd internal
- make build
- ./bin/modfetch version

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->