### PR TITLE
feat: add real model discovery CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,10 @@ export MODFETCH_CONFIG=~/.config/modfetch/config.yml
 modfetch starter list
 modfetch starter download --id gpt2-config
 
+# Search real providers and download a selected model
+modfetch discover search "sshleifer/tiny-gpt2"
+modfetch discover download "sshleifer/tiny-gpt2" --select 1
+
 # The same starter works anywhere a URL is accepted
 modfetch download --url 'starter://gpt2-tokenizer'
 
@@ -321,6 +325,10 @@ modfetch download --url 'URL'
 # Choose a beginner-safe starter download
 modfetch starter list
 modfetch starter download --id gpt2-config
+
+# Search real model providers
+modfetch discover search "tiny gpt2"
+modfetch discover download "sshleifer/tiny-gpt2" --select 1
 
 # Verify downloads
 modfetch verify --all

--- a/TESTING.md
+++ b/TESTING.md
@@ -60,6 +60,7 @@ export MODFETCH_CONFIG="${MODFETCH_CONFIG:-$HOME/.config/modfetch/config.yml}"
 ./bin/modfetch version
 ./bin/modfetch download --config "$MODFETCH_CONFIG" --url 'https://proof.ovh.net/files/1Mb.dat' --summary-json
 ./bin/modfetch starter download --config "$MODFETCH_CONFIG" --id gpt2-config --summary-json
+./bin/modfetch discover search --provider huggingface --limit 2 'sshleifer/tiny-gpt2'
 ./bin/modfetch verify --config "$MODFETCH_CONFIG" --all
 ```
 
@@ -70,9 +71,10 @@ changes:
 scripts/uat/real_download_matrix.sh
 ```
 
-The matrix downloads a public direct HTTP file, a starter alias, and a public
-Hugging Face artifact. Set `MODFETCH_UAT_CIVITAI_URI` to add a known-small
-CivitAI URI for environments where that content and token policy are known.
+The matrix downloads a public direct HTTP file, a starter alias, a public
+Hugging Face artifact, and a tiny real Hugging Face model selected through
+`discover`. Set `MODFETCH_UAT_CIVITAI_URI` to add a known-small CivitAI URI for
+environments where that content and token policy are known.
 
 For TUI validation:
 

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -35,7 +35,7 @@ _modfetch_completions()
     local cur prev words cword
     _init_completion || return
     local presets="automatic1111 comfyui forge hf-cache ollama"
-    local cmds="config download starter place verify status tui library batch dedupe clean hostcaps version help completion"
+    local cmds="config download discover starter place verify status tui library batch dedupe clean hostcaps version help completion"
     if [[ ${cword} -eq 1 ]]; then
         COMPREPLY=( $(compgen -W "${cmds}" -- "$cur") )
         return
@@ -57,6 +57,18 @@ _modfetch_completions()
             esac ;;
         download)
             COMPREPLY=( $(compgen -W "--config --log-level --json --quiet --no-resume --url --dest --sha256 --sha256-file --batch --place --summary-json --batch-parallel --dry-run --force --no-auth-preflight --extract --extract-dir --quant --list-quants" -- "$cur") ) ;;
+        discover)
+            if [[ ${cword} -eq 2 ]]; then
+                COMPREPLY=( $(compgen -W "search download" -- "$cur") )
+                return
+            fi
+            case ${words[2]} in
+                search)
+                    COMPREPLY=( $(compgen -W "--config --log-level --json --provider --limit huggingface civitai all" -- "$cur") ) ;;
+                download)
+                    COMPREPLY=( $(compgen -W "--config --log-level --json --provider --limit --select --dest --place --summary-json --dry-run --quiet --no-resume huggingface civitai" -- "$cur") ) ;;
+                *) ;;
+            esac ;;
         starter)
             if [[ ${cword} -eq 2 ]]; then
                 COMPREPLY=( $(compgen -W "list show download" -- "$cur") )
@@ -129,7 +141,7 @@ const zshCompletion = `#compdef modfetch
 # zsh completion for modfetch (basic)
 _modfetch() {
   local -a cmds
-  cmds=(config download starter place verify status tui library batch dedupe clean hostcaps version help completion)
+  cmds=(config download discover starter place verify status tui library batch dedupe clean hostcaps version help completion)
   if (( CURRENT == 2 )); then
     _describe 'command' cmds
     return
@@ -154,6 +166,20 @@ _modfetch() {
       ;;
     download)
       _arguments '*:options:(--config --log-level --json --quiet --no-resume --url --dest --sha256 --sha256-file --batch --place --summary-json --batch-parallel --dry-run --force --no-auth-preflight --extract --extract-dir --quant --list-quants)'
+      ;;
+    discover)
+      if (( CURRENT == 3 )); then
+        _arguments '*:subcommands:(search download)'
+      else
+        case $words[3] in
+          search)
+            _arguments '*:options:(--config --log-level --json --provider --limit huggingface civitai all)'
+            ;;
+          download)
+            _arguments '*:options:(--config --log-level --json --provider --limit --select --dest --place --summary-json --dry-run --quiet --no-resume huggingface civitai)'
+            ;;
+        esac
+      fi
       ;;
     starter)
       if (( CURRENT == 3 )); then
@@ -236,6 +262,7 @@ compdef _modfetch modfetch
 const fishCompletion = `# fish completion for modfetch
 complete -c modfetch -f -n "__fish_use_subcommand" -a "config" -d "config ops"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "download" -d "download assets"
+complete -c modfetch -f -n "__fish_use_subcommand" -a "discover" -d "search real model providers"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "starter" -d "beginner starter downloads"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "dedupe" -d "dedupe duplicate downloads"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "place" -d "place files"
@@ -293,6 +320,25 @@ complete -c modfetch -n "__fish_seen_subcommand_from download" -l extract -d "Ex
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l extract-dir -d "Extraction directory"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l quant -d "HuggingFace quantization to download"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l list-quants -d "List HuggingFace quantizations"
+complete -c modfetch -n "__fish_seen_subcommand_from discover" -a "search" -d "Search real model providers"
+complete -c modfetch -n "__fish_seen_subcommand_from discover" -a "download" -d "Download a selected discovery result"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from search" -l config -d "Path to config"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from search" -l log-level -d "Log level"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from search" -l json -d "JSON output"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from search" -l provider -a "huggingface civitai all" -d "Provider"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from search" -l limit -d "Result limit"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l config -d "Path to config"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l log-level -d "Log level"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l json -d "JSON output"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l provider -a "huggingface civitai" -d "Provider"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l limit -d "Result limit"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l select -d "Result index"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l dest -d "Destination path"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l place -d "Place after download"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l summary-json -d "Print completion summary as JSON"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l dry-run -d "Plan without downloading"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l quiet -d "Suppress progress and info logs"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l no-resume -d "Start fresh instead of resuming"
 complete -c modfetch -n "__fish_seen_subcommand_from starter" -a "list" -d "List starter downloads"
 complete -c modfetch -n "__fish_seen_subcommand_from starter" -a "show" -d "Show starter details"
 complete -c modfetch -n "__fish_seen_subcommand_from starter" -a "download" -d "Download a starter"

--- a/cmd/modfetch/completion_test.go
+++ b/cmd/modfetch/completion_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCompletionTopLevelCommands(t *testing.T) {
 	for name, script := range completionScripts() {
-		for _, command := range []string{"config", "download", "starter", "place", "verify", "status", "tui", "batch", "dedupe", "clean", "hostcaps", "version", "help", "completion"} {
+		for _, command := range []string{"config", "download", "discover", "starter", "place", "verify", "status", "tui", "batch", "dedupe", "clean", "hostcaps", "version", "help", "completion"} {
 			want := completionCommandToken(name, command)
 			if !strings.Contains(script, want) {
 				t.Fatalf("%s completion missing top-level command %q", name, command)
@@ -20,6 +20,7 @@ func TestCompletionCurrentFlags(t *testing.T) {
 	tests := map[string][]string{
 		"config":   {"--strict", "--out"},
 		"download": {"--no-resume", "--summary-json", "--batch-parallel", "--dry-run", "--force", "--no-auth-preflight", "--quant", "--list-quants"},
+		"discover": {"--provider", "--limit", "--select", "--summary-json", "--dry-run"},
 		"starter":  {"--id", "--summary-json", "--dry-run"},
 		"place":    {"--dry-run", "--preset", "--list-presets"},
 		"batch":    {"--naming-pattern"},
@@ -62,16 +63,19 @@ func TestCompletionNestedSubcommandFlags(t *testing.T) {
 		case "bash":
 			assertContains(t, name, "config", configSection, "case ${words[2]}", "validate)", "wizard)", "--strict", "--out")
 			assertContains(t, name, "batch", batchSection, "case ${words[2]}", "import)", "--naming-pattern")
+			assertContains(t, name, "discover", completionCommandSection(t, name, script, "discover"), "search", "download", "--provider", "--select")
 			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "--target", "--dry-run", "--token-env")
 			assertContains(t, name, "starter", completionCommandSection(t, name, script, "starter"), "list", "show", "download", "gpt2-config")
 		case "zsh":
 			assertContains(t, name, "config", configSection, "case $words[3]", "validate)", "wizard)", "--strict", "--out")
 			assertContains(t, name, "batch", batchSection, "case $words[3]", "import)", "--naming-pattern")
+			assertContains(t, name, "discover", completionCommandSection(t, name, script, "discover"), "search", "download", "--provider", "--select")
 			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "--target", "--dry-run", "--token-env")
 			assertContains(t, name, "starter", completionCommandSection(t, name, script, "starter"), "list", "show", "download", "gpt2-config")
 		case "fish":
 			assertContains(t, name, "config", configSection, "and __fish_seen_subcommand_from validate", "and __fish_seen_subcommand_from wizard", "-l strict", "-l out")
 			assertContains(t, name, "batch", batchSection, "and __fish_seen_subcommand_from import", "-l naming-pattern")
+			assertContains(t, name, "discover", completionCommandSection(t, name, script, "discover"), "search", "download", "-l provider", "-l select")
 			assertContains(t, name, "library", completionCommandSection(t, name, script, "library"), "sync", "push", "pull", "-l target", "-l dry-run", "-l token-env")
 			assertContains(t, name, "starter", completionCommandSection(t, name, script, "starter"), "gpt2-config", "-l id", "-l dry-run")
 		}

--- a/cmd/modfetch/discover_cmd.go
+++ b/cmd/modfetch/discover_cmd.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/dustin/go-humanize"
+
+	"github.com/jxwalker/modfetch/internal/discovery"
+)
+
+func handleDiscover(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: modfetch discover [search|download] QUERY")
+	}
+	switch args[0] {
+	case "search":
+		return discoverSearch(ctx, args[1:])
+	case "download":
+		return discoverDownload(ctx, args[1:])
+	case "help", "-h", "--help":
+		printDiscoverUsage()
+		return nil
+	default:
+		return discoverSearch(ctx, args)
+	}
+}
+
+func printDiscoverUsage() {
+	fmt.Println(strings.TrimSpace(`Usage:
+  modfetch discover search QUERY [--provider huggingface|civitai|all] [--limit N] [--json]
+  modfetch discover download QUERY [--provider huggingface|civitai] [--select N] [download flags]
+
+Examples:
+  modfetch discover search "tiny gpt2"
+  modfetch discover download "sshleifer/tiny-gpt2" --select 1 --summary-json
+  modfetch discover download "llama gguf" --select 2 --dry-run`))
+}
+
+func discoverSearch(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("discover search", flag.ContinueOnError)
+	common := addCommonConfigLogFlags(fs, "print discovery results as JSON")
+	provider := fs.String("provider", discovery.ProviderHuggingFace, "provider: huggingface|civitai|all")
+	limit := fs.Int("limit", 5, "maximum results to show")
+	flagArgs, queryArgs := splitDiscoverArgs(args, map[string]bool{
+		"json": true,
+	})
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	query := strings.TrimSpace(strings.Join(append(queryArgs, fs.Args()...), " "))
+	results, err := discovery.Search(ctx, discovery.Options{Provider: *provider, Query: query, Limit: *limit})
+	if err != nil {
+		return err
+	}
+	return printDiscoveryResults(results, query, *common.jsonOut)
+}
+
+func discoverDownload(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("discover download", flag.ContinueOnError)
+	common := addCommonConfigLogFlags(fs, "")
+	provider := fs.String("provider", discovery.ProviderHuggingFace, "provider: huggingface|civitai")
+	limit := fs.Int("limit", 5, "maximum search results to inspect")
+	selectIndex := fs.Int("select", 1, "1-based result index to download")
+	dest := fs.String("dest", "", "destination path")
+	placeFlag := fs.Bool("place", false, "place after successful download")
+	summaryJSON := fs.Bool("summary-json", false, "print completion summary as JSON")
+	dryRun := fs.Bool("dry-run", false, "plan without downloading")
+	quiet := fs.Bool("quiet", false, "suppress progress and info logs")
+	noResume := fs.Bool("no-resume", false, "start fresh instead of resuming")
+	flagArgs, queryArgs := splitDiscoverArgs(args, map[string]bool{
+		"json": true, "place": true, "summary-json": true, "dry-run": true, "quiet": true, "no-resume": true,
+	})
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	query := strings.TrimSpace(strings.Join(append(queryArgs, fs.Args()...), " "))
+	results, err := discovery.Search(ctx, discovery.Options{Provider: *provider, Query: query, Limit: *limit})
+	if err != nil {
+		return err
+	}
+	if len(results) == 0 {
+		return fmt.Errorf("no discovery results for %q", query)
+	}
+	if *selectIndex < 1 || *selectIndex > len(results) {
+		return fmt.Errorf("--select must be between 1 and %d", len(results))
+	}
+	selected := results[*selectIndex-1]
+	if !*quiet && !*common.jsonOut {
+		fmt.Fprintf(os.Stderr, "Selected %d: %s (%s)\n", selected.Index, selected.Name, selected.URI)
+	}
+	downloadArgs := []string{
+		"--config", *common.configPath,
+		"--log-level", *common.logLevel,
+		"--url", selected.URI,
+	}
+	if *common.jsonOut {
+		downloadArgs = append(downloadArgs, "--json")
+	}
+	if strings.TrimSpace(*dest) != "" {
+		downloadArgs = append(downloadArgs, "--dest", *dest)
+	}
+	if *placeFlag {
+		downloadArgs = append(downloadArgs, "--place")
+	}
+	if *summaryJSON {
+		downloadArgs = append(downloadArgs, "--summary-json")
+	}
+	if *dryRun {
+		downloadArgs = append(downloadArgs, "--dry-run")
+	}
+	if *quiet {
+		downloadArgs = append(downloadArgs, "--quiet")
+	}
+	if *noResume {
+		downloadArgs = append(downloadArgs, "--no-resume")
+	}
+	return handleDownload(ctx, downloadArgs)
+}
+
+func printDiscoveryResults(results []discovery.Result, query string, jsonOut bool) error {
+	if jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(results)
+	}
+	if len(results) == 0 {
+		fmt.Println("No matching models found.")
+		return nil
+	}
+	fmt.Println("Real model candidates:")
+	for _, result := range results {
+		size := "-"
+		if result.Size > 0 {
+			size = humanize.Bytes(uint64(result.Size))
+		}
+		meta := strings.TrimSpace(result.Pipeline)
+		if meta == "" {
+			meta = strings.TrimSpace(result.Description)
+		}
+		if meta == "" {
+			meta = result.Provider
+		}
+		fmt.Printf("%2d. %-36s %-12s downloads=%s likes=%s\n", result.Index, trimDisplay(result.Name, 36), size, humanize.Comma(result.Downloads), humanize.Comma(result.Likes))
+		fmt.Printf("    %s\n", meta)
+		if result.FilePath != "" || result.FileName != "" {
+			file := result.FilePath
+			if file == "" {
+				file = result.FileName
+			}
+			fmt.Printf("    file: %s\n", file)
+		}
+		fmt.Printf("    uri:  %s\n", result.URI)
+		fmt.Printf("    download: modfetch discover download %s --select %s\n", strconv.Quote(query), strconv.Itoa(result.Index))
+	}
+	return nil
+}
+
+func trimDisplay(value string, max int) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= max {
+		return value
+	}
+	if max <= 1 {
+		return value[:max]
+	}
+	return value[:max-1] + "..."
+}
+
+func splitDiscoverArgs(args []string, boolFlags map[string]bool) ([]string, []string) {
+	var flagArgs []string
+	var queryArgs []string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			queryArgs = append(queryArgs, args[i+1:]...)
+			break
+		}
+		if !strings.HasPrefix(arg, "-") || arg == "-" {
+			queryArgs = append(queryArgs, arg)
+			continue
+		}
+		flagArgs = append(flagArgs, arg)
+		name := strings.TrimLeft(arg, "-")
+		if eq := strings.IndexByte(name, '='); eq >= 0 {
+			name = name[:eq]
+		}
+		if strings.Contains(arg, "=") || boolFlags[name] {
+			continue
+		}
+		if i+1 < len(args) {
+			i++
+			flagArgs = append(flagArgs, args[i])
+		}
+	}
+	return flagArgs, queryArgs
+}

--- a/cmd/modfetch/discover_cmd_test.go
+++ b/cmd/modfetch/discover_cmd_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/discovery"
+)
+
+func TestPrintDiscoveryResultsShowsDownloadCommand(t *testing.T) {
+	out := captureStdout(t, func() {
+		err := printDiscoveryResults([]discovery.Result{{
+			Index:     1,
+			Provider:  discovery.ProviderHuggingFace,
+			Name:      "owner/tiny",
+			Pipeline:  "text-generation",
+			Downloads: 42,
+			Likes:     7,
+			FilePath:  "tiny.gguf",
+			Size:      2048,
+			URI:       "hf://owner/tiny/tiny.gguf?rev=main",
+		}}, "tiny gpt2", false)
+		if err != nil {
+			t.Fatalf("print discovery results: %v", err)
+		}
+	})
+	for _, want := range []string{"owner/tiny", "tiny.gguf", "hf://owner/tiny/tiny.gguf?rev=main", "modfetch discover download \"tiny gpt2\" --select 1"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -60,6 +60,8 @@ func run(ctx context.Context, args []string) error {
 		return handleStatus(ctx, args[1:])
 	case "download":
 		return handleDownload(ctx, args[1:])
+	case "discover":
+		return handleDiscover(ctx, args[1:])
 	case "starter":
 		return handleStarter(ctx, args[1:])
 	case "place":
@@ -103,6 +105,7 @@ Commands:
   config print      Print the loaded config as JSON
   config wizard     Interactive TUI to generate a YAML config
   download          Download a file via direct URL or resolver URI (starter://, hf://, civitai://)
+  discover          Search real model providers and download a selected result
   starter           List or download beginner-safe starter artifacts
   status            Show download status (table or JSON)
   place             Place a file into configured app directories

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -8,6 +8,7 @@ Complete command-line reference for modfetch. For the visual TUI interface, see 
 - [Global Flags](#global-flags)
 - [Commands](#commands)
   - [download](#download)
+  - [discover](#discover)
   - [starter](#starter)
   - [verify](#verify)
   - [place](#place)
@@ -32,6 +33,8 @@ modfetch provides a rich CLI for downloading, verifying, and managing AI models.
 **Quick command summary:**
 ```bash
 modfetch download --url URL       # Download a file
+modfetch discover search "tiny gpt2"
+modfetch discover download "sshleifer/tiny-gpt2" --select 1
 modfetch verify --all              # Verify all downloads
 modfetch place --path FILE         # Place model into app
 modfetch clean --days 7            # Clean old partials
@@ -119,6 +122,23 @@ modfetch download --url 'civitai://model/123456'
 modfetch download --url 'civitai://model/123456?version=456789'
 modfetch download --url 'civitai://model/123456?file=specific-file.safetensors'
 ```
+
+### discover
+
+Search real model providers, inspect the recommended downloadable file, and
+download a selected result through the normal `download` pipeline.
+
+```bash
+modfetch discover search "tiny gpt2"
+modfetch discover search "llama gguf" --provider huggingface --limit 10
+modfetch discover download "sshleifer/tiny-gpt2" --select 1 --summary-json
+```
+
+Search results include a resolver URI that can be copied into `download`, batch
+files, or the TUI new-download modal. `discover download` searches first, picks
+the `--select` result number, and then delegates to `download`, so normal flags
+such as `--config`, `--dest`, `--place`, `--dry-run`, `--quiet`, and
+`--summary-json` still apply.
 
 ### starter
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -223,6 +223,13 @@ modfetch starter list
 modfetch starter download --id gpt2-config
 ```
 
+To choose from real provider search results instead:
+
+```bash
+modfetch discover search "sshleifer/tiny-gpt2"
+modfetch discover download "sshleifer/tiny-gpt2" --select 1
+```
+
 Starter IDs also work in the TUI and regular download command as
 `starter://ID`, for example `starter://gpt2-tokenizer`.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -45,8 +45,9 @@ scripts/uat/real_download_matrix.sh
 
 The real download matrix builds the local binary if needed, creates an isolated
 temporary config, then performs live public downloads through direct HTTP,
-`starter://`, and Hugging Face resolver paths. It verifies the resulting
-download records before removing its temporary workspace.
+`starter://`, Hugging Face resolver paths, and a tiny real Hugging Face model
+selected through `discover`. It verifies the resulting download records before
+removing its temporary workspace.
 
 Set `MODFETCH_UAT_CIVITAI_URI` to add a known-small CivitAI download to the
 matrix. This is intentionally opt-in because CivitAI availability, gating, and

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -1,0 +1,375 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	ProviderHuggingFace = "huggingface"
+	ProviderCivitAI     = "civitai"
+	ProviderAll         = "all"
+)
+
+var (
+	huggingFaceBaseURL = "https://huggingface.co"
+	civitaiBaseURL     = "https://civitai.com"
+)
+
+type Options struct {
+	Provider string
+	Query    string
+	Limit    int
+}
+
+type Result struct {
+	Index       int      `json:"index"`
+	Provider    string   `json:"provider"`
+	ModelID     string   `json:"model_id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Pipeline    string   `json:"pipeline,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Downloads   int64    `json:"downloads,omitempty"`
+	Likes       int64    `json:"likes,omitempty"`
+	VersionID   string   `json:"version_id,omitempty"`
+	FilePath    string   `json:"file_path,omitempty"`
+	FileName    string   `json:"file_name,omitempty"`
+	FileType    string   `json:"file_type,omitempty"`
+	Size        int64    `json:"size,omitempty"`
+	URI         string   `json:"uri"`
+}
+
+type hfModel struct {
+	ID          string   `json:"id"`
+	ModelID     string   `json:"modelId"`
+	Downloads   int64    `json:"downloads"`
+	Likes       int64    `json:"likes"`
+	Tags        []string `json:"tags"`
+	PipelineTag string   `json:"pipeline_tag"`
+}
+
+type hfRepoFile struct {
+	Type string `json:"type"`
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+}
+
+type civitaiSearchResponse struct {
+	Items []civitaiModel `json:"items"`
+}
+
+type civitaiModel struct {
+	ID            int              `json:"id"`
+	Name          string           `json:"name"`
+	Description   string           `json:"description"`
+	Type          string           `json:"type"`
+	Tags          []string         `json:"tags"`
+	ModelVersions []civitaiVersion `json:"modelVersions"`
+	Stats         struct {
+		DownloadCount int64 `json:"downloadCount"`
+		ThumbsUpCount int64 `json:"thumbsUpCount"`
+	} `json:"stats"`
+}
+
+type civitaiVersion struct {
+	ID    int           `json:"id"`
+	Name  string        `json:"name"`
+	Files []civitaiFile `json:"files"`
+}
+
+type civitaiFile struct {
+	Name   string  `json:"name"`
+	Type   string  `json:"type"`
+	SizeKB float64 `json:"sizeKB"`
+}
+
+func Search(ctx context.Context, opts Options) ([]Result, error) {
+	opts.Provider = normalizeProvider(opts.Provider)
+	opts.Query = strings.TrimSpace(opts.Query)
+	if opts.Query == "" {
+		return nil, errors.New("discover query is required")
+	}
+	if opts.Limit <= 0 {
+		opts.Limit = 5
+	}
+	if opts.Limit > 25 {
+		opts.Limit = 25
+	}
+	if opts.Provider != ProviderHuggingFace && opts.Provider != ProviderCivitAI && opts.Provider != ProviderAll {
+		return nil, fmt.Errorf("unknown discovery provider %q", opts.Provider)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	var (
+		results []Result
+		errs    []error
+	)
+	if opts.Provider == ProviderHuggingFace || opts.Provider == ProviderAll {
+		hf, err := searchHuggingFace(ctx, client, opts.Query, opts.Limit)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		results = append(results, hf...)
+	}
+	if opts.Provider == ProviderCivitAI || opts.Provider == ProviderAll {
+		civ, err := searchCivitAI(ctx, client, opts.Query, opts.Limit)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		results = append(results, civ...)
+	}
+	if len(results) == 0 && len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].Provider != results[j].Provider {
+			return results[i].Provider < results[j].Provider
+		}
+		if results[i].Downloads != results[j].Downloads {
+			return results[i].Downloads > results[j].Downloads
+		}
+		return results[i].Likes > results[j].Likes
+	})
+	if len(results) > opts.Limit {
+		results = results[:opts.Limit]
+	}
+	for i := range results {
+		results[i].Index = i + 1
+	}
+	return results, nil
+}
+
+func normalizeProvider(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "", "hf", "huggingface", "hugging-face":
+		return ProviderHuggingFace
+	case "civ", "civitai", "civit-ai":
+		return ProviderCivitAI
+	case "all":
+		return ProviderAll
+	default:
+		return strings.ToLower(strings.TrimSpace(provider))
+	}
+}
+
+func searchHuggingFace(ctx context.Context, client *http.Client, query string, limit int) ([]Result, error) {
+	u, err := url.Parse(huggingFaceBaseURL + "/api/models")
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	q.Set("search", query)
+	q.Set("limit", fmt.Sprintf("%d", limit))
+	q.Set("sort", "downloads")
+	q.Set("direction", "-1")
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	var models []hfModel
+	if err := doJSON(client, req, &models); err != nil {
+		return nil, fmt.Errorf("huggingface search: %w", err)
+	}
+	out := make([]Result, 0, len(models))
+	for _, model := range models {
+		modelID := strings.TrimSpace(model.ModelID)
+		if modelID == "" {
+			modelID = strings.TrimSpace(model.ID)
+		}
+		if modelID == "" {
+			continue
+		}
+		candidate, _ := bestHFFile(ctx, client, modelID)
+		result := Result{
+			Provider:  ProviderHuggingFace,
+			ModelID:   modelID,
+			Name:      modelID,
+			Pipeline:  model.PipelineTag,
+			Tags:      model.Tags,
+			Downloads: model.Downloads,
+			Likes:     model.Likes,
+			URI:       "hf://" + modelID + "?rev=main",
+		}
+		if candidate.Path != "" {
+			result.FilePath = candidate.Path
+			result.FileName = path.Base(candidate.Path)
+			result.FileType = strings.TrimPrefix(strings.ToLower(path.Ext(candidate.Path)), ".")
+			result.Size = candidate.Size
+			result.URI = "hf://" + modelID + "/" + candidate.Path + "?rev=main"
+		}
+		out = append(out, result)
+	}
+	return out, nil
+}
+
+func bestHFFile(ctx context.Context, client *http.Client, modelID string) (hfRepoFile, error) {
+	u := strings.TrimRight(huggingFaceBaseURL, "/") + "/api/models/" + modelID + "/tree/main?recursive=true"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return hfRepoFile{}, err
+	}
+	var files []hfRepoFile
+	if err := doJSON(client, req, &files); err != nil {
+		return hfRepoFile{}, err
+	}
+	var best hfRepoFile
+	bestScore := -1
+	for _, file := range files {
+		if file.Type != "file" {
+			continue
+		}
+		score := hfFileScore(file.Path)
+		if score < 0 {
+			continue
+		}
+		if score > bestScore || (score == bestScore && preferSmallerNonZero(file.Size, best.Size)) {
+			best = file
+			bestScore = score
+		}
+	}
+	if best.Path == "" {
+		return hfRepoFile{}, errors.New("no downloadable model file found")
+	}
+	return best, nil
+}
+
+func hfFileScore(filePath string) int {
+	name := strings.ToLower(path.Base(filePath))
+	ext := strings.ToLower(path.Ext(name))
+	var score int
+	switch ext {
+	case ".gguf":
+		score = 100
+	case ".safetensors":
+		score = 90
+	case ".bin":
+		score = 80
+	case ".pt", ".pth", ".ckpt":
+		score = 70
+	case ".onnx":
+		score = 50
+	default:
+		return -1
+	}
+	switch {
+	case strings.Contains(name, "q4_k_m"):
+		score += 12
+	case strings.Contains(name, "q5_k_m"):
+		score += 10
+	case strings.Contains(name, "q4"):
+		score += 8
+	case strings.Contains(name, "fp16") || strings.Contains(name, "f16"):
+		score += 5
+	}
+	if strings.Contains(name, "optimizer") || strings.Contains(name, "training_args") {
+		score -= 100
+	}
+	return score
+}
+
+func searchCivitAI(ctx context.Context, client *http.Client, query string, limit int) ([]Result, error) {
+	u, err := url.Parse(civitaiBaseURL + "/api/v1/models")
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	q.Set("query", query)
+	q.Set("limit", fmt.Sprintf("%d", limit))
+	q.Set("sort", "Most Downloaded")
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	var payload civitaiSearchResponse
+	if err := doJSON(client, req, &payload); err != nil {
+		return nil, fmt.Errorf("civitai search: %w", err)
+	}
+	out := make([]Result, 0, len(payload.Items))
+	for _, model := range payload.Items {
+		if model.ID == 0 {
+			continue
+		}
+		version, file := bestCivitAIFile(model.ModelVersions)
+		uri := fmt.Sprintf("civitai://model/%d", model.ID)
+		if version.ID != 0 {
+			uri += "?version=" + url.QueryEscape(fmt.Sprintf("%d", version.ID))
+			if strings.TrimSpace(file.Name) != "" {
+				uri += "&file=" + url.QueryEscape(file.Name)
+			}
+		}
+		out = append(out, Result{
+			Provider:    ProviderCivitAI,
+			ModelID:     fmt.Sprintf("%d", model.ID),
+			Name:        strings.TrimSpace(model.Name),
+			Description: strings.TrimSpace(model.Type),
+			Tags:        model.Tags,
+			Downloads:   model.Stats.DownloadCount,
+			Likes:       model.Stats.ThumbsUpCount,
+			VersionID:   zeroIntString(version.ID),
+			FileName:    file.Name,
+			FileType:    file.Type,
+			Size:        int64(file.SizeKB * 1024),
+			URI:         uri,
+		})
+	}
+	return out, nil
+}
+
+func bestCivitAIFile(versions []civitaiVersion) (civitaiVersion, civitaiFile) {
+	var version civitaiVersion
+	for _, candidate := range versions {
+		if candidate.ID > version.ID {
+			version = candidate
+		}
+	}
+	var best civitaiFile
+	for _, file := range version.Files {
+		if strings.EqualFold(file.Type, "Model") {
+			return version, file
+		}
+		if best.Name == "" {
+			best = file
+		}
+	}
+	return version, best
+}
+
+func doJSON(client *http.Client, req *http.Request, dst any) error {
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("%s", resp.Status)
+	}
+	return json.NewDecoder(resp.Body).Decode(dst)
+}
+
+func preferSmallerNonZero(a, b int64) bool {
+	if a <= 0 {
+		return false
+	}
+	if b <= 0 {
+		return true
+	}
+	return a < b
+}
+
+func zeroIntString(v int) string {
+	if v == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d", v)
+}

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -1,0 +1,78 @@
+package discovery
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSearchHuggingFaceReturnsDownloadableURI(t *testing.T) {
+	old := huggingFaceBaseURL
+	defer func() { huggingFaceBaseURL = old }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/models":
+			if got := r.URL.Query().Get("search"); got != "tiny" {
+				t.Fatalf("search query = %q", got)
+			}
+			_, _ = w.Write([]byte(`[{"id":"owner/tiny","modelId":"owner/tiny","downloads":42,"likes":7,"pipeline_tag":"text-generation","tags":["gguf"]}]`))
+		case "/api/models/owner/tiny/tree/main":
+			_, _ = w.Write([]byte(`[
+				{"type":"file","path":"README.md","size":123},
+				{"type":"file","path":"tiny.Q4_K_M.gguf","size":2048},
+				{"type":"file","path":"model.safetensors","size":4096}
+			]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	huggingFaceBaseURL = server.URL
+
+	results, err := Search(context.Background(), Options{Provider: ProviderHuggingFace, Query: "tiny", Limit: 3})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d", len(results))
+	}
+	got := results[0]
+	if got.URI != "hf://owner/tiny/tiny.Q4_K_M.gguf?rev=main" {
+		t.Fatalf("uri = %q", got.URI)
+	}
+	if got.Size != 2048 || got.FileType != "gguf" || got.Index != 1 {
+		t.Fatalf("unexpected result: %+v", got)
+	}
+}
+
+func TestSearchCivitAIReturnsResolverURI(t *testing.T) {
+	old := civitaiBaseURL
+	defer func() { civitaiBaseURL = old }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/models" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"items":[{"id":123,"name":"Tiny Checkpoint","type":"Checkpoint","tags":["sd"],"stats":{"downloadCount":9,"thumbsUpCount":2},"modelVersions":[{"id":456,"name":"v1","files":[{"name":"tiny.safetensors","type":"Model","sizeKB":10.5}]}]}]}`))
+	}))
+	defer server.Close()
+	civitaiBaseURL = server.URL
+
+	results, err := Search(context.Background(), Options{Provider: ProviderCivitAI, Query: "tiny", Limit: 3})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d", len(results))
+	}
+	got := results[0]
+	if got.URI != "civitai://model/123?version=456&file=tiny.safetensors" {
+		t.Fatalf("uri = %q", got.URI)
+	}
+	if got.Size != 10752 || got.FileType != "Model" || got.VersionID != "456" {
+		t.Fatalf("unexpected result: %+v", got)
+	}
+}

--- a/scripts/uat/real_download_matrix.sh
+++ b/scripts/uat/real_download_matrix.sh
@@ -47,6 +47,12 @@ run_case "direct public HTTP" "https://proof.ovh.net/files/1Mb.dat"
 run_case "starter alias via resolver" "starter://gpt2-tokenizer"
 run_case "public Hugging Face resolver" "hf://gpt2/config.json?rev=607a30d783dfa663caf39e06633721c8d4cfcd7e"
 
+printf '\n==> real Hugging Face discovery search\n' >&2
+"$bin" discover search --provider huggingface --limit 2 "sshleifer/tiny-gpt2" >/dev/null
+
+printf '\n==> real Hugging Face discovery download\n' >&2
+"$bin" discover download --config "$cfg" --provider huggingface --limit 2 --select 1 --summary-json --quiet "sshleifer/tiny-gpt2"
+
 if [[ -n "${MODFETCH_UAT_CIVITAI_URI:-}" ]]; then
   run_case "configured CivitAI URI" "$MODFETCH_UAT_CIVITAI_URI"
 else


### PR DESCRIPTION
## Summary
- add `modfetch discover search` for real Hugging Face/CivitAI provider search with downloadable resolver URIs
- add `modfetch discover download` to select a search result and run it through the normal download pipeline
- extend docs, completions, tests, and the real-network UAT matrix with a tiny real Hugging Face model download

## Validation
- `go test -count=1 ./...`
- `go vet ./...`
- `make build`
- `scripts/check-docs-drift.sh`
- `scripts/uat/real_download_matrix.sh`
- `./bin/modfetch discover search --provider huggingface --limit 2 'sshleifer/tiny-gpt2'`
- query-first dry run: `./bin/modfetch discover download 'sshleifer/tiny-gpt2' --select 1 --dry-run --summary-json --quiet --config <temp config>`
- `bash -n scripts/uat/real_download_matrix.sh && git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->