### PR TITLE
chore: satisfy local golangci-lint

### DIFF
--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -141,7 +141,7 @@ func (m *Model) renderToastDrawer() string {
 	var sb strings.Builder
 	for i := len(m.toasts) - 1; i >= 0; i-- { // newest first
 		t := m.toasts[i]
-		sb.WriteString(fmt.Sprintf("%s  %s\n", t.msg, m.th.label.Render(humanize.Time(t.when))))
+		fmt.Fprintf(&sb, "%s  %s\n", t.msg, m.th.label.Render(humanize.Time(t.when)))
 	}
 	return sb.String()
 }

--- a/internal/tui/configwizard/wizard.go
+++ b/internal/tui/configwizard/wizard.go
@@ -166,7 +166,7 @@ func (w *Wizard) View() string {
 		if i == w.focus {
 			marker = ">"
 		}
-		b.WriteString(fmt.Sprintf("%s %-32s %s\n", marker, w.labels[i]+":", input.View()))
+		fmt.Fprintf(&b, "%s %-32s %s\n", marker, w.labels[i]+":", input.View())
 	}
 	if w.done {
 		b.WriteString("\nDone. Saving...\n")

--- a/internal/tui/downloads_view.go
+++ b/internal/tui/downloads_view.go
@@ -352,10 +352,10 @@ func (m *Model) renderInspector() string {
 	total := m.totalCache[keyFor(r)]
 	rate := m.rateCache[keyFor(r)]
 	eta := m.etaCache[keyFor(r)]
-	sb.WriteString(fmt.Sprintf("%s %s/%s\n", m.th.label.Render("Progress:"), humanize.Bytes(uint64(cur)), humanize.Bytes(uint64(total))))
-	sb.WriteString(fmt.Sprintf("%s %s/s\n", m.th.label.Render("Speed:"), humanize.Bytes(uint64(rate))))
-	sb.WriteString(fmt.Sprintf("%s %s\n", m.th.label.Render("ETA:"), eta))
-	sb.WriteString(fmt.Sprintf("%s %s\n", m.th.label.Render("Throughput:"), m.renderSparkline(keyFor(r))))
+	fmt.Fprintf(&sb, "%s %s/%s\n", m.th.label.Render("Progress:"), humanize.Bytes(uint64(cur)), humanize.Bytes(uint64(total)))
+	fmt.Fprintf(&sb, "%s %s/s\n", m.th.label.Render("Speed:"), humanize.Bytes(uint64(rate)))
+	fmt.Fprintf(&sb, "%s %s\n", m.th.label.Render("ETA:"), eta)
+	fmt.Fprintf(&sb, "%s %s\n", m.th.label.Render("Throughput:"), m.renderSparkline(keyFor(r)))
 	// Retries and status (with transient retrying overlay)
 	statusLabel := r.Status
 	if ts, ok := m.retrying[keyFor(r)]; ok {
@@ -365,35 +365,35 @@ func (m *Model) renderInspector() string {
 			delete(m.retrying, keyFor(r))
 		}
 	}
-	sb.WriteString(fmt.Sprintf("%s %d\n", m.th.label.Render("Retries:"), r.Retries))
-	sb.WriteString(fmt.Sprintf("%s %s\n", m.th.label.Render("Status:"), statusLabel))
+	fmt.Fprintf(&sb, "%s %d\n", m.th.label.Render("Retries:"), r.Retries)
+	fmt.Fprintf(&sb, "%s %s\n", m.th.label.Render("Status:"), statusLabel)
 	// Completed job duration and average speed
 	if strings.EqualFold(strings.TrimSpace(r.Status), "complete") && r.CreatedAt > 0 && r.UpdatedAt >= r.CreatedAt {
 		dur := time.Duration((r.UpdatedAt - r.CreatedAt)) * time.Second
-		sb.WriteString(fmt.Sprintf("%s %s\n", m.th.label.Render("Duration:"), dur.String()))
+		fmt.Fprintf(&sb, "%s %s\n", m.th.label.Render("Duration:"), dur.String())
 		// Start/End wall times
 		startAt := time.Unix(r.CreatedAt, 0).Local().Format("2006-01-02 15:04:05")
 		endAt := time.Unix(r.UpdatedAt, 0).Local().Format("2006-01-02 15:04:05")
-		sb.WriteString(fmt.Sprintf("%s %s\n", m.th.label.Render("Started:"), startAt))
-		sb.WriteString(fmt.Sprintf("%s %s\n", m.th.label.Render("Finished:"), endAt))
+		fmt.Fprintf(&sb, "%s %s\n", m.th.label.Render("Started:"), startAt)
+		fmt.Fprintf(&sb, "%s %s\n", m.th.label.Render("Finished:"), endAt)
 		if r.Size > 0 && dur > 0 {
 			avg := float64(r.Size) / dur.Seconds()
-			sb.WriteString(fmt.Sprintf("%s %s/s\n", m.th.label.Render("Avg Speed:"), humanize.Bytes(uint64(avg))))
+			fmt.Fprintf(&sb, "%s %s/s\n", m.th.label.Render("Avg Speed:"), humanize.Bytes(uint64(avg)))
 		}
 	} else if strings.EqualFold(strings.TrimSpace(r.Status), "running") && r.CreatedAt > 0 {
 		// Show start time for running jobs
 		startAt := time.Unix(r.CreatedAt, 0).Local().Format("2006-01-02 15:04:05")
-		sb.WriteString(fmt.Sprintf("%s %s\n", m.th.label.Render("Started:"), startAt))
+		fmt.Fprintf(&sb, "%s %s\n", m.th.label.Render("Started:"), startAt)
 	}
 	// Verification details
 	if strings.TrimSpace(r.ExpectedSHA256) != "" || strings.TrimSpace(r.ActualSHA256) != "" {
 		sb.WriteString(m.th.label.Render("SHA256:"))
 		sb.WriteString("\n")
 		if strings.TrimSpace(r.ExpectedSHA256) != "" {
-			sb.WriteString(fmt.Sprintf("expected: %s\n", r.ExpectedSHA256))
+			fmt.Fprintf(&sb, "expected: %s\n", r.ExpectedSHA256)
 		}
 		if strings.TrimSpace(r.ActualSHA256) != "" {
-			sb.WriteString(fmt.Sprintf("actual:   %s\n", r.ActualSHA256))
+			fmt.Fprintf(&sb, "actual:   %s\n", r.ActualSHA256)
 		}
 		if r.ExpectedSHA256 != "" && r.ActualSHA256 != "" {
 			if strings.EqualFold(strings.TrimSpace(r.ExpectedSHA256), strings.TrimSpace(r.ActualSHA256)) {
@@ -405,7 +405,7 @@ func (m *Model) renderInspector() string {
 	}
 	// Show reason for hold/error if available
 	if strings.TrimSpace(r.LastError) != "" {
-		sb.WriteString(fmt.Sprintf("%s %s\n", m.th.label.Render("Reason:"), r.LastError))
+		fmt.Fprintf(&sb, "%s %s\n", m.th.label.Render("Reason:"), r.LastError)
 	}
 	return sb.String()
 }

--- a/internal/tui/library_view.go
+++ b/internal/tui/library_view.go
@@ -336,11 +336,11 @@ func (m *Model) renderLibraryDetail() string {
 		sb.WriteString(m.th.head.Render("Usage Statistics") + "\n")
 		if model.DownloadCount > 0 {
 			sb.WriteString(m.th.label.Render("Downloads: "))
-			sb.WriteString(fmt.Sprintf("%d\n", model.DownloadCount))
+			fmt.Fprintf(&sb, "%d\n", model.DownloadCount)
 		}
 		if model.TimesUsed > 0 {
 			sb.WriteString(m.th.label.Render("Times Used: "))
-			sb.WriteString(fmt.Sprintf("%d\n", model.TimesUsed))
+			fmt.Fprintf(&sb, "%d\n", model.TimesUsed)
 		}
 		if model.LastUsed != nil {
 			sb.WriteString(m.th.label.Render("Last Used: "))
@@ -435,7 +435,7 @@ func (m *Model) renderLibraryConfirm() string {
 	}
 	var sb strings.Builder
 	sb.WriteString(m.th.bad.Render(title) + "\n\n")
-	sb.WriteString(fmt.Sprintf("Affected items: %d\n", len(m.libraryConfirm.rows)))
+	fmt.Fprintf(&sb, "Affected items: %d\n", len(m.libraryConfirm.rows))
 	if m.cfg != nil && strings.TrimSpace(m.cfg.General.DownloadRoot) != "" {
 		sb.WriteString("Files under the download root may be removed; library metadata is kept.\n")
 	}

--- a/internal/tui/settings_view.go
+++ b/internal/tui/settings_view.go
@@ -148,15 +148,15 @@ func (m *Model) renderSettings() string {
 	// Section: Download Settings
 	sb.WriteString(m.th.head.Render("Download Settings") + "\n")
 	sb.WriteString(m.th.label.Render("Timeout: "))
-	sb.WriteString(fmt.Sprintf("%d seconds\n", m.cfg.Network.TimeoutSeconds))
+	fmt.Fprintf(&sb, "%d seconds\n", m.cfg.Network.TimeoutSeconds)
 	sb.WriteString(m.th.label.Render("Max Redirects: "))
-	sb.WriteString(fmt.Sprintf("%d\n", m.cfg.Network.MaxRedirects))
+	fmt.Fprintf(&sb, "%d\n", m.cfg.Network.MaxRedirects)
 	sb.WriteString(m.th.label.Render("Chunk Size: "))
-	sb.WriteString(fmt.Sprintf("%d MB\n", m.cfg.Concurrency.ChunkSizeMB))
+	fmt.Fprintf(&sb, "%d MB\n", m.cfg.Concurrency.ChunkSizeMB)
 	sb.WriteString(m.th.label.Render("Per-File Chunks: "))
-	sb.WriteString(fmt.Sprintf("%d\n", m.cfg.Concurrency.PerFileChunks))
+	fmt.Fprintf(&sb, "%d\n", m.cfg.Concurrency.PerFileChunks)
 	sb.WriteString(m.th.label.Render("Global Files: "))
-	sb.WriteString(fmt.Sprintf("%d\n", m.cfg.Concurrency.GlobalFiles))
+	fmt.Fprintf(&sb, "%d\n", m.cfg.Concurrency.GlobalFiles)
 	sb.WriteString(m.th.label.Render("Stage Partials: "))
 	if m.cfg.General.StagePartials {
 		sb.WriteString("Yes\n")
@@ -191,7 +191,7 @@ func (m *Model) renderSettings() string {
 	}
 	sb.WriteString(m.th.label.Render("Refresh Rate: "))
 	if m.cfg.UI.RefreshHz > 0 {
-		sb.WriteString(fmt.Sprintf("%d Hz\n", m.cfg.UI.RefreshHz))
+		fmt.Fprintf(&sb, "%d Hz\n", m.cfg.UI.RefreshHz)
 	} else {
 		sb.WriteString("1 Hz (default)\n")
 	}


### PR DESCRIPTION
## Summary
- install-compatible lint cleanup for current golangci-lint/staticcheck
- replace WriteString(fmt.Sprintf(...)) patterns with fmt.Fprintf on TUI builders

## Validation
- golangci-lint --version
- make lint
- go test -count=1 ./internal/tui ./internal/tui/configwizard ./cmd/modfetch
- go test -count=1 ./...
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->