### PR TITLE
chore: publish AUR package workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 Added
+- Added `scripts/publish-aur.sh` to validate and publish AUR metadata for
+  AUR releases.
 - Added Ollama Library metadata enrichment for `ollama.com/library/...` URLs,
   including page-backed descriptions, download counts, size tags, and fallback
   metadata when the page cannot be fetched.
-- Added AUR `modfetch-bin` packaging metadata for the published Linux release
-  binaries.
+- Added and published AUR `modfetch-bin` packaging metadata for the published
+  Linux release binaries.
 - Added portable AUR package validation that checks `PKGBUILD`, `.SRCINFO`, and
   published release checksums.
 - Added `library sync push` and `library sync pull` for `file://` catalog sync
@@ -26,7 +28,7 @@ Added
 Docs
 - Documented Arch Linux AUR package maintenance and release checklist coverage.
 - Aligned README, installation, release, roadmap, and TUI docs with the shipped
-  v0.7.0 state and the current AUR SSH publication blocker.
+  v0.7.0 state and published AUR package.
 - Removed obsolete top-level sprint and test status reports that described old
   sandbox limits instead of the current validation workflow.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - [User Guide](docs/USER_GUIDE.md) - Full feature reference
 - [Configuration](docs/CONFIG.md) - Config file options
 - [Testing](TESTING.md) - Maintainer validation commands
-- [Installation Guide](docs/INSTALLATION.md) - Install with Homebrew, one-line installer, release binaries, or staged AUR metadata
+- [Installation Guide](docs/INSTALLATION.md) - Install with Homebrew, AUR, one-line installer, or release binaries
 - [Release Checklist](docs/RELEASE.md) - Maintainer checklist for tags, artifacts, and package updates
 
 ---
@@ -110,7 +110,7 @@ The modfetch TUI provides a beautiful, full-featured interface for managing your
 
 ✅ **Production Ready:** Core download, verify, and TUI features are stable
 
-🚀 **Active Development:** AUR publication and metadata enrichment
+🚀 **Active Development:** metadata enrichment and user-driven archive support
 
 📖 **Documentation:** Comprehensive guides with visual examples
 
@@ -217,10 +217,13 @@ brew upgrade jxwalker/tap/modfetch
 
 The formula installs the published GitHub Release binary and verifies its SHA256 checksum.
 
-Arch Linux packaging metadata is staged under `packaging/aur/` for the
-`modfetch-bin` AUR package. Publication requires an AUR account with a
-registered SSH key; until that package is published, Arch users should use
-Homebrew/Linuxbrew, the one-line installer, or the manual release binary.
+Arch Linux users can install the published `modfetch-bin` AUR package:
+
+```bash
+git clone https://aur.archlinux.org/modfetch-bin.git
+cd modfetch-bin
+makepkg -si
+```
 </details>
 
 <details>
@@ -494,7 +497,7 @@ Troubleshooting
 Roadmap
 - See docs/ROADMAP.md for the active, prioritized roadmap
 - v0.7.x focus:
-  - AUR package publication once maintainer SSH auth is available
+  - Completed: AUR `modfetch-bin` publication
   - Completed: Ollama Library metadata enrichment beyond ModelScope
   - Completed: authenticated HTTP(S) catalog sync push/pull
   - User-driven archive format expansion

--- a/TESTING.md
+++ b/TESTING.md
@@ -15,9 +15,11 @@ go vet ./...
 make build
 ```
 
-`scripts/check-aur-package.sh` validates the staged AUR metadata and published
+`scripts/check-aur-package.sh` validates the AUR metadata and published
 release checksums. On macOS, it reports that `makepkg` is unavailable and skips
 only the Arch-specific `.SRCINFO` regeneration check.
+`scripts/publish-aur.sh vX.Y.Z` wraps the publish flow and fails before clone or
+push when AUR SSH authentication is not configured.
 
 ## Auth-Gated Coverage
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -63,17 +63,14 @@ sudo cp bin/modfetch /usr/local/bin/
   brew tap jxwalker/tap
   brew install jxwalker/tap/modfetch
   ```
-- **Arch Linux / AUR**: package metadata is maintained in `packaging/aur/` for
-  the future `modfetch-bin` AUR package. Publication is pending an AUR account
-  with a registered maintainer SSH key. After the package is published, install
-  it with:
+- **Arch Linux / AUR**: install the published `modfetch-bin` AUR package:
   ```bash
   git clone https://aur.archlinux.org/modfetch-bin.git
   cd modfetch-bin
   makepkg -si
   ```
-  Until then, use Homebrew/Linuxbrew, the one-line installer, or the manual
-  release binary.
+  Maintainers can update the AUR package with `scripts/publish-aur.sh vX.Y.Z`
+  after release assets are published.
 - **Ubuntu/Debian**: One-liner installer handles all dependencies
 - **CentOS/RHEL**: Ensure `curl` and `tar` are installed first
 - **Other distributions**: Use the one-line installer or manual release binary.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -80,6 +80,10 @@ Use this checklist from a clean `main` checkout before tagging a modfetch releas
   ```
 - Push `PKGBUILD` and `.SRCINFO` to
   `ssh://aur@aur.archlinux.org/modfetch-bin.git`.
+  From this repository, prefer the checked publish helper:
+  ```bash
+  scripts/publish-aur.sh vX.Y.Z
+  ```
 
 ## Final Verification
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -138,10 +138,9 @@ Acceptance checks:
 
 These are useful, but not required for the first v0.7.0 release:
 
-- [IN PROGRESS] AUR packaging after Homebrew is stable:
-  package metadata and validation are staged in `packaging/aur/`; AUR
-  publication is pending a maintainer AUR account with an AUR-registered SSH
-  public key.
+- [DONE] AUR packaging after Homebrew is stable:
+  `modfetch-bin` is published to AUR, package metadata and validation live under
+  `packaging/aur/`, and updates are automated by `scripts/publish-aur.sh`.
 - [DONE] Remote catalog sync foundation:
   `library sync push/pull --target file://...` reuses the portable catalog
   schema for shared folders, mounted drives, and local filesystem sync tests.

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -52,7 +52,7 @@ The repository publish helper performs validation, auth checking, AUR clone,
 file copy, commit, and push:
 
 ```bash
-scripts/publish-aur.sh v0.7.0
+scripts/publish-aur.sh vX.Y.Z
 ```
 
 If authentication fails, paste `~/.ssh/aur.pub` into the AUR account profile and

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -1,9 +1,7 @@
 # AUR Packaging
 
-This directory stages the `modfetch-bin` AUR package. It packages the published
-Linux release binaries instead of rebuilding from source. The package will not
-be published to AUR until a maintainer account with an AUR-registered SSH key
-pushes these files.
+This directory maintains the published `modfetch-bin` AUR package. It packages
+the published Linux release binaries instead of rebuilding from source.
 
 Validate metadata and live release checksums from the repository root:
 
@@ -21,8 +19,8 @@ modfetch version
 namcap PKGBUILD
 ```
 
-Publishing requires an AUR account with a registered SSH public key. A dedicated
-key is preferred so it can be revoked independently:
+Updating the package requires an AUR account with a registered SSH public key. A
+dedicated key is preferred so it can be revoked independently:
 
 ```bash
 ssh-keygen -t ed25519 -f ~/.ssh/aur -C "aur-modfetch"
@@ -44,8 +42,18 @@ Verify auth before publishing:
 ssh -o BatchMode=yes -o ConnectTimeout=5 aur@aur.archlinux.org help
 ```
 
-To publish, push `PKGBUILD` and `.SRCINFO` to:
+The AUR Git remote is:
 
 ```bash
 ssh://aur@aur.archlinux.org/modfetch-bin.git
 ```
+
+The repository publish helper performs validation, auth checking, AUR clone,
+file copy, commit, and push:
+
+```bash
+scripts/publish-aur.sh v0.7.0
+```
+
+If authentication fails, paste `~/.ssh/aur.pub` into the AUR account profile and
+retry the command.

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -48,7 +48,7 @@ The AUR Git remote is:
 ssh://aur@aur.archlinux.org/modfetch-bin.git
 ```
 
-The repository publish helper performs validation, auth checking, AUR clone,
+The repository publishing helper performs validation, auth checking, AUR clone,
 file copy, commit, and push:
 
 ```bash

--- a/scripts/publish-aur.sh
+++ b/scripts/publish-aur.sh
@@ -9,7 +9,13 @@ branch="${AUR_BRANCH:-master}"
 tag="${1:-}"
 
 if [[ -z "$tag" ]]; then
-  pkgver="$(grep -E '^[[:space:]]*pkgver=' "$aur_dir/PKGBUILD" | head -n 1 | cut -d= -f2-)"
+  pkgver_line="$(grep -E '^[[:space:]]*pkgver=' "$aur_dir/PKGBUILD" | head -n 1 || true)"
+  pkgver="${pkgver_line#*=}"
+  pkgver="$(printf '%s' "$pkgver" | sed -E "s/^[[:space:]]+//; s/[[:space:]]+$//; s/^['\\\"]//; s/['\\\"]$//")"
+  if [[ -z "$pkgver" ]]; then
+    echo "failed to read pkgver from $aur_dir/PKGBUILD" >&2
+    exit 1
+  fi
   tag="v${pkgver}"
 fi
 
@@ -45,7 +51,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-git -c init.defaultBranch="$branch" clone --depth 1 "$remote" "$workdir/$pkgbase"
+git -c init.defaultBranch="$branch" clone --depth 1 --branch "$branch" "$remote" "$workdir/$pkgbase"
 
 cp "$aur_dir/PKGBUILD" "$aur_dir/.SRCINFO" "$workdir/$pkgbase/"
 cd "$workdir/$pkgbase"

--- a/scripts/publish-aur.sh
+++ b/scripts/publish-aur.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+aur_dir="$root/packaging/aur"
+pkgbase="${AUR_PKGBASE:-modfetch-bin}"
+remote="${AUR_REMOTE:-ssh://aur@aur.archlinux.org/${pkgbase}.git}"
+tag="${1:-}"
+
+if [[ -z "$tag" ]]; then
+  pkgver="$(grep -E '^[[:space:]]*pkgver=' "$aur_dir/PKGBUILD" | head -n 1 | cut -d= -f2-)"
+  tag="v${pkgver}"
+fi
+
+if [[ "$tag" != v* ]]; then
+  echo "release tag must start with v, got: $tag" >&2
+  exit 1
+fi
+
+"$root/scripts/check-aur-package.sh" "$tag"
+
+if ! ssh -o BatchMode=yes -o ConnectTimeout=10 aur@aur.archlinux.org help >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+AUR SSH authentication failed.
+
+Register this machine's AUR public key in the AUR account profile, then retry:
+
+  cat ~/.ssh/aur.pub
+
+Expected local SSH config:
+
+  Host aur.archlinux.org
+    User aur
+    IdentityFile ~/.ssh/aur
+    IdentitiesOnly yes
+
+EOF
+  exit 1
+fi
+
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/modfetch-aur.XXXXXX")"
+cleanup() {
+  rm -rf "$workdir"
+}
+trap cleanup EXIT
+
+git -c init.defaultBranch=master clone "$remote" "$workdir/$pkgbase"
+
+cp "$aur_dir/PKGBUILD" "$aur_dir/.SRCINFO" "$workdir/$pkgbase/"
+cd "$workdir/$pkgbase"
+
+git add PKGBUILD .SRCINFO
+if git diff --cached --quiet; then
+  echo "AUR package ${pkgbase} is already up to date for ${tag}"
+  exit 0
+fi
+
+git commit -m "Update ${pkgbase} to ${tag}"
+git push origin master
+
+echo "Published ${pkgbase} ${tag} to AUR"

--- a/scripts/publish-aur.sh
+++ b/scripts/publish-aur.sh
@@ -5,6 +5,7 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 aur_dir="$root/packaging/aur"
 pkgbase="${AUR_PKGBASE:-modfetch-bin}"
 remote="${AUR_REMOTE:-ssh://aur@aur.archlinux.org/${pkgbase}.git}"
+branch="${AUR_BRANCH:-master}"
 tag="${1:-}"
 
 if [[ -z "$tag" ]]; then
@@ -19,7 +20,7 @@ fi
 
 "$root/scripts/check-aur-package.sh" "$tag"
 
-if ! ssh -o BatchMode=yes -o ConnectTimeout=10 aur@aur.archlinux.org help >/dev/null 2>&1; then
+if [[ "$remote" == ssh://aur@aur.archlinux.org/* ]] && ! ssh -o BatchMode=yes -o ConnectTimeout=10 aur@aur.archlinux.org help >/dev/null 2>&1; then
   cat >&2 <<'EOF'
 AUR SSH authentication failed.
 
@@ -44,7 +45,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-git -c init.defaultBranch=master clone "$remote" "$workdir/$pkgbase"
+git -c init.defaultBranch="$branch" clone --depth 1 "$remote" "$workdir/$pkgbase"
 
 cp "$aur_dir/PKGBUILD" "$aur_dir/.SRCINFO" "$workdir/$pkgbase/"
 cd "$workdir/$pkgbase"
@@ -56,6 +57,6 @@ if git diff --cached --quiet; then
 fi
 
 git commit -m "Update ${pkgbase} to ${tag}"
-git push origin master
+git push origin "HEAD:${branch}"
 
 echo "Published ${pkgbase} ${tag} to AUR"


### PR DESCRIPTION
## Summary
- published modfetch-bin v0.7.0 to AUR and added a repeatable publish helper
- update install, release, testing, roadmap, and AUR docs from pending to published status
- keep AUR package validation tied to live release checksums

## Validation
- ssh -o BatchMode=yes -o ConnectTimeout=10 aur@aur.archlinux.org help
- scripts/publish-aur.sh v0.7.0
- git clone https://aur.archlinux.org/modfetch-bin.git /tmp/modfetch-bin-verify
- curl -fsS https://aur.archlinux.org/packages/modfetch-bin
- scripts/check-docs-drift.sh
- scripts/check-aur-package.sh v0.7.0
- bash -n scripts/publish-aur.sh scripts/check-aur-package.sh
- go test -count=1 ./...
- go vet ./...
- make build
- git diff --check
- rg -n "TODO|FIXME" cmd internal scripts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->