### PR TITLE
fix: preserve canceled download partials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+Fixes
+- Preserved staged partial files and chunk state on canceled downloads so large
+  Hugging Face/Xet-style transfers can resume instead of restarting from zero.
+- Improved chunked-download progress reporting by using staged sparse-file
+  allocated bytes while chunks are still in flight.
+
 ## v0.7.1 — 2026-05-05
 
 Added

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ vet:
 	go vet ./...
 
 lint:
-ifdef GOLANGCI_BIN
+ifneq ($(strip $(GOLANGCI_BIN)),)
 	$(GOLANGCI_BIN) run ./...
 else
 	@echo "golangci-lint not found. Install: https://golangci-lint.run/ or run via CI."
@@ -73,4 +73,3 @@ checksums: $(DIST)
 
 release-dist: clean linux darwin checksums
 	@echo "Artifacts in $(DIST)/ ready for release"
-

--- a/cmd/modfetch/download_progress.go
+++ b/cmd/modfetch/download_progress.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -57,6 +58,11 @@ func startProgressLoop(ctx context.Context, st *state.DB, cfg *config.Config, ur
 					for _, c := range chunks {
 						if strings.EqualFold(c.Status, "complete") {
 							completed += c.Size
+						}
+					}
+					if cfg != nil && !strings.EqualFold(status, "planning") {
+						if allocated := stagedAllocatedBytes(cfg, url, dest); allocated > completed {
+							completed = min64(allocated, max64(total, allocated))
 						}
 					}
 				} else {
@@ -200,6 +206,25 @@ func max64(a, b int64) int64 {
 		return a
 	}
 	return b
+}
+
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func stagedAllocatedBytes(cfg *config.Config, url, dest string) int64 {
+	pp := stagedPartPath(cfg, url, dest)
+	fi, err := os.Stat(pp)
+	if err != nil {
+		return 0
+	}
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok && st.Blocks > 0 {
+		return st.Blocks * 512
+	}
+	return 0
 }
 
 // stagedPartPath mirrors downloader.stagePartPath hashing to locate .part for progress

--- a/internal/downloader/chunked.go
+++ b/internal/downloader/chunked.go
@@ -224,11 +224,21 @@ func (e *Chunked) Download(ctx context.Context, url, destPath, expectedSHA strin
 	}
 
 	completed := false
-	// Cleanup on cancellation
+	// Preserve staged data on cancellation so the next invocation can resume.
 	defer func() {
 		if ctx.Err() != nil && !completed {
-			_ = os.Remove(part)
-			_ = e.st.ClearChunksAndUpsertDownload(state.DownloadRow{URL: url, Dest: destPath, ExpectedSHA256: expectedSHA, ActualSHA256: "", ETag: h.etag, LastModified: h.lastMod, Size: h.size, Status: "canceled"})
+			_ = e.st.ResetActiveChunks(url, destPath)
+			_ = e.st.UpsertDownload(state.DownloadRow{
+				URL:            url,
+				Dest:           destPath,
+				ExpectedSHA256: expectedSHA,
+				ActualSHA256:   "",
+				ETag:           h.etag,
+				LastModified:   h.lastMod,
+				Size:           h.size,
+				Status:         "canceled",
+				LastError:      "download canceled; staged partial preserved for resume",
+			})
 		}
 	}()
 	f, err := os.OpenFile(part, os.O_CREATE|os.O_RDWR, 0o644)

--- a/internal/downloader/chunked_test.go
+++ b/internal/downloader/chunked_test.go
@@ -1,15 +1,186 @@
 package downloader
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/jxwalker/modfetch/internal/config"
 	"github.com/jxwalker/modfetch/internal/logging"
 	"github.com/jxwalker/modfetch/internal/state"
 	"github.com/jxwalker/modfetch/internal/util"
 )
+
+func TestChunkedCancelPreservesPartialAndChunksForResume(t *testing.T) {
+	const size = 3 * 1024 * 1024
+	data := bytes.Repeat([]byte("0123456789abcdef"), size/16)
+	sum := sha256.Sum256(data)
+	wantSHA := hex.EncodeToString(sum[:])
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.Header().Set("ETag", `"range-test"`)
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
+		if r.Method == http.MethodHead {
+			return
+		}
+		start, end := int64(0), int64(len(data)-1)
+		if rg := strings.TrimSpace(r.Header.Get("Range")); rg != "" {
+			if _, err := fmt.Sscanf(rg, "bytes=%d-%d", &start, &end); err != nil {
+				http.Error(w, "bad range", http.StatusRequestedRangeNotSatisfiable)
+				return
+			}
+			if start < 0 || end < start || end >= int64(len(data)) {
+				http.Error(w, "range not satisfiable", http.StatusRequestedRangeNotSatisfiable)
+				return
+			}
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)))
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", end-start+1))
+			w.WriteHeader(http.StatusPartialContent)
+		}
+		chunk := int64(32 * 1024)
+		for off := start; off <= end; off += chunk {
+			next := off + chunk
+			if next > end+1 {
+				next = end + 1
+			}
+			if _, err := w.Write(data[off:next]); err != nil {
+				return
+			}
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	cfg := writeChunkedTestConfig(t, tmp, 1)
+	log := logging.New("info", false)
+	st, err := state.Open(cfg)
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	defer func() { _ = st.SQL.Close() }()
+
+	dl := NewChunked(cfg, log, st, nil)
+	url := srv.URL + "/model.gguf"
+	dest := filepath.Join(cfg.General.DownloadRoot, "model.gguf")
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := dl.Download(ctx, url, dest, "", nil, false)
+		errCh <- err
+	}()
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			cancel()
+			t.Fatal("timed out waiting for first completed chunk")
+		default:
+		}
+		chunks, err := st.ListChunks(url, dest)
+		if err != nil {
+			t.Fatalf("list chunks: %v", err)
+		}
+		if countChunkStatus(chunks, "complete") >= 1 {
+			cancel()
+			goto canceled
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+canceled:
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancelled download error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for canceled download to return")
+	}
+
+	part := stagePartPath(cfg, url, dest)
+	if fi, err := os.Stat(part); err != nil {
+		t.Fatalf("expected staged partial to be preserved at %s: %v", part, err)
+	} else if fi.Size() != size {
+		t.Fatalf("staged partial logical size = %d, want %d", fi.Size(), size)
+	}
+	chunks, err := st.ListChunks(url, dest)
+	if err != nil {
+		t.Fatalf("list chunks after cancel: %v", err)
+	}
+	if len(chunks) != 3 {
+		t.Fatalf("chunk plan length after cancel = %d, want 3", len(chunks))
+	}
+	if complete := countChunkStatus(chunks, "complete"); complete == 0 {
+		t.Fatalf("expected at least one completed chunk to be preserved, got %+v", chunks)
+	}
+	if running := countChunkStatus(chunks, "running"); running != 0 {
+		t.Fatalf("running chunks should be reset for resume, got %+v", chunks)
+	}
+
+	final, gotSHA, err := dl.Download(context.Background(), url, dest, wantSHA, nil, false)
+	if err != nil {
+		t.Fatalf("resume download: %v", err)
+	}
+	if final != dest {
+		t.Fatalf("final path = %s, want %s", final, dest)
+	}
+	if gotSHA != wantSHA {
+		t.Fatalf("sha = %s, want %s", gotSHA, wantSHA)
+	}
+	if _, err := os.Stat(part); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("staged partial should be removed after completion, stat err=%v", err)
+	}
+}
+
+func writeChunkedTestConfig(t *testing.T, tmp string, perFileChunks int) *config.Config {
+	t.Helper()
+	cfgYaml := []byte(fmt.Sprintf(`version: 1
+general:
+  data_root: %q
+  download_root: %q
+  placement_mode: "symlink"
+  quarantine: false
+  allow_overwrite: true
+concurrency:
+  per_file_chunks: %d
+  chunk_size_mb: 1
+`, filepath.Join(tmp, "data"), filepath.Join(tmp, "dl"), perFileChunks))
+	cfgPath := filepath.Join(tmp, "config.yml")
+	if err := os.WriteFile(cfgPath, cfgYaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("config load: %v", err)
+	}
+	return cfg
+}
+
+func countChunkStatus(chunks []state.ChunkRow, status string) int {
+	var n int
+	for _, c := range chunks {
+		if strings.EqualFold(c.Status, status) {
+			n++
+		}
+	}
+	return n
+}
 
 // Integration: chunked download of a 1MB test file with multiple chunks.
 func TestChunkedDownload1MB(t *testing.T) {

--- a/internal/downloader/single.go
+++ b/internal/downloader/single.go
@@ -137,11 +137,20 @@ func (s *Single) Download(ctx context.Context, url, destPath, expectedSHA string
 	_ = s.st.ClearChunksAndUpsertDownload(state.DownloadRow{URL: url, Dest: destPath, ExpectedSHA256: expectedSHA, ETag: etag, LastModified: lastMod, Size: size, Status: "planning"})
 
 	completed := false
-	// Cleanup on cancellation
+	// Preserve staged data on cancellation so the next invocation can resume.
 	defer func() {
 		if ctx.Err() != nil && !completed {
-			_ = os.Remove(part)
-			_ = s.st.ClearChunksAndUpsertDownload(state.DownloadRow{URL: url, Dest: destPath, ExpectedSHA256: expectedSHA, ActualSHA256: "", ETag: etag, LastModified: lastMod, Size: size, Status: "canceled"})
+			_ = s.st.ClearChunksAndUpsertDownload(state.DownloadRow{
+				URL:            url,
+				Dest:           destPath,
+				ExpectedSHA256: expectedSHA,
+				ActualSHA256:   "",
+				ETag:           etag,
+				LastModified:   lastMod,
+				Size:           size,
+				Status:         "canceled",
+				LastError:      "download canceled; staged partial preserved for resume",
+			})
 		}
 	}()
 

--- a/internal/downloader/single_test.go
+++ b/internal/downloader/single_test.go
@@ -1,14 +1,128 @@
 package downloader
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/jxwalker/modfetch/internal/config"
 	"github.com/jxwalker/modfetch/internal/logging"
 	"github.com/jxwalker/modfetch/internal/state"
 )
+
+func TestSingleCancelPreservesPartialForResume(t *testing.T) {
+	const size = 1024 * 1024
+	data := bytes.Repeat([]byte("abcdef0123456789"), size/16)
+	sum := sha256.Sum256(data)
+	wantSHA := hex.EncodeToString(sum[:])
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
+		if r.Method == http.MethodHead {
+			return
+		}
+		start, end := int64(0), int64(len(data)-1)
+		if rg := strings.TrimSpace(r.Header.Get("Range")); rg != "" {
+			if _, err := fmt.Sscanf(rg, "bytes=%d-", &start); err != nil {
+				http.Error(w, "bad range", http.StatusRequestedRangeNotSatisfiable)
+				return
+			}
+			if start < 0 || start >= int64(len(data)) {
+				http.Error(w, "range not satisfiable", http.StatusRequestedRangeNotSatisfiable)
+				return
+			}
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)))
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", end-start+1))
+			w.WriteHeader(http.StatusPartialContent)
+		}
+		chunk := int64(16 * 1024)
+		for off := start; off <= end; off += chunk {
+			next := off + chunk
+			if next > end+1 {
+				next = end + 1
+			}
+			if _, err := w.Write(data[off:next]); err != nil {
+				return
+			}
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	cfg := writeChunkedTestConfig(t, tmp, 1)
+	log := logging.New("info", false)
+	st, err := state.Open(cfg)
+	if err != nil {
+		t.Fatalf("state open: %v", err)
+	}
+	defer func() { _ = st.SQL.Close() }()
+
+	dl := NewSingle(cfg, log, st, nil)
+	url := srv.URL + "/single.bin"
+	dest := filepath.Join(cfg.General.DownloadRoot, "single.bin")
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := dl.Download(ctx, url, dest, "", nil, false)
+		errCh <- err
+	}()
+
+	part := stagePartPath(cfg, url, dest)
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			cancel()
+			t.Fatal("timed out waiting for partial bytes")
+		default:
+		}
+		if fi, err := os.Stat(part); err == nil && fi.Size() >= 64*1024 {
+			cancel()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancelled download error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for canceled download to return")
+	}
+	if fi, err := os.Stat(part); err != nil {
+		t.Fatalf("expected partial to be preserved: %v", err)
+	} else if fi.Size() == 0 || fi.Size() >= size {
+		t.Fatalf("partial size = %d, want between 1 and %d", fi.Size(), size-1)
+	}
+
+	final, gotSHA, err := dl.Download(context.Background(), url, dest, wantSHA, nil, false)
+	if err != nil {
+		t.Fatalf("resume download: %v", err)
+	}
+	if final != dest {
+		t.Fatalf("final path = %s, want %s", final, dest)
+	}
+	if gotSHA != wantSHA {
+		t.Fatalf("sha = %s, want %s", gotSHA, wantSHA)
+	}
+}
 
 // Integration test that downloads a tiny public text file from Hugging Face.
 func TestSingleDownloadHF(t *testing.T) {

--- a/internal/state/chunks.go
+++ b/internal/state/chunks.go
@@ -112,3 +112,13 @@ func (db *DB) DeleteChunks(url, dest string) error {
 	}
 	return err
 }
+
+// ResetActiveChunks marks in-flight chunk rows as pending so a canceled process
+// can resume by refetching any chunk that may have been only partially written.
+func (db *DB) ResetActiveChunks(url, dest string) error {
+	_, err := db.SQL.Exec(`UPDATE chunks SET status='pending', updated_at=strftime('%s','now') WHERE url=? AND dest=? AND status='running'`, url, dest)
+	if err == nil {
+		db.NotifyChange()
+	}
+	return err
+}


### PR DESCRIPTION
## Summary
- preserve staged .part files and chunk plans when downloads are canceled so large transfers can resume
- reset in-flight chunk rows to pending on cancellation so partially written chunks are refetched safely
- improve chunked progress reporting by counting allocated sparse-file bytes while chunks are in flight
- fix the Makefile lint guard so missing golangci-lint reports the intended error

## Validation
- go test -count=1 ./internal/downloader -run "Test(Chunked|Single)CancelPreservesPartial"
- go test -count=1 ./internal/downloader ./internal/state ./cmd/modfetch
- go vet ./...
- scripts/check-docs-drift.sh
- git diff --check
- go test -count=1 ./...
- make build
- scripts/uat/real_download_matrix.sh

Note: make lint was attempted, but golangci-lint is not installed locally; this patch fixes the previous broken fallback so it now reports that clearly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->