### PR TITLE
chore: update package metadata for v0.7.1

### DIFF
--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = modfetch-bin
 	pkgdesc = Robust CLI/TUI downloader for LLM and Stable Diffusion assets
-	pkgver = 0.7.0
+	pkgver = 0.7.1
 	pkgrel = 1
 	url = https://github.com/jxwalker/modfetch
 	arch = x86_64
@@ -8,11 +8,11 @@ pkgbase = modfetch-bin
 	license = MIT
 	provides = modfetch
 	conflicts = modfetch
-	source = LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v0.7.0/LICENSE
+	source = LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v0.7.1/LICENSE
 	sha256sums = 73be8e0a20ff3b0a6991d6405d4d485e5ffc8dfb07a13a1f1b7afb081f57ee54
-	source_x86_64 = modfetch-0.7.0-linux-amd64::https://github.com/jxwalker/modfetch/releases/download/v0.7.0/modfetch_linux_amd64
-	sha256sums_x86_64 = 7fe79e9ac38961e9bc7238b268388b36af98a7a2b6c6891fc94397ac504e7118
-	source_aarch64 = modfetch-0.7.0-linux-arm64::https://github.com/jxwalker/modfetch/releases/download/v0.7.0/modfetch_linux_arm64
-	sha256sums_aarch64 = 398c2d3d1d9cc7a83b5d9dc99ca2c0176a3ee5b4db3b73f4b9b9e6c9a55da1eb
+	source_x86_64 = modfetch-0.7.1-linux-amd64::https://github.com/jxwalker/modfetch/releases/download/v0.7.1/modfetch_linux_amd64
+	sha256sums_x86_64 = c7db15650986c32cf4b1550699e624a929e21b926194a2523896fbacec95276c
+	source_aarch64 = modfetch-0.7.1-linux-arm64::https://github.com/jxwalker/modfetch/releases/download/v0.7.1/modfetch_linux_arm64
+	sha256sums_aarch64 = 893e51802932381bc14d472d94002813c491c5170f14e50573e0b30cf873c868
 
 pkgname = modfetch-bin

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: James Walker <james@jameswalker.org.uk>
 pkgname=modfetch-bin
 _pkgname=modfetch
-pkgver=0.7.0
+pkgver=0.7.1
 pkgrel=1
 pkgdesc="Robust CLI/TUI downloader for LLM and Stable Diffusion assets"
 arch=('x86_64' 'aarch64')
@@ -14,10 +14,10 @@ source=("LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v${pkgver}
 sha256sums=('73be8e0a20ff3b0a6991d6405d4d485e5ffc8dfb07a13a1f1b7afb081f57ee54')
 
 source_x86_64=("${_pkgname}-${pkgver}-linux-amd64::https://github.com/jxwalker/modfetch/releases/download/v${pkgver}/${_pkgname}_linux_amd64")
-sha256sums_x86_64=('7fe79e9ac38961e9bc7238b268388b36af98a7a2b6c6891fc94397ac504e7118')
+sha256sums_x86_64=('c7db15650986c32cf4b1550699e624a929e21b926194a2523896fbacec95276c')
 
 source_aarch64=("${_pkgname}-${pkgver}-linux-arm64::https://github.com/jxwalker/modfetch/releases/download/v${pkgver}/${_pkgname}_linux_arm64")
-sha256sums_aarch64=('398c2d3d1d9cc7a83b5d9dc99ca2c0176a3ee5b4db3b73f4b9b9e6c9a55da1eb')
+sha256sums_aarch64=('893e51802932381bc14d472d94002813c491c5170f14e50573e0b30cf873c868')
 
 package() {
   local binary

--- a/packaging/homebrew/modfetch.rb
+++ b/packaging/homebrew/modfetch.rb
@@ -1,25 +1,25 @@
 class Modfetch < Formula
   desc "Robust CLI/TUI downloader for LLM and Stable Diffusion assets"
   homepage "https://github.com/jxwalker/modfetch"
-  version "0.5.2"
+  version "0.7.1"
   on_macos do
     on_arm do
       url "https://github.com/jxwalker/modfetch/releases/download/v#{version}/modfetch_darwin_arm64"
-      sha256 "1cda41590d96a08f255c6e230e0cc23e73491b488ea0df500f73258e593ddff6"
+      sha256 "9b1eb0498197e10616c13996839aba4648800f4ac9d6ed8f17bdc9c4a54ca464"
     end
     on_intel do
       url "https://github.com/jxwalker/modfetch/releases/download/v#{version}/modfetch_darwin_amd64"
-      sha256 "a53533b5202b450c32e76d1c872c824ca4d0b42dada0e9049799c81bb08eb4bd"
+      sha256 "174f34693fcae4476633d3c670a8f3366f3002baa15ea1ad6882d3f25ede1e6b"
     end
   end
   on_linux do
     on_arm do
       url "https://github.com/jxwalker/modfetch/releases/download/v#{version}/modfetch_linux_arm64"
-      sha256 "f504fc75c2d2bdf011f817ec5a8d2742649576ccc192f4e87476e4f17d3bed41"
+      sha256 "893e51802932381bc14d472d94002813c491c5170f14e50573e0b30cf873c868"
     end
     on_intel do
       url "https://github.com/jxwalker/modfetch/releases/download/v#{version}/modfetch_linux_amd64"
-      sha256 "a9394e97bffec284b3c65bd16a02e62191be5aa11b9997b9a5cbd2cd6dc10b84"
+      sha256 "c7db15650986c32cf4b1550699e624a929e21b926194a2523896fbacec95276c"
     end
   end
 
@@ -39,4 +39,3 @@ class Modfetch < Formula
     system "#{bin}/modfetch", "version"
   end
 end
-


### PR DESCRIPTION
## Summary
- update AUR PKGBUILD and .SRCINFO to v0.7.1 Linux artifact paths and checksums
- refresh the in-repo Homebrew formula copy to v0.7.1 published assets

## Validation
- scripts/check-aur-package.sh v0.7.1
- ruby -c packaging/homebrew/modfetch.rb
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->