### PR TITLE
feat: add large download tuning profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+Added
+- Added `modfetch download --profile large-model`, `--connections`, and
+  `--chunk-size-mb` for aria2-style one-shot tuning of very large model
+  downloads without editing YAML.
+
 Fixes
 - Preserved staged partial files and chunk state on canceled downloads so large
   Hugging Face/Xet-style transfers can resume instead of restarting from zero.

--- a/README.md
+++ b/README.md
@@ -383,8 +383,9 @@ modfetch library scan --repair-stale
     
         modfetch download --config /path/to/config.yml --url 'hf://org/repo/path?rev=main' --dry-run
         modfetch download --config /path/to/config.yml --url 'https://example.com/file.bin' --dry-run --summary-json
+  - Large model tuning: use `--profile large-model` for DS4/GGUF-size artifacts, or set explicit aria2-style range tuning with `--connections 16 --chunk-size-mb 64`.
   - On completion, a summary is printed (dest, size, SHA256, duration, average speed)
-  - Cancel with Ctrl+C (SIGINT/SIGTERM); partial files are cleaned up
+  - Cancel with Ctrl+C (SIGINT/SIGTERM); staged partial files and completed chunks are preserved for resume. Use `--no-resume` or `modfetch clean` when you want to discard staged data.
 - Place artifacts into apps:
   
   modfetch place --config /path/to/config.yml --path /path/to/model.safetensors

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -56,7 +56,7 @@ _modfetch_completions()
                 *) ;;
             esac ;;
         download)
-            COMPREPLY=( $(compgen -W "--config --log-level --json --quiet --no-resume --url --dest --sha256 --sha256-file --batch --place --summary-json --batch-parallel --dry-run --force --no-auth-preflight --extract --extract-dir --quant --list-quants" -- "$cur") ) ;;
+            COMPREPLY=( $(compgen -W "--config --log-level --json --quiet --no-resume --url --dest --sha256 --sha256-file --batch --place --summary-json --batch-parallel --profile --connections --chunk-size-mb --dry-run --force --no-auth-preflight --extract --extract-dir --quant --list-quants" -- "$cur") ) ;;
         discover)
             if [[ ${cword} -eq 2 ]]; then
                 COMPREPLY=( $(compgen -W "search download" -- "$cur") )
@@ -165,7 +165,7 @@ _modfetch() {
       fi
       ;;
     download)
-      _arguments '*:options:(--config --log-level --json --quiet --no-resume --url --dest --sha256 --sha256-file --batch --place --summary-json --batch-parallel --dry-run --force --no-auth-preflight --extract --extract-dir --quant --list-quants)'
+      _arguments '*:options:(--config --log-level --json --quiet --no-resume --url --dest --sha256 --sha256-file --batch --place --summary-json --batch-parallel --profile --connections --chunk-size-mb --dry-run --force --no-auth-preflight --extract --extract-dir --quant --list-quants)'
       ;;
     discover)
       if (( CURRENT == 3 )); then
@@ -313,6 +313,9 @@ complete -c modfetch -n "__fish_seen_subcommand_from download" -l quiet -d "Supp
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l no-resume -d "Start fresh instead of resuming"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l summary-json -d "Print completion summary as JSON"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l batch-parallel -d "Parallel batch downloads"
+complete -c modfetch -n "__fish_seen_subcommand_from download" -l profile -d "Download tuning profile"
+complete -c modfetch -n "__fish_seen_subcommand_from download" -l connections -d "Parallel range requests per file"
+complete -c modfetch -n "__fish_seen_subcommand_from download" -l chunk-size-mb -d "Range chunk size in MiB"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l dry-run -d "Plan without downloading"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l force -d "Skip SHA256 verification"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l no-auth-preflight -d "Skip auth preflight probe"

--- a/cmd/modfetch/completion_test.go
+++ b/cmd/modfetch/completion_test.go
@@ -19,7 +19,7 @@ func TestCompletionTopLevelCommands(t *testing.T) {
 func TestCompletionCurrentFlags(t *testing.T) {
 	tests := map[string][]string{
 		"config":   {"--strict", "--out"},
-		"download": {"--no-resume", "--summary-json", "--batch-parallel", "--dry-run", "--force", "--no-auth-preflight", "--quant", "--list-quants"},
+		"download": {"--no-resume", "--summary-json", "--batch-parallel", "--profile", "--connections", "--chunk-size-mb", "--dry-run", "--force", "--no-auth-preflight", "--quant", "--list-quants"},
 		"discover": {"--provider", "--limit", "--select", "--summary-json", "--dry-run"},
 		"starter":  {"--id", "--summary-json", "--dry-run"},
 		"place":    {"--dry-run", "--preset", "--list-presets"},

--- a/cmd/modfetch/download_cmd.go
+++ b/cmd/modfetch/download_cmd.go
@@ -44,6 +44,9 @@ func handleDownload(ctx context.Context, args []string) error {
 	placeFlag := fs.Bool("place", false, "place files after successful download")
 	summaryJSON := fs.Bool("summary-json", false, "print a JSON summary when a download completes")
 	batchParallel := fs.Int("batch-parallel", 0, "max parallel downloads when using --batch (default: config concurrency per_host_requests)")
+	profile := fs.String("profile", "", "download tuning profile: default or large-model")
+	connections := fs.Int("connections", 0, "parallel range requests per file (aria2-style; overrides concurrency.per_file_chunks)")
+	chunkSizeMB := fs.Int("chunk-size-mb", 0, "range chunk size in MiB for this invocation")
 	dryRun := fs.Bool("dry-run", false, "plan only: resolve URL/URI and compute default destination; no download")
 	forceSkip := fs.Bool("force", false, "skip SHA256 verification even if --sha256/--sha256-file is provided")
 	noAuthPreflight := fs.Bool("no-auth-preflight", false, "skip auth preflight probe")
@@ -58,6 +61,7 @@ func handleDownload(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	batchDefaultParallel := c.Concurrency.PerHostRequests
 	if strings.TrimSpace(*sha) == "" && strings.TrimSpace(*shaFile) != "" {
 		v, perr := parseSHA256FromFile(*shaFile)
 		if perr != nil {
@@ -67,6 +71,9 @@ func handleDownload(ctx context.Context, args []string) error {
 	}
 	if storage.IsS3URI(strings.TrimSpace(*dest)) && (*extractFlag || *placeFlag) {
 		return errors.New("s3 destinations cannot be combined with --extract or --place")
+	}
+	if err := applyDownloadTuning(c, *profile, *connections, *chunkSizeMB); err != nil {
+		return err
 	}
 	// quiet forces log level to error unless JSON is requested
 	if *quiet && !*common.jsonOut {
@@ -153,7 +160,7 @@ func handleDownload(ctx context.Context, args []string) error {
 			}
 			return "", fmt.Errorf("could not reserve unique destination for %q in %s after %d attempts", base, dir, maxSuffixAttempts)
 		}
-		parallel := c.Concurrency.PerHostRequests
+		parallel := batchDefaultParallel
 		if *batchParallel > 0 {
 			parallel = *batchParallel
 		}
@@ -511,9 +518,12 @@ func handleDownload(ctx context.Context, args []string) error {
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
 			_ = enc.Encode(map[string]any{
-				"resolver_uri": *url,
-				"resolved_url": logging.SanitizeURL(resolvedURL),
-				"default_dest": candDest,
+				"resolver_uri":  *url,
+				"resolved_url":  logging.SanitizeURL(resolvedURL),
+				"default_dest":  candDest,
+				"connections":   effectiveDownloadConnections(c),
+				"chunk_size_mb": effectiveChunkSizeMB(c),
+				"profile":       effectiveDownloadProfile(*profile),
 			})
 			return nil
 		}
@@ -521,6 +531,9 @@ func handleDownload(ctx context.Context, args []string) error {
 		fmt.Printf("  Resolver URI: %s\n", logging.SanitizeURL(*url))
 		fmt.Printf("  Resolved URL: %s\n", logging.SanitizeURL(resolvedURL))
 		fmt.Printf("  Default dest: %s\n", candDest)
+		fmt.Printf("  Profile: %s\n", effectiveDownloadProfile(*profile))
+		fmt.Printf("  Connections: %d\n", effectiveDownloadConnections(c))
+		fmt.Printf("  Chunk size: %d MiB\n", effectiveChunkSizeMB(c))
 		return nil
 	}
 	if !*noAuthPreflight && !c.Network.DisableAuthPreflight {
@@ -674,6 +687,70 @@ func handleDownload(ctx context.Context, args []string) error {
 		}
 	}
 	return nil
+}
+
+func applyDownloadTuning(c *config.Config, profile string, connections, chunkSizeMB int) error {
+	if c == nil {
+		return errors.New("nil config")
+	}
+	if connections < 0 {
+		return errors.New("--connections must be >= 0")
+	}
+	if chunkSizeMB < 0 {
+		return errors.New("--chunk-size-mb must be >= 0")
+	}
+	switch strings.ToLower(strings.TrimSpace(profile)) {
+	case "", "default":
+	case "large", "large-model":
+		if c.Concurrency.PerFileChunks < 16 {
+			c.Concurrency.PerFileChunks = 16
+		}
+		if c.Concurrency.PerHostRequests < 16 {
+			c.Concurrency.PerHostRequests = 16
+		}
+		if c.Concurrency.ChunkSizeMB < 64 {
+			c.Concurrency.ChunkSizeMB = 64
+		}
+	default:
+		return fmt.Errorf("unknown download profile %q (valid: default, large-model)", profile)
+	}
+	if connections > 0 {
+		c.Concurrency.PerFileChunks = connections
+		if c.Concurrency.PerHostRequests < connections {
+			c.Concurrency.PerHostRequests = connections
+		}
+	}
+	if chunkSizeMB > 0 {
+		c.Concurrency.ChunkSizeMB = chunkSizeMB
+	}
+	return nil
+}
+
+func effectiveDownloadProfile(profile string) string {
+	switch strings.ToLower(strings.TrimSpace(profile)) {
+	case "large", "large-model":
+		return "large-model"
+	default:
+		return "default"
+	}
+}
+
+func effectiveDownloadConnections(c *config.Config) int {
+	if c == nil || c.Concurrency.PerFileChunks <= 0 {
+		return 4
+	}
+	connections := c.Concurrency.PerFileChunks
+	if c.Concurrency.PerHostRequests > 0 && c.Concurrency.PerHostRequests < connections {
+		return c.Concurrency.PerHostRequests
+	}
+	return connections
+}
+
+func effectiveChunkSizeMB(c *config.Config) int {
+	if c == nil || c.Concurrency.ChunkSizeMB <= 0 {
+		return 8
+	}
+	return c.Concurrency.ChunkSizeMB
 }
 
 // resolveBatchDownloadCandidate resolves a single source URI or direct URL to

--- a/cmd/modfetch/download_cmd.go
+++ b/cmd/modfetch/download_cmd.go
@@ -31,6 +31,13 @@ import (
 	"github.com/jxwalker/modfetch/internal/util"
 )
 
+const (
+	defaultDownloadConnections    = 4
+	defaultDownloadChunkSizeMB    = 8
+	largeModelDownloadConnections = 16
+	largeModelChunkSizeMB         = 64
+)
+
 func handleDownload(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("download", flag.ContinueOnError)
 	common := addCommonConfigLogFlags(fs, "")
@@ -61,7 +68,7 @@ func handleDownload(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	batchDefaultParallel := c.Concurrency.PerHostRequests
+	batchFileParallel := c.Concurrency.PerHostRequests
 	if strings.TrimSpace(*sha) == "" && strings.TrimSpace(*shaFile) != "" {
 		v, perr := parseSHA256FromFile(*shaFile)
 		if perr != nil {
@@ -160,7 +167,9 @@ func handleDownload(ctx context.Context, args []string) error {
 			}
 			return "", fmt.Errorf("could not reserve unique destination for %q in %s after %d attempts", base, dir, maxSuffixAttempts)
 		}
-		parallel := batchDefaultParallel
+		// Download tuning flags control range concurrency inside each worker.
+		// Keep batch file fan-out on the original config unless explicitly set.
+		parallel := batchFileParallel
 		if *batchParallel > 0 {
 			parallel = *batchParallel
 		}
@@ -518,7 +527,7 @@ func handleDownload(ctx context.Context, args []string) error {
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
 			_ = enc.Encode(map[string]any{
-				"resolver_uri":  *url,
+				"resolver_uri":  logging.SanitizeURL(*url),
 				"resolved_url":  logging.SanitizeURL(resolvedURL),
 				"default_dest":  candDest,
 				"connections":   effectiveDownloadConnections(c),
@@ -702,14 +711,14 @@ func applyDownloadTuning(c *config.Config, profile string, connections, chunkSiz
 	switch strings.ToLower(strings.TrimSpace(profile)) {
 	case "", "default":
 	case "large", "large-model":
-		if c.Concurrency.PerFileChunks < 16 {
-			c.Concurrency.PerFileChunks = 16
+		if c.Concurrency.PerFileChunks < largeModelDownloadConnections {
+			c.Concurrency.PerFileChunks = largeModelDownloadConnections
 		}
-		if c.Concurrency.PerHostRequests < 16 {
-			c.Concurrency.PerHostRequests = 16
+		if c.Concurrency.PerHostRequests < largeModelDownloadConnections {
+			c.Concurrency.PerHostRequests = largeModelDownloadConnections
 		}
-		if c.Concurrency.ChunkSizeMB < 64 {
-			c.Concurrency.ChunkSizeMB = 64
+		if c.Concurrency.ChunkSizeMB < largeModelChunkSizeMB {
+			c.Concurrency.ChunkSizeMB = largeModelChunkSizeMB
 		}
 	default:
 		return fmt.Errorf("unknown download profile %q (valid: default, large-model)", profile)
@@ -737,7 +746,7 @@ func effectiveDownloadProfile(profile string) string {
 
 func effectiveDownloadConnections(c *config.Config) int {
 	if c == nil || c.Concurrency.PerFileChunks <= 0 {
-		return 4
+		return defaultDownloadConnections
 	}
 	connections := c.Concurrency.PerFileChunks
 	if c.Concurrency.PerHostRequests > 0 && c.Concurrency.PerHostRequests < connections {
@@ -748,7 +757,7 @@ func effectiveDownloadConnections(c *config.Config) int {
 
 func effectiveChunkSizeMB(c *config.Config) int {
 	if c == nil || c.Concurrency.ChunkSizeMB <= 0 {
-		return 8
+		return defaultDownloadChunkSizeMB
 	}
 	return c.Concurrency.ChunkSizeMB
 }

--- a/cmd/modfetch/download_cmd.go
+++ b/cmd/modfetch/download_cmd.go
@@ -33,7 +33,8 @@ import (
 
 const (
 	defaultDownloadConnections    = 4
-	defaultDownloadChunkSizeMB    = 8
+	autoChunkSizeMinMB            = 1
+	autoChunkSizeMaxMB            = 64
 	largeModelDownloadConnections = 16
 	largeModelChunkSizeMB         = 64
 )
@@ -524,16 +525,26 @@ func handleDownload(ctx context.Context, args []string) error {
 			candDest = filepath.Join(c.General.DownloadRoot, util.SafeFileName(base))
 		}
 		if *summaryJSON {
+			chunkMode, chunkSizeMB := effectiveChunkSize(c)
+			summary := map[string]any{
+				"resolver_uri":    logging.SanitizeURL(*url),
+				"resolved_url":    logging.SanitizeURL(resolvedURL),
+				"default_dest":    candDest,
+				"connections":     effectiveDownloadConnections(c),
+				"chunk_size_mode": chunkMode,
+				"profile":         effectiveDownloadProfile(*profile),
+			}
+			if chunkSizeMB > 0 {
+				summary["chunk_size_mb"] = chunkSizeMB
+			} else {
+				summary["chunk_size_range_mb"] = map[string]int{
+					"min": autoChunkSizeMinMB,
+					"max": autoChunkSizeMaxMB,
+				}
+			}
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
-			_ = enc.Encode(map[string]any{
-				"resolver_uri":  logging.SanitizeURL(*url),
-				"resolved_url":  logging.SanitizeURL(resolvedURL),
-				"default_dest":  candDest,
-				"connections":   effectiveDownloadConnections(c),
-				"chunk_size_mb": effectiveChunkSizeMB(c),
-				"profile":       effectiveDownloadProfile(*profile),
-			})
+			_ = enc.Encode(summary)
 			return nil
 		}
 		fmt.Printf("Plan (dry-run)\n")
@@ -542,7 +553,11 @@ func handleDownload(ctx context.Context, args []string) error {
 		fmt.Printf("  Default dest: %s\n", candDest)
 		fmt.Printf("  Profile: %s\n", effectiveDownloadProfile(*profile))
 		fmt.Printf("  Connections: %d\n", effectiveDownloadConnections(c))
-		fmt.Printf("  Chunk size: %d MiB\n", effectiveChunkSizeMB(c))
+		if chunkMode, chunkSizeMB := effectiveChunkSize(c); chunkMode == "fixed" {
+			fmt.Printf("  Chunk size: %d MiB\n", chunkSizeMB)
+		} else {
+			fmt.Printf("  Chunk size: auto (%d-%d MiB)\n", autoChunkSizeMinMB, autoChunkSizeMaxMB)
+		}
 		return nil
 	}
 	if !*noAuthPreflight && !c.Network.DisableAuthPreflight {
@@ -755,11 +770,11 @@ func effectiveDownloadConnections(c *config.Config) int {
 	return connections
 }
 
-func effectiveChunkSizeMB(c *config.Config) int {
+func effectiveChunkSize(c *config.Config) (string, int) {
 	if c == nil || c.Concurrency.ChunkSizeMB <= 0 {
-		return defaultDownloadChunkSizeMB
+		return "auto", 0
 	}
-	return c.Concurrency.ChunkSizeMB
+	return "fixed", c.Concurrency.ChunkSizeMB
 }
 
 // resolveBatchDownloadCandidate resolves a single source URI or direct URL to

--- a/cmd/modfetch/download_tuning_test.go
+++ b/cmd/modfetch/download_tuning_test.go
@@ -52,6 +52,41 @@ func TestDownloadDryRunReportsTuning(t *testing.T) {
 	}
 }
 
+func TestDownloadDryRunSanitizesResolverURI(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yml")
+	cfgBody := "version: 1\n" +
+		"general:\n" +
+		"  data_root: " + filepath.Join(tmp, "data") + "\n" +
+		"  download_root: " + filepath.Join(tmp, "downloads") + "\n"
+	if err := os.WriteFile(cfgPath, []byte(cfgBody), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = handleDownload(context.Background(), []string{
+			"--config", cfgPath,
+			"--url", "https://user:secret@example.com/model.gguf?token=secret&x=1",
+			"--dry-run",
+			"--summary-json",
+		})
+	})
+	if runErr != nil {
+		t.Fatalf("download dry-run: %v", runErr)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode dry-run JSON: %v\n%s", err, out)
+	}
+	if got["resolver_uri"] != "https://example.com/model.gguf" {
+		t.Fatalf("resolver_uri = %v, want sanitized URL", got["resolver_uri"])
+	}
+	if strings.Contains(out, "secret") || strings.Contains(out, "token=") {
+		t.Fatalf("dry-run JSON leaked sensitive URL material: %s", out)
+	}
+}
+
 func TestApplyDownloadTuningLargeModelProfile(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Concurrency.PerFileChunks = 4

--- a/cmd/modfetch/download_tuning_test.go
+++ b/cmd/modfetch/download_tuning_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/config"
+)
+
+func TestDownloadDryRunReportsTuning(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yml")
+	cfgBody := "version: 1\n" +
+		"general:\n" +
+		"  data_root: " + filepath.Join(tmp, "data") + "\n" +
+		"  download_root: " + filepath.Join(tmp, "downloads") + "\n"
+	if err := os.WriteFile(cfgPath, []byte(cfgBody), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = handleDownload(context.Background(), []string{
+			"--config", cfgPath,
+			"--url", "starter://gpt2-config",
+			"--dry-run",
+			"--summary-json",
+			"--profile", "large-model",
+			"--connections", "20",
+			"--chunk-size-mb", "32",
+		})
+	})
+	if runErr != nil {
+		t.Fatalf("download dry-run: %v", runErr)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode dry-run JSON: %v\n%s", err, out)
+	}
+	if got["profile"] != "large-model" {
+		t.Fatalf("profile = %v, want large-model", got["profile"])
+	}
+	if got["connections"] != float64(20) {
+		t.Fatalf("connections = %v, want 20", got["connections"])
+	}
+	if got["chunk_size_mb"] != float64(32) {
+		t.Fatalf("chunk_size_mb = %v, want 32", got["chunk_size_mb"])
+	}
+}
+
+func TestApplyDownloadTuningLargeModelProfile(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Concurrency.PerFileChunks = 4
+	cfg.Concurrency.PerHostRequests = 4
+	cfg.Concurrency.ChunkSizeMB = 8
+
+	if err := applyDownloadTuning(cfg, "large-model", 0, 0); err != nil {
+		t.Fatalf("apply tuning: %v", err)
+	}
+	if cfg.Concurrency.PerFileChunks != 16 {
+		t.Fatalf("per_file_chunks = %d, want 16", cfg.Concurrency.PerFileChunks)
+	}
+	if cfg.Concurrency.PerHostRequests != 16 {
+		t.Fatalf("per_host_requests = %d, want 16", cfg.Concurrency.PerHostRequests)
+	}
+	if cfg.Concurrency.ChunkSizeMB != 64 {
+		t.Fatalf("chunk_size_mb = %d, want 64", cfg.Concurrency.ChunkSizeMB)
+	}
+}
+
+func TestApplyDownloadTuningExplicitOverridesProfile(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Concurrency.PerFileChunks = 4
+	cfg.Concurrency.PerHostRequests = 4
+	cfg.Concurrency.ChunkSizeMB = 8
+
+	if err := applyDownloadTuning(cfg, "large-model", 24, 32); err != nil {
+		t.Fatalf("apply tuning: %v", err)
+	}
+	if cfg.Concurrency.PerFileChunks != 24 {
+		t.Fatalf("per_file_chunks = %d, want 24", cfg.Concurrency.PerFileChunks)
+	}
+	if cfg.Concurrency.PerHostRequests != 24 {
+		t.Fatalf("per_host_requests = %d, want 24", cfg.Concurrency.PerHostRequests)
+	}
+	if cfg.Concurrency.ChunkSizeMB != 32 {
+		t.Fatalf("chunk_size_mb = %d, want 32", cfg.Concurrency.ChunkSizeMB)
+	}
+}
+
+func TestApplyDownloadTuningRejectsInvalidValues(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		profile     string
+		connections int
+		chunkSizeMB int
+		want        string
+	}{
+		{name: "bad profile", profile: "turbo", want: "unknown download profile"},
+		{name: "negative connections", connections: -1, want: "--connections"},
+		{name: "negative chunk size", chunkSizeMB: -1, want: "--chunk-size-mb"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := applyDownloadTuning(&config.Config{}, tt.profile, tt.connections, tt.chunkSizeMB)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/modfetch/download_tuning_test.go
+++ b/cmd/modfetch/download_tuning_test.go
@@ -47,6 +47,9 @@ func TestDownloadDryRunReportsTuning(t *testing.T) {
 	if got["connections"] != float64(20) {
 		t.Fatalf("connections = %v, want 20", got["connections"])
 	}
+	if got["chunk_size_mode"] != "fixed" {
+		t.Fatalf("chunk_size_mode = %v, want fixed", got["chunk_size_mode"])
+	}
 	if got["chunk_size_mb"] != float64(32) {
 		t.Fatalf("chunk_size_mb = %v, want 32", got["chunk_size_mb"])
 	}
@@ -81,6 +84,19 @@ func TestDownloadDryRunSanitizesResolverURI(t *testing.T) {
 	}
 	if got["resolver_uri"] != "https://example.com/model.gguf" {
 		t.Fatalf("resolver_uri = %v, want sanitized URL", got["resolver_uri"])
+	}
+	if got["chunk_size_mode"] != "auto" {
+		t.Fatalf("chunk_size_mode = %v, want auto", got["chunk_size_mode"])
+	}
+	if _, ok := got["chunk_size_mb"]; ok {
+		t.Fatalf("chunk_size_mb should be omitted in auto mode: %v", got["chunk_size_mb"])
+	}
+	chunkRange, ok := got["chunk_size_range_mb"].(map[string]any)
+	if !ok {
+		t.Fatalf("chunk_size_range_mb = %T, want object", got["chunk_size_range_mb"])
+	}
+	if chunkRange["min"] != float64(1) || chunkRange["max"] != float64(64) {
+		t.Fatalf("chunk_size_range_mb = %v, want min=1 max=64", chunkRange)
 	}
 	if strings.Contains(out, "secret") || strings.Contains(out, "token=") {
 		t.Fatalf("dry-run JSON leaked sensitive URL material: %s", out)
@@ -145,5 +161,19 @@ func TestApplyDownloadTuningRejectsInvalidValues(t *testing.T) {
 				t.Fatalf("error = %v, want containing %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestEffectiveChunkSizeReportsAutoWhenUnset(t *testing.T) {
+	mode, size := effectiveChunkSize(&config.Config{})
+	if mode != "auto" || size != 0 {
+		t.Fatalf("effectiveChunkSize = (%q, %d), want (auto, 0)", mode, size)
+	}
+
+	cfg := &config.Config{}
+	cfg.Concurrency.ChunkSizeMB = 32
+	mode, size = effectiveChunkSize(cfg)
+	if mode != "fixed" || size != 32 {
+		t.Fatalf("effectiveChunkSize = (%q, %d), want (fixed, 32)", mode, size)
 	}
 }

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -95,6 +95,10 @@ modfetch download --url URL [OPTIONS]
 - `--extract` - Extract `.zip`, `.tar`, `.tar.gz`, `.tgz`, or `.7z` archives after download. 7z archives require `7zz`, `7z`, or `7za` on `PATH`.
 - `--extract-dir PATH` - Directory for extracted archive contents
 - `--batch-parallel N` - Concurrent downloads in batch mode
+- `--profile large-model` - Apply large-file tuning for DS4/GGUF-size artifacts
+  (`16` range connections and `64 MiB` chunks unless overridden)
+- `--connections N` - Parallel range requests per file, similar to aria2 `-x/-s`
+- `--chunk-size-mb N` - Range chunk size for this invocation
 - `--no-resume` - Remove staged partial data and start fresh
 - `--force` - Skip SHA256 verification even when a hash is provided
 - `--quant NAME` - Select a Hugging Face quantization to download
@@ -116,6 +120,10 @@ modfetch download --url 'https://example.com/model.safetensors'
 # Hugging Face (requires HF_TOKEN for private repos)
 modfetch download --url 'hf://gpt2/README.md?rev=main'
 modfetch download --url 'hf://TheBloke/Llama-2-7B-GGUF/llama-2-7b.Q4_K_M.gguf?rev=main'
+
+# Large GGUF / Hugging Face Xet-style object
+modfetch download --url 'hf://owner/repo/model.gguf?rev=main' --profile large-model
+modfetch download --url 'https://huggingface.co/owner/repo/resolve/main/model.gguf' --connections 16 --chunk-size-mb 64
 
 # CivitAI (requires CIVITAI_TOKEN for restricted content)
 modfetch download --url 'civitai://model/123456'


### PR DESCRIPTION
## Summary
- add download --profile large-model plus --connections and --chunk-size-mb one-shot tuning
- report effective tuning in dry-run text and JSON output
- document large model tuning and preserve-resume behavior

## Validation
- go test -count=1 ./cmd/modfetch -run 'TestDownloadDryRunReportsTuning|TestApplyDownloadTuning|TestCompletionCurrentFlags'
- scripts/uat/real_download_matrix.sh
- scripts/check-docs-drift.sh
- make build
- make lint
- git diff --check
- go test -count=1 ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->