### PR TITLE
 codebase review

### DIFF
--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -64,9 +64,9 @@ _modfetch_completions()
             fi
             case ${words[2]} in
                 search)
-                    COMPREPLY=( $(compgen -W "--config --log-level --json --provider --limit huggingface civitai all" -- "$cur") ) ;;
+                    COMPREPLY=( $(compgen -W "--config --log-level --json --provider --limit huggingface civitai modelscope all" -- "$cur") ) ;;
                 download)
-                    COMPREPLY=( $(compgen -W "--config --log-level --json --provider --limit --select --dest --place --summary-json --dry-run --quiet --no-resume huggingface civitai" -- "$cur") ) ;;
+                    COMPREPLY=( $(compgen -W "--config --log-level --json --provider --limit --select --dest --place --summary-json --dry-run --quiet --no-resume huggingface civitai modelscope all" -- "$cur") ) ;;
                 *) ;;
             esac ;;
         starter)
@@ -173,10 +173,10 @@ _modfetch() {
       else
         case $words[3] in
           search)
-            _arguments '*:options:(--config --log-level --json --provider --limit huggingface civitai all)'
+            _arguments '*:options:(--config --log-level --json --provider --limit huggingface civitai modelscope all)'
             ;;
           download)
-            _arguments '*:options:(--config --log-level --json --provider --limit --select --dest --place --summary-json --dry-run --quiet --no-resume huggingface civitai)'
+            _arguments '*:options:(--config --log-level --json --provider --limit --select --dest --place --summary-json --dry-run --quiet --no-resume huggingface civitai modelscope all)'
             ;;
         esac
       fi
@@ -325,12 +325,12 @@ complete -c modfetch -n "__fish_seen_subcommand_from discover" -a "download" -d 
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from search" -l config -d "Path to config"
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from search" -l log-level -d "Log level"
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from search" -l json -d "JSON output"
-complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from search" -l provider -a "huggingface civitai all" -d "Provider"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from search" -l provider -a "huggingface civitai modelscope all" -d "Provider"
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from search" -l limit -d "Result limit"
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l config -d "Path to config"
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l log-level -d "Log level"
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l json -d "JSON output"
-complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l provider -a "huggingface civitai" -d "Provider"
+complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l provider -a "huggingface civitai modelscope all" -d "Provider"
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l limit -d "Result limit"
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l select -d "Result index"
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l dest -d "Destination path"

--- a/cmd/modfetch/discover_cmd.go
+++ b/cmd/modfetch/discover_cmd.go
@@ -34,8 +34,8 @@ func handleDiscover(ctx context.Context, args []string) error {
 
 func printDiscoverUsage() {
 	fmt.Println(strings.TrimSpace(`Usage:
-  modfetch discover search QUERY [--provider huggingface|civitai|all] [--limit N] [--json]
-  modfetch discover download QUERY [--provider huggingface|civitai] [--select N] [download flags]
+  modfetch discover search QUERY [--provider huggingface|civitai|modelscope|all] [--limit N] [--json]
+  modfetch discover download QUERY [--provider huggingface|civitai|modelscope|all] [--select N] [download flags]
 
 Examples:
   modfetch discover search "tiny gpt2"
@@ -46,7 +46,7 @@ Examples:
 func discoverSearch(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("discover search", flag.ContinueOnError)
 	common := addCommonConfigLogFlags(fs, "print discovery results as JSON")
-	provider := fs.String("provider", discovery.ProviderHuggingFace, "provider: huggingface|civitai|all")
+	provider := fs.String("provider", discovery.ProviderHuggingFace, "provider: huggingface|civitai|modelscope|all")
 	limit := fs.Int("limit", 5, "maximum results to show")
 	flagArgs, queryArgs := splitDiscoverArgs(args, map[string]bool{
 		"json": true,
@@ -65,7 +65,7 @@ func discoverSearch(ctx context.Context, args []string) error {
 func discoverDownload(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("discover download", flag.ContinueOnError)
 	common := addCommonConfigLogFlags(fs, "")
-	provider := fs.String("provider", discovery.ProviderHuggingFace, "provider: huggingface|civitai")
+	provider := fs.String("provider", discovery.ProviderHuggingFace, "provider: huggingface|civitai|modelscope|all")
 	limit := fs.Int("limit", 5, "maximum search results to inspect")
 	selectIndex := fs.Int("select", 1, "1-based result index to download")
 	dest := fs.String("dest", "", "destination path")

--- a/cmd/modfetch/download_cmd.go
+++ b/cmd/modfetch/download_cmd.go
@@ -460,33 +460,31 @@ func handleDownload(ctx context.Context, args []string) error {
 		resolvedURL = res.URL
 		headers = res.Headers
 	} else {
-		// Attach auth headers for direct URLs when possible. Mirrors the
-		// batch/TUI behaviour: if Sources.<Provider>.TokenEnv is empty, fall
-		// back to the conventional CIVITAI_TOKEN / HF_TOKEN names so users
-		// who set those env vars without configuring token_env still get
-		// authenticated downloads instead of preflight 401/403s.
+		// Attach auth headers for direct URLs when possible, but only when
+		// sources.<provider>.token_env is explicitly configured. An empty
+		// token_env means "do not attach auth", matching the semantics in
+		// internal/resolver/{civitai,huggingface}.go and cmd/modfetch/batch_cmd.go;
+		// we deliberately do not fall back to ambient CIVITAI_TOKEN / HF_TOKEN
+		// here so users who left token_env unset never get unexpected
+		// credentials sent to direct URLs.
 		if u, err := neturl.Parse(resolvedURL); err == nil {
 			h := strings.ToLower(u.Hostname())
 			if hostIs(h, "civitai.com") && c.Sources.CivitAI.Enabled {
-				env := strings.TrimSpace(c.Sources.CivitAI.TokenEnv)
-				if env == "" {
-					env = "CIVITAI_TOKEN"
-				}
-				if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
-					headers["Authorization"] = "Bearer " + tok
-				} else {
-					log.Warnf("CivitAI token env %s is not set; gated content will return 401. Export %s.", env, env)
+				if env := strings.TrimSpace(c.Sources.CivitAI.TokenEnv); env != "" {
+					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
+						headers["Authorization"] = "Bearer " + tok
+					} else {
+						log.Warnf("CivitAI token env %s is not set; gated content will return 401. Export %s.", env, env)
+					}
 				}
 			}
 			if hostIs(h, "huggingface.co") && c.Sources.HuggingFace.Enabled {
-				env := strings.TrimSpace(c.Sources.HuggingFace.TokenEnv)
-				if env == "" {
-					env = "HF_TOKEN"
-				}
-				if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
-					headers["Authorization"] = "Bearer " + tok
-				} else {
-					log.Warnf("Hugging Face token env %s is not set; gated repos will return 401. Export %s and accept the repo license.", env, env)
+				if env := strings.TrimSpace(c.Sources.HuggingFace.TokenEnv); env != "" {
+					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
+						headers["Authorization"] = "Bearer " + tok
+					} else {
+						log.Warnf("Hugging Face token env %s is not set; gated repos will return 401. Export %s and accept the repo license.", env, env)
+					}
 				}
 			}
 		}
@@ -633,6 +631,13 @@ func handleDownload(ctx context.Context, args []string) error {
 		size = fi.Size()
 	}
 	dur := time.Since(startWall).Seconds()
+	// Guard against zero/near-zero durations: float64(size)/0 yields +Inf,
+	// which json.Encoder cannot serialize and silently fails. Match the
+	// non-JSON branch below by reporting 0 in that edge case.
+	avgBps := 0.0
+	if dur > 0 {
+		avgBps = float64(size) / dur
+	}
 	if *summaryJSON {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
@@ -641,7 +646,7 @@ func handleDownload(ctx context.Context, args []string) error {
 			"dest":      final,
 			"size":      size,
 			"duration":  dur,
-			"avg_bps":   float64(size) / dur,
+			"avg_bps":   avgBps,
 			"sha256":    sum,
 			"status":    "ok",
 			"extracted": extracted,
@@ -684,22 +689,22 @@ func resolveBatchDownloadCandidate(ctx context.Context, c *config.Config, uri st
 	}
 	if u, err := neturl.Parse(uri); err == nil {
 		h := strings.ToLower(u.Hostname())
+		// Only attach auth when token_env is explicitly configured. Empty
+		// token_env means "do not attach auth"; matches the existing batch
+		// import logic in cmd/modfetch/batch_cmd.go and the resolver package
+		// to avoid leaking ambient CIVITAI_TOKEN / HF_TOKEN credentials.
 		if hostIs(h, "civitai.com") && c.Sources.CivitAI.Enabled {
-			env := strings.TrimSpace(c.Sources.CivitAI.TokenEnv)
-			if env == "" {
-				env = "CIVITAI_TOKEN"
-			}
-			if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
-				headers["Authorization"] = "Bearer " + tok
+			if env := strings.TrimSpace(c.Sources.CivitAI.TokenEnv); env != "" {
+				if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
+					headers["Authorization"] = "Bearer " + tok
+				}
 			}
 		}
 		if hostIs(h, "huggingface.co") && c.Sources.HuggingFace.Enabled {
-			env := strings.TrimSpace(c.Sources.HuggingFace.TokenEnv)
-			if env == "" {
-				env = "HF_TOKEN"
-			}
-			if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
-				headers["Authorization"] = "Bearer " + tok
+			if env := strings.TrimSpace(c.Sources.HuggingFace.TokenEnv); env != "" {
+				if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
+					headers["Authorization"] = "Bearer " + tok
+				}
 			}
 		}
 	}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -431,6 +431,7 @@ func searchModelScope(ctx context.Context, client *http.Client, query string, li
 		return nil, fmt.Errorf("modelscope search: %w", err)
 	}
 	out := make([]Result, 0, len(payload.Data.Models))
+	var fileErrs []error
 	for _, model := range payload.Data.Models {
 		owner := strings.TrimSpace(model.Owner)
 		name := strings.TrimSpace(model.Name)
@@ -448,8 +449,18 @@ func searchModelScope(ctx context.Context, client *http.Client, query string, li
 		// returns nothing usable (private repo, transient error, repo without
 		// downloadable weights, etc.) skip the result entirely: the model page
 		// URL is HTML and would silently produce a downloaded HTML page rather
-		// than a model file.
-		fileURI, filePath, fileSize := bestModelScopeFile(ctx, client, owner, name, modelScopeDefaultRevision)
+		// than a model file. Oversized responses short-circuit the whole
+		// search; other per-model fetch errors are collected so that if every
+		// model fails, the user sees a real provider error instead of an
+		// empty-looking success.
+		fileURI, filePath, fileSize, fileErr := bestModelScopeFile(ctx, client, owner, name, modelScopeDefaultRevision)
+		if errors.Is(fileErr, errDiscoveryResponseTooLarge) {
+			return nil, fmt.Errorf("modelscope file listing for %s: %w", modelID, fileErr)
+		}
+		if fileErr != nil {
+			fileErrs = append(fileErrs, fmt.Errorf("modelscope file listing for %s: %w", modelID, fileErr))
+			continue
+		}
 		if fileURI == "" || filePath == "" {
 			continue
 		}
@@ -468,6 +479,9 @@ func searchModelScope(ctx context.Context, client *http.Client, query string, li
 			Size:      fileSize,
 		}
 		out = append(out, result)
+	}
+	if len(out) == 0 && len(fileErrs) > 0 {
+		return nil, errors.Join(fileErrs...)
 	}
 	return out, nil
 }
@@ -491,31 +505,33 @@ func checkModelScopeEnvelope(success bool, code int, message string) error {
 // bestModelScopeFile fetches the repository file list and selects a single
 // downloadable file using the same scoring heuristic as HuggingFace. It
 // returns a fully-formed `/models/<owner>/<name>/resolve/<rev>/<path>` URL on
-// success. If the listing fails or no suitable file is found, it returns
-// empty strings so the caller can fall back to the model page URL.
-func bestModelScopeFile(ctx context.Context, client *http.Client, owner, name, revision string) (uri, filePath string, size int64) {
+// success. The error is non-nil only for fetch-level failures (network,
+// oversized response, malformed envelope); a successful fetch with no usable
+// file returns empty strings and a nil error so the caller can decide whether
+// to skip the model.
+func bestModelScopeFile(ctx context.Context, client *http.Client, owner, name, revision string) (uri, filePath string, size int64, err error) {
 	if revision == "" {
 		revision = modelScopeDefaultRevision
 	}
-	u, err := url.Parse(strings.TrimRight(modelScopeBaseURL, "/") + "/api/v1/models/" + url.PathEscape(owner) + "/" + url.PathEscape(name) + "/repo/files")
-	if err != nil {
-		return "", "", 0
+	u, parseErr := url.Parse(strings.TrimRight(modelScopeBaseURL, "/") + "/api/v1/models/" + url.PathEscape(owner) + "/" + url.PathEscape(name) + "/repo/files")
+	if parseErr != nil {
+		return "", "", 0, parseErr
 	}
 	q := u.Query()
 	q.Set("Revision", revision)
 	q.Set("Recursive", "true")
 	q.Set("PageSize", "200")
 	u.RawQuery = q.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return "", "", 0
+	req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if reqErr != nil {
+		return "", "", 0, reqErr
 	}
 	var payload modelScopeFilesResponse
-	if err := doJSON(client, req, &payload); err != nil {
-		return "", "", 0
+	if jerr := doJSON(client, req, &payload); jerr != nil {
+		return "", "", 0, jerr
 	}
-	if err := checkModelScopeEnvelope(payload.Success, payload.Code, payload.Message); err != nil {
-		return "", "", 0
+	if envErr := checkModelScopeEnvelope(payload.Success, payload.Code, payload.Message); envErr != nil {
+		return "", "", 0, envErr
 	}
 
 	bestScore := -1
@@ -542,12 +558,12 @@ func bestModelScopeFile(ctx context.Context, client *http.Client, owner, name, r
 		}
 	}
 	if best.Path == "" {
-		return "", "", 0
+		return "", "", 0, nil
 	}
 	uri = strings.TrimRight(modelScopeBaseURL, "/") + "/models/" +
 		url.PathEscape(owner) + "/" + url.PathEscape(name) +
 		"/resolve/" + url.PathEscape(revision) + "/" + escapePathSegments(best.Path)
-	return uri, best.Path, best.Size
+	return uri, best.Path, best.Size, nil
 }
 
 // isModelScopeBlob accepts the variants ModelScope's API has used to label a

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -401,10 +402,10 @@ func TestSearch_ModelScope(t *testing.T) {
 	}
 }
 
-func TestSearch_ModelScope_DropsResultsWithoutDownloadableFile(t *testing.T) {
-	// When the file listing fails, the model page URL would be HTML, so the
-	// result is dropped entirely rather than handed to `download --url`,
-	// which would otherwise save HTML masquerading as a model artifact.
+func TestSearch_ModelScope_FileListingFailureSurfaced(t *testing.T) {
+	// When the only model's file listing fails (404, auth, transient
+	// network), the empty result list would be misleading. Surface the
+	// underlying provider error so the user can act on it.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -432,12 +433,68 @@ func TestSearch_ModelScope_DropsResultsWithoutDownloadableFile(t *testing.T) {
 	modelScopeBaseURL = srv.URL
 	defer func() { modelScopeBaseURL = orig }()
 
+	_, err := Search(context.Background(), Options{Provider: ProviderModelScope, Query: "alice", Limit: 5})
+	if err == nil {
+		t.Fatal("expected error when every ModelScope file listing fails")
+	}
+	if !strings.Contains(err.Error(), "modelscope file listing for alice/MyModel") {
+		t.Errorf("err = %q, want provider-specific context naming the model", err.Error())
+	}
+}
+
+func TestSearch_ModelScope_PartialFileListingFailureKeepsResults(t *testing.T) {
+	// If at least one model resolves to a real downloadable file, per-model
+	// listing failures should be silently dropped so the partial result set
+	// is still useful.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/models":
+			_ = json.NewEncoder(w).Encode(modelScopeSearchResponse{
+				Code:    200,
+				Success: true,
+				Data: struct {
+					Models []modelScopeSearchModel `json:"Models"`
+				}{
+					Models: []modelScopeSearchModel{
+						{ID: "alice/Broken", Name: "Broken", Owner: "alice"},
+						{ID: "alice/Works", Name: "Works", Owner: "alice"},
+					},
+				},
+			})
+		case strings.Contains(r.URL.Path, "/alice/Broken/repo/files"):
+			http.Error(w, "not found", http.StatusNotFound)
+		case strings.Contains(r.URL.Path, "/alice/Works/repo/files"):
+			_ = json.NewEncoder(w).Encode(modelScopeFilesResponse{
+				Code:    200,
+				Success: true,
+				Data: struct {
+					Files []modelScopeFile `json:"Files"`
+				}{
+					Files: []modelScopeFile{
+						{Type: "blob", Path: "model.safetensors", Size: 1024},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	orig := modelScopeBaseURL
+	modelScopeBaseURL = srv.URL
+	defer func() { modelScopeBaseURL = orig }()
+
 	results, err := Search(context.Background(), Options{Provider: ProviderModelScope, Query: "alice", Limit: 5})
 	if err != nil {
 		t.Fatalf("Search ModelScope: %v", err)
 	}
-	if len(results) != 0 {
-		t.Fatalf("results len = %d, want 0 (result must be dropped when no downloadable file is resolvable)", len(results))
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1 (Works should survive Broken's failure)", len(results))
+	}
+	if results[0].ModelID != "alice/Works" {
+		t.Errorf("ModelID = %q, want alice/Works", results[0].ModelID)
 	}
 }
 
@@ -740,6 +797,103 @@ func TestSearch_LimitCapped(t *testing.T) {
 	}
 }
 
+// ---- doJSON oversized response -------------------------------------------
+
+// TestDoJSON_OversizedResponse verifies that a body larger than
+// maxDiscoveryBodyBytes returns the distinct errDiscoveryResponseTooLarge
+// error rather than masquerading as a JSON parse failure or being silently
+// truncated. This guards every discovery provider since they share doJSON.
+func TestDoJSON_OversizedResponse(t *testing.T) {
+	// Stream maxDiscoveryBodyBytes+1 bytes of valid JSON-ish padding so the
+	// LimitReader trips the oversized check before the decoder runs.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Open array, then write enough whitespace to exceed the cap. The
+		// payload is intentionally not closed; we never reach decoding.
+		_, _ = w.Write([]byte("["))
+		const chunk = 64 * 1024
+		buf := make([]byte, chunk)
+		for i := range buf {
+			buf[i] = ' '
+		}
+		written := 1
+		for int64(written) <= maxDiscoveryBodyBytes {
+			n, err := w.Write(buf)
+			if err != nil {
+				return
+			}
+			written += n
+		}
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	var dst []hfModel
+	err = doJSON(srv.Client(), req, &dst)
+	if !errors.Is(err, errDiscoveryResponseTooLarge) {
+		t.Fatalf("doJSON err = %v, want errDiscoveryResponseTooLarge", err)
+	}
+}
+
+// TestSearchModelScope_OversizedFileListingSurfacesError verifies that an
+// oversized /repo/files response is surfaced as a provider-level error
+// rather than silently dropping the model from results.
+func TestSearchModelScope_OversizedFileListingSurfacesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/models":
+			_ = json.NewEncoder(w).Encode(modelScopeSearchResponse{
+				Code:    200,
+				Success: true,
+				Data: struct {
+					Models []modelScopeSearchModel `json:"Models"`
+				}{
+					Models: []modelScopeSearchModel{
+						{ID: "alice/big", Name: "big", Owner: "alice"},
+					},
+				},
+			})
+		case strings.HasSuffix(r.URL.Path, "/repo/files"):
+			_, _ = w.Write([]byte("["))
+			const chunk = 64 * 1024
+			buf := make([]byte, chunk)
+			for i := range buf {
+				buf[i] = ' '
+			}
+			written := 1
+			for int64(written) <= maxDiscoveryBodyBytes {
+				n, werr := w.Write(buf)
+				if werr != nil {
+					return
+				}
+				written += n
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	orig := modelScopeBaseURL
+	modelScopeBaseURL = srv.URL
+	defer func() { modelScopeBaseURL = orig }()
+
+	_, err := Search(context.Background(), Options{Provider: ProviderModelScope, Query: "big", Limit: 5})
+	if err == nil {
+		t.Fatal("expected error when ModelScope file listing exceeds max body size")
+	}
+	if !errors.Is(err, errDiscoveryResponseTooLarge) {
+		t.Errorf("err = %v, want chain containing errDiscoveryResponseTooLarge", err)
+	}
+	if !strings.Contains(err.Error(), "modelscope file listing for alice/big") {
+		t.Errorf("err = %q, want provider-specific context", err.Error())
+	}
+}
+
 func TestSearch_IndexAssigned(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -760,7 +914,10 @@ func TestSearch_IndexAssigned(t *testing.T) {
 	huggingFaceBaseURL = srv.URL
 	defer func() { huggingFaceBaseURL = orig }()
 
-	results, _ := Search(context.Background(), Options{Provider: ProviderHuggingFace, Query: "model", Limit: 5})
+	results, err := Search(context.Background(), Options{Provider: ProviderHuggingFace, Query: "model", Limit: 5})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
 	for i, r := range results {
 		if r.Index != i+1 {
 			t.Errorf("results[%d].Index = %d, want %d", i, r.Index, i+1)

--- a/internal/metadata/civitai_test.go
+++ b/internal/metadata/civitai_test.go
@@ -159,6 +159,29 @@ func TestCivitAIFetcher_FetchMetadata_Unauthorized(t *testing.T) {
 	}
 }
 
+// TestCivitAIFetcher_FetchMetadata_OversizedResponse verifies that an API
+// response larger than maxMetadataBodyBytes returns the distinct
+// "response exceeds" error rather than a generic parse/read failure, so
+// callers can branch on the size cap without log scraping.
+func TestCivitAIFetcher_FetchMetadata_OversizedResponse(t *testing.T) {
+	client := routedHTTPClient(t, "civitai.com", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		writeOversizedJSONBody(w, maxMetadataBodyBytes)
+	}))
+
+	f := NewCivitAIFetcher(client)
+	ctx := context.Background()
+	url := "https://civitai.com/api/download/models/12345"
+
+	_, err := f.FetchMetadata(ctx, url)
+	if err == nil {
+		t.Fatal("FetchMetadata() expected error for oversized response, got nil")
+	}
+	if !strings.Contains(err.Error(), "response exceeds") {
+		t.Errorf("err = %q, want a 'response exceeds' size-cap error", err.Error())
+	}
+}
+
 func TestMapCivitAIType(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/metadata/fetcher.go
+++ b/internal/metadata/fetcher.go
@@ -182,10 +182,11 @@ func (f *HuggingFaceFetcher) FetchMetadata(ctx context.Context, url string) (*st
 	body, err := readBoundedBody(resp.Body, maxMetadataBodyBytes)
 	if err != nil {
 		// readBoundedBody returns ErrResponseTooLarge for oversized payloads
-		// and the underlying I/O error otherwise. Both degrade to basic
-		// metadata so the user still gets a usable record, but the error
-		// itself is distinct and remains inspectable via errors.Is at the
-		// callsite if we ever want to log or branch on it.
+		// and the underlying I/O error otherwise. Either way we degrade to
+		// basic metadata so the user still gets a usable record. The original
+		// error is intentionally swallowed here (rather than logged or
+		// wrapped) because the caller has no way to act on it once we've
+		// already committed to the basic-metadata fallback.
 		return f.basicMetadata(url, modelID, filename, version), nil
 	}
 

--- a/internal/metadata/fetcher_test.go
+++ b/internal/metadata/fetcher_test.go
@@ -7,6 +7,28 @@ import (
 	"time"
 )
 
+// writeOversizedJSONBody streams more than max bytes of an unterminated JSON
+// document. It's enough to trip the LimitReader cap in readBoundedBody before
+// the decoder ever sees the body.
+func writeOversizedJSONBody(w http.ResponseWriter, max int64) {
+	if _, err := w.Write([]byte("{\"description\":\"")); err != nil {
+		return
+	}
+	const chunk = 64 * 1024
+	buf := make([]byte, chunk)
+	for i := range buf {
+		buf[i] = 'x'
+	}
+	written := int64(len("{\"description\":\""))
+	for written <= max {
+		n, err := w.Write(buf)
+		if err != nil {
+			return
+		}
+		written += int64(n)
+	}
+}
+
 func TestHuggingFaceFetcher_CanHandle(t *testing.T) {
 	tests := []struct {
 		name string
@@ -136,6 +158,41 @@ func TestHuggingFaceFetcher_FetchMetadata_APIFailure(t *testing.T) {
 
 	if meta.ModelID != "TheBloke/Llama-2-7B-GGUF" {
 		t.Errorf("ModelID = %q, want %q", meta.ModelID, "TheBloke/Llama-2-7B-GGUF")
+	}
+}
+
+// TestHuggingFaceFetcher_FetchMetadata_OversizedResponse verifies that an
+// API response larger than maxMetadataBodyBytes degrades to basic metadata
+// instead of returning a JSON parse error or hanging on a runaway body.
+func TestHuggingFaceFetcher_FetchMetadata_OversizedResponse(t *testing.T) {
+	client := routedHTTPClient(t, "huggingface.co", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		writeOversizedJSONBody(w, maxMetadataBodyBytes)
+	}))
+
+	f := NewHuggingFaceFetcher(client)
+	ctx := context.Background()
+	url := "https://huggingface.co/TheBloke/Llama-2-7B-GGUF/resolve/main/llama-2-7b.Q4_K_M.gguf"
+
+	meta, err := f.FetchMetadata(ctx, url)
+	if err != nil {
+		t.Fatalf("FetchMetadata() should fall back to basic metadata on oversized body, got error = %v", err)
+	}
+	// Basic metadata derives identity from the URL, never from the (oversized)
+	// API body, so these fields should match the URL-only fallback path.
+	if meta.Source != "huggingface" {
+		t.Errorf("Source = %q, want %q", meta.Source, "huggingface")
+	}
+	if meta.ModelID != "TheBloke/Llama-2-7B-GGUF" {
+		t.Errorf("ModelID = %q, want %q", meta.ModelID, "TheBloke/Llama-2-7B-GGUF")
+	}
+	if meta.Quantization != "Q4_K_M" {
+		t.Errorf("Quantization = %q, want %q (extracted from URL filename)", meta.Quantization, "Q4_K_M")
+	}
+	// Description in the basic-metadata branch is empty; if it carried the
+	// truncated oversized body, it would be huge.
+	if meta.Description != "" {
+		t.Errorf("Description should be empty on basic-metadata fallback, got %d bytes", len(meta.Description))
 	}
 }
 


### PR DESCRIPTION
This pull request adds support for the ModelScope provider to the model discovery system and introduces safeguards to prevent excessive memory usage from large server responses. It also refactors the metadata fetching logic to consistently enforce response size limits and handle oversized payloads gracefully.

**Model Discovery Enhancements:**

* Added support for the ModelScope provider (`modelscope.cn`) in the discovery API, including provider normalization, result fetching, and file selection logic. This allows users to search and retrieve models from ModelScope in addition to existing providers. [[1]](diffhunk://#diff-916e6863e1245c673b4e5965c98dc27bafbd72650fdb38ce65ea73ee6304e027R17-R37) [[2]](diffhunk://#diff-916e6863e1245c673b4e5965c98dc27bafbd72650fdb38ce65ea73ee6304e027L107-R120) [[3]](diffhunk://#diff-916e6863e1245c673b4e5965c98dc27bafbd72650fdb38ce65ea73ee6304e027R143-R149) [[4]](diffhunk://#diff-916e6863e1245c673b4e5965c98dc27bafbd72650fdb38ce65ea73ee6304e027R177-R178) [[5]](diffhunk://#diff-916e6863e1245c673b4e5965c98dc27bafbd72650fdb38ce65ea73ee6304e027R370-R574)
* Implemented logic to select the best downloadable file for a ModelScope model, mirroring the approach used for HuggingFace, and ensured that only valid, downloadable files are returned in search results.

**Response Size Limiting and Error Handling:**

* Introduced a maximum response body size (`maxDiscoveryBodyBytes` for discovery, `maxMetadataBodyBytes` for metadata) to prevent memory overuse from large or malicious server responses. If a response exceeds this size, a specific error is returned. [[1]](diffhunk://#diff-916e6863e1245c673b4e5965c98dc27bafbd72650fdb38ce65ea73ee6304e027R17-R37) [[2]](diffhunk://#diff-916e6863e1245c673b4e5965c98dc27bafbd72650fdb38ce65ea73ee6304e027L357-R593) [[3]](diffhunk://#diff-b79267fd84276f23527cdd38632a7db973290dfbea3dfacfaf364c360578148bR18-R45)
* Refactored the `doJSON` and metadata fetching logic to use bounded body readers and to distinguish between oversized responses and other I/O or JSON parsing errors, improving robustness and error reporting. [[1]](diffhunk://#diff-916e6863e1245c673b4e5965c98dc27bafbd72650fdb38ce65ea73ee6304e027L357-R593) [[2]](diffhunk://#diff-b79267fd84276f23527cdd38632a7db973290dfbea3dfacfaf364c360578148bR18-R45) [[3]](diffhunk://#diff-7cd13ce61838a849333c8ef406e4568e86264afacf62aef3c39b8be06daed37aL101-R105) [[4]](diffhunk://#diff-b79267fd84276f23527cdd38632a7db973290dfbea3dfacfaf364c360578148bL153-R188)

**Code Quality and Consistency:**

* Updated imports and error handling in related files to support the new error types and response size checks. [[1]](diffhunk://#diff-916e6863e1245c673b4e5965c98dc27bafbd72650fdb38ce65ea73ee6304e027R8) [[2]](diffhunk://#diff-7cd13ce61838a849333c8ef406e4568e86264afacf62aef3c39b8be06daed37aR6-L7) [[3]](diffhunk://#diff-b79267fd84276f23527cdd38632a7db973290dfbea3dfacfaf364c360578148bR6)

These changes improve the reliability, security, and feature set of the discovery and metadata subsystems.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->