### PR TITLE
feat: add adaptive transfer benchmarking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 Added
+- Added `modfetch bench` to run disposable, timed download samples with
+  modfetch and aria2 on the same URL, producing comparable throughput JSON.
+- Added automatic large-transfer tuning for range-capable objects, so
+  `download` can promote very large Hugging Face/Xet-style files to
+  large-model settings without requiring YAML edits.
 - Added `modfetch download --profile large-model`, `--connections`, and
   `--chunk-size-mb` for aria2-style one-shot tuning of very large model
   downloads without editing YAML.

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ modfetch library scan --repair-stale
     
         modfetch download --config /path/to/config.yml --url 'hf://org/repo/path?rev=main' --dry-run
         modfetch download --config /path/to/config.yml --url 'https://example.com/file.bin' --dry-run --summary-json
-  - Large model tuning: the default `--profile auto` promotes range-capable multi-GB objects to large-model settings. Use `--profile large-model` to force DS4/GGUF tuning, `--profile default` to disable auto-tuning, or explicit aria2-style range tuning with `--connections 16 --chunk-size-mb 64`.
+  - Large model tuning: the default `--profile auto` promotes range-capable objects around 1 GiB or larger to large-model settings. Use `--profile large-model` to force DS4/GGUF tuning, `--profile default` to disable auto-tuning, or explicit aria2-style range tuning with `--connections 16 --chunk-size-mb 64`.
   - Benchmark transfers: use `modfetch bench --url <URL> --tools modfetch,aria2 --duration 30s --json` to run disposable samples against the same URL before committing to a huge download.
   - On completion, a summary is printed (dest, size, SHA256, duration, average speed)
   - Cancel with Ctrl+C (SIGINT/SIGTERM); staged partial files and completed chunks are preserved for resume. Use `--no-resume` or `modfetch clean` when you want to discard staged data.

--- a/README.md
+++ b/README.md
@@ -383,7 +383,8 @@ modfetch library scan --repair-stale
     
         modfetch download --config /path/to/config.yml --url 'hf://org/repo/path?rev=main' --dry-run
         modfetch download --config /path/to/config.yml --url 'https://example.com/file.bin' --dry-run --summary-json
-  - Large model tuning: use `--profile large-model` for DS4/GGUF-size artifacts, or set explicit aria2-style range tuning with `--connections 16 --chunk-size-mb 64`.
+  - Large model tuning: the default `--profile auto` promotes range-capable multi-GB objects to large-model settings. Use `--profile large-model` to force DS4/GGUF tuning, `--profile default` to disable auto-tuning, or explicit aria2-style range tuning with `--connections 16 --chunk-size-mb 64`.
+  - Benchmark transfers: use `modfetch bench --url <URL> --tools modfetch,aria2 --duration 30s --json` to run disposable samples against the same URL before committing to a huge download.
   - On completion, a summary is printed (dest, size, SHA256, duration, average speed)
   - Cancel with Ctrl+C (SIGINT/SIGTERM); staged partial files and completed chunks are preserved for resume. Use `--no-resume` or `modfetch clean` when you want to discard staged data.
 - Place artifacts into apps:

--- a/cmd/modfetch/bench_cmd.go
+++ b/cmd/modfetch/bench_cmd.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -112,7 +113,13 @@ func handleBench(ctx context.Context, args []string) error {
 	if *common.jsonOut {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(summary)
+		if err := enc.Encode(summary); err != nil {
+			return err
+		}
+		if !hasSuccessfulBench(results) {
+			return errors.New("no successful benchmarks")
+		}
+		return nil
 	}
 	fmt.Printf("Benchmark: %s\n", logging.SanitizeURL(resolvedURL))
 	for _, r := range results {
@@ -129,7 +136,19 @@ func handleBench(ctx context.Context, args []string) error {
 	if *keep {
 		fmt.Printf("Work dir: %s\n", workDir)
 	}
+	if !hasSuccessfulBench(results) {
+		return errors.New("no successful benchmarks")
+	}
 	return nil
+}
+
+func hasSuccessfulBench(results []benchResult) bool {
+	for _, result := range results {
+		if result.Status != "error" {
+			return true
+		}
+	}
+	return false
 }
 
 func parseBenchTools(raw string) []string {
@@ -186,11 +205,9 @@ func runModfetchBench(ctx context.Context, base *config.Config, log *logging.Log
 	final, _, err := downloader.NewAuto(&cfg, log, st, nil).Download(sampleCtx, rawURL, dest, "", headers, true)
 	elapsed := time.Since(start)
 	bytes, chunkRows := completedChunkBytes(st, rawURL, dest)
+	bytes = maxInt64(bytes, sampledPartBytes(&cfg, rawURL, dest, chunkRows))
 	if final != "" {
 		bytes = maxInt64(bytes, fileSize(final))
-	}
-	if chunkRows == 0 {
-		bytes = maxInt64(bytes, fileSize(downloader.StagePartPath(&cfg, rawURL, dest)))
 	}
 	status := "sampled"
 	errText := ""
@@ -285,7 +302,7 @@ func hasSensitiveHeaders(headers map[string]string) bool {
 			continue
 		}
 		switch strings.ToLower(strings.TrimSpace(name)) {
-		case "authorization", "cookie", "x-api-key":
+		case "authorization", "proxy-authorization", "cookie", "x-api-key":
 			return true
 		}
 	}
@@ -316,6 +333,28 @@ func fileSize(path string) int64 {
 	fi, err := os.Stat(path)
 	if err != nil {
 		return 0
+	}
+	return fi.Size()
+}
+
+func sampledPartBytes(cfg *config.Config, rawURL, dest string, chunkRows int) int64 {
+	part := downloader.StagePartPath(cfg, rawURL, dest)
+	if chunkRows > 0 {
+		return allocatedFileBytes(part)
+	}
+	return fileSize(part)
+}
+
+func allocatedFileBytes(path string) int64 {
+	if path == "" {
+		return 0
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok && st.Blocks > 0 {
+		return st.Blocks * 512
 	}
 	return fi.Size()
 }

--- a/cmd/modfetch/bench_cmd.go
+++ b/cmd/modfetch/bench_cmd.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -45,7 +44,7 @@ type benchSummary struct {
 
 func handleBench(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("bench", flag.ContinueOnError)
-	common := addCommonConfigLogFlags(fs, "")
+	common := addCommonConfigLogFlags(fs, "emit benchmark results as JSON")
 	urlFlag := fs.String("url", "", "HTTP URL or resolver URI to benchmark")
 	toolsFlag := fs.String("tools", "modfetch,aria2", "comma-separated tools: modfetch,aria2")
 	durationFlag := fs.Duration("duration", 15*time.Second, "sample duration per tool")
@@ -162,23 +161,7 @@ func resolveBenchURL(ctx context.Context, c *config.Config, raw string) (string,
 		return res.URL, res.Headers, nil
 	}
 	headers := map[string]string{}
-	if u, err := url.Parse(raw); err == nil {
-		host := strings.ToLower(u.Hostname())
-		if hostIs(host, "huggingface.co") && c.Sources.HuggingFace.Enabled {
-			if env := strings.TrimSpace(c.Sources.HuggingFace.TokenEnv); env != "" {
-				if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
-					headers["Authorization"] = "Bearer " + tok
-				}
-			}
-		}
-		if hostIs(host, "civitai.com") && c.Sources.CivitAI.Enabled {
-			if env := strings.TrimSpace(c.Sources.CivitAI.TokenEnv); env != "" {
-				if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
-					headers["Authorization"] = "Bearer " + tok
-				}
-			}
-		}
-	}
+	headers = attachDirectProviderAuthHeaders(c, raw, headers, nil)
 	return raw, headers, nil
 }
 
@@ -244,9 +227,6 @@ func runAria2Bench(ctx context.Context, cfg *config.Config, rawURL string, heade
 	}
 	destName := "aria2-bench.bin"
 	connections := effectiveDownloadConnections(cfg)
-	if connections <= 0 {
-		connections = defaultDownloadConnections
-	}
 	chunkSize := fixedChunkSizeMB(cfg)
 	if chunkSize <= 0 {
 		chunkSize = autoChunkSizeMaxMB

--- a/cmd/modfetch/bench_cmd.go
+++ b/cmd/modfetch/bench_cmd.go
@@ -74,8 +74,14 @@ func handleBench(ctx context.Context, args []string) error {
 		return err
 	}
 	log := logging.New(*common.logLevel, false)
-	if decision, err := maybeApplyAdaptiveDownloadTuning(ctx, c, resolvedURL, headers, *profile, *connections, *chunkSizeMB); err == nil && decision.Applied && !*common.jsonOut {
-		log.Infof("adaptive tuning: %s", decision.Reason)
+	if decision, err := maybeApplyAdaptiveDownloadTuning(ctx, c, resolvedURL, headers, *profile, *connections, *chunkSizeMB); !*common.jsonOut {
+		if err != nil && profileWantsAuto(*profile) {
+			log.Warnf("adaptive tuning probe failed: %v", err)
+		} else if err == nil && decision != nil && decision.Applied {
+			log.Infof("adaptive tuning: %s", decision.Reason)
+		} else if err == nil && decision != nil && profileWantsAuto(*profile) {
+			log.Infof("adaptive tuning skipped: %s", decision.Reason)
+		}
 	}
 	workDir, err := os.MkdirTemp("", "modfetch-bench.*")
 	if err != nil {

--- a/cmd/modfetch/bench_cmd.go
+++ b/cmd/modfetch/bench_cmd.go
@@ -1,0 +1,353 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dustin/go-humanize"
+
+	"github.com/jxwalker/modfetch/internal/config"
+	"github.com/jxwalker/modfetch/internal/downloader"
+	"github.com/jxwalker/modfetch/internal/logging"
+	"github.com/jxwalker/modfetch/internal/resolver"
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+type benchResult struct {
+	Tool        string  `json:"tool"`
+	Status      string  `json:"status"`
+	Bytes       int64   `json:"bytes"`
+	Duration    float64 `json:"duration"`
+	AvgBPS      float64 `json:"avg_bps"`
+	Connections int     `json:"connections,omitempty"`
+	ChunkSizeMB int     `json:"chunk_size_mb,omitempty"`
+	Error       string  `json:"error,omitempty"`
+	Dest        string  `json:"dest,omitempty"`
+}
+
+type benchSummary struct {
+	URL      string        `json:"url"`
+	WorkDir  string        `json:"work_dir,omitempty"`
+	Duration float64       `json:"duration"`
+	Results  []benchResult `json:"results"`
+	Winner   string        `json:"winner,omitempty"`
+}
+
+func handleBench(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("bench", flag.ContinueOnError)
+	common := addCommonConfigLogFlags(fs, "")
+	urlFlag := fs.String("url", "", "HTTP URL or resolver URI to benchmark")
+	toolsFlag := fs.String("tools", "modfetch,aria2", "comma-separated tools: modfetch,aria2")
+	durationFlag := fs.Duration("duration", 15*time.Second, "sample duration per tool")
+	profile := fs.String("profile", "", "download tuning profile: auto, default, or large-model")
+	connections := fs.Int("connections", 0, "parallel range requests per file")
+	chunkSizeMB := fs.Int("chunk-size-mb", 0, "range chunk size in MiB")
+	keep := fs.Bool("keep", false, "keep temporary benchmark downloads")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*urlFlag) == "" {
+		return errors.New("--url is required")
+	}
+	if *durationFlag <= 0 {
+		return errors.New("--duration must be > 0")
+	}
+	c, _, err := loadConfig(*common.configPath)
+	if err != nil {
+		return err
+	}
+	if err := applyDownloadTuning(c, *profile, *connections, *chunkSizeMB); err != nil {
+		return err
+	}
+	resolvedURL, headers, err := resolveBenchURL(ctx, c, *urlFlag)
+	if err != nil {
+		return err
+	}
+	log := logging.New(*common.logLevel, false)
+	if decision, err := maybeApplyAdaptiveDownloadTuning(ctx, c, resolvedURL, headers, *profile, *connections, *chunkSizeMB); err == nil && decision.Applied && !*common.jsonOut {
+		log.Infof("adaptive tuning: %s", decision.Reason)
+	}
+	workDir, err := os.MkdirTemp("", "modfetch-bench.*")
+	if err != nil {
+		return err
+	}
+	if !*keep {
+		defer func() { _ = os.RemoveAll(workDir) }()
+	}
+	results := make([]benchResult, 0, 2)
+	for _, tool := range parseBenchTools(*toolsFlag) {
+		switch tool {
+		case "modfetch":
+			results = append(results, runModfetchBench(ctx, c, log, resolvedURL, headers, workDir, *durationFlag))
+		case "aria2":
+			results = append(results, runAria2Bench(ctx, c, resolvedURL, headers, workDir, *durationFlag))
+		default:
+			results = append(results, benchResult{Tool: tool, Status: "error", Error: "unknown tool"})
+		}
+	}
+	summary := benchSummary{
+		URL:      logging.SanitizeURL(resolvedURL),
+		Duration: durationFlag.Seconds(),
+		Results:  results,
+		Winner:   benchWinner(results),
+	}
+	if *keep {
+		summary.WorkDir = workDir
+	}
+	if *common.jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(summary)
+	}
+	fmt.Printf("Benchmark: %s\n", logging.SanitizeURL(resolvedURL))
+	for _, r := range results {
+		if r.Status == "error" {
+			fmt.Printf("  %-8s error: %s\n", r.Tool, r.Error)
+			continue
+		}
+		fmt.Printf("  %-8s %-9s %10s in %5.1fs  %10s/s\n",
+			r.Tool, r.Status, humanize.Bytes(uint64(r.Bytes)), r.Duration, humanize.Bytes(uint64(r.AvgBPS)))
+	}
+	if summary.Winner != "" {
+		fmt.Printf("Winner: %s\n", summary.Winner)
+	}
+	if *keep {
+		fmt.Printf("Work dir: %s\n", workDir)
+	}
+	return nil
+}
+
+func parseBenchTools(raw string) []string {
+	var out []string
+	seen := map[string]struct{}{}
+	for _, part := range strings.Split(raw, ",") {
+		tool := strings.ToLower(strings.TrimSpace(part))
+		if tool == "" {
+			continue
+		}
+		if _, ok := seen[tool]; ok {
+			continue
+		}
+		seen[tool] = struct{}{}
+		out = append(out, tool)
+	}
+	if len(out) == 0 {
+		return []string{"modfetch"}
+	}
+	return out
+}
+
+func resolveBenchURL(ctx context.Context, c *config.Config, raw string) (string, map[string]string, error) {
+	if isResolverURI(raw) {
+		res, err := resolver.Resolve(ctx, raw, c)
+		if err != nil {
+			return "", nil, err
+		}
+		return res.URL, res.Headers, nil
+	}
+	headers := map[string]string{}
+	if u, err := url.Parse(raw); err == nil {
+		host := strings.ToLower(u.Hostname())
+		if hostIs(host, "huggingface.co") && c.Sources.HuggingFace.Enabled {
+			if env := strings.TrimSpace(c.Sources.HuggingFace.TokenEnv); env != "" {
+				if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
+					headers["Authorization"] = "Bearer " + tok
+				}
+			}
+		}
+		if hostIs(host, "civitai.com") && c.Sources.CivitAI.Enabled {
+			if env := strings.TrimSpace(c.Sources.CivitAI.TokenEnv); env != "" {
+				if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
+					headers["Authorization"] = "Bearer " + tok
+				}
+			}
+		}
+	}
+	return raw, headers, nil
+}
+
+func runModfetchBench(ctx context.Context, base *config.Config, log *logging.Logger, rawURL string, headers map[string]string, workDir string, duration time.Duration) benchResult {
+	cfg := *base
+	root := filepath.Join(workDir, "modfetch")
+	cfg.General.DataRoot = filepath.Join(root, "data")
+	cfg.General.DownloadRoot = filepath.Join(root, "downloads")
+	cfg.General.PartialsRoot = filepath.Join(root, "partials")
+	if err := os.MkdirAll(cfg.General.DownloadRoot, 0o755); err != nil {
+		return benchResult{Tool: "modfetch", Status: "error", Error: err.Error()}
+	}
+	st, err := state.Open(&cfg)
+	if err != nil {
+		return benchResult{Tool: "modfetch", Status: "error", Error: err.Error()}
+	}
+	defer func() { _ = st.Close() }()
+	dest := filepath.Join(cfg.General.DownloadRoot, "modfetch-bench.bin")
+	sampleCtx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
+	start := time.Now()
+	final, _, err := downloader.NewAuto(&cfg, log, st, nil).Download(sampleCtx, rawURL, dest, "", headers, true)
+	elapsed := time.Since(start)
+	bytes, chunkRows := completedChunkBytes(st, rawURL, dest)
+	if final != "" {
+		bytes = maxInt64(bytes, fileSize(final))
+	}
+	if chunkRows == 0 {
+		bytes = maxInt64(bytes, fileSize(downloader.StagePartPath(&cfg, rawURL, dest)))
+	}
+	status := "sampled"
+	errText := ""
+	if err == nil {
+		status = "complete"
+	} else if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		status = "error"
+		errText = err.Error()
+	}
+	return benchResult{
+		Tool:        "modfetch",
+		Status:      status,
+		Bytes:       bytes,
+		Duration:    elapsed.Seconds(),
+		AvgBPS:      bytesPerSecond(bytes, elapsed),
+		Connections: effectiveDownloadConnections(&cfg),
+		ChunkSizeMB: fixedChunkSizeMB(&cfg),
+		Error:       errText,
+		Dest:        dest,
+	}
+}
+
+func runAria2Bench(ctx context.Context, cfg *config.Config, rawURL string, headers map[string]string, workDir string, duration time.Duration) benchResult {
+	aria2Path, err := exec.LookPath("aria2c")
+	if err != nil {
+		return benchResult{Tool: "aria2", Status: "error", Error: "aria2c not found on PATH"}
+	}
+	dir := filepath.Join(workDir, "aria2")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return benchResult{Tool: "aria2", Status: "error", Error: err.Error()}
+	}
+	destName := "aria2-bench.bin"
+	connections := effectiveDownloadConnections(cfg)
+	if connections <= 0 {
+		connections = defaultDownloadConnections
+	}
+	chunkSize := fixedChunkSizeMB(cfg)
+	if chunkSize <= 0 {
+		chunkSize = autoChunkSizeMaxMB
+	}
+	args := []string{
+		"--allow-overwrite=true",
+		"--auto-file-renaming=false",
+		"--continue=false",
+		"--console-log-level=warn",
+		"--summary-interval=0",
+		"--dir", dir,
+		"--out", destName,
+		"--max-connection-per-server", strconv.Itoa(connections),
+		"--split", strconv.Itoa(connections),
+		"--min-split-size", fmt.Sprintf("%dM", chunkSize),
+	}
+	for k, v := range headers {
+		args = append(args, "--header", k+": "+v)
+	}
+	args = append(args, rawURL)
+	sampleCtx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
+	start := time.Now()
+	cmd := exec.CommandContext(sampleCtx, aria2Path, args...)
+	out, err := cmd.CombinedOutput()
+	elapsed := time.Since(start)
+	dest := filepath.Join(dir, destName)
+	bytes := fileSize(dest)
+	status := "sampled"
+	errText := ""
+	if err == nil {
+		status = "complete"
+	} else if sampleCtx.Err() == nil {
+		status = "error"
+		errText = strings.TrimSpace(string(out))
+		if errText == "" {
+			errText = err.Error()
+		}
+	}
+	return benchResult{
+		Tool:        "aria2",
+		Status:      status,
+		Bytes:       bytes,
+		Duration:    elapsed.Seconds(),
+		AvgBPS:      bytesPerSecond(bytes, elapsed),
+		Connections: connections,
+		ChunkSizeMB: chunkSize,
+		Error:       errText,
+		Dest:        dest,
+	}
+}
+
+func completedChunkBytes(st *state.DB, rawURL, dest string) (int64, int) {
+	if st == nil {
+		return 0, 0
+	}
+	chunks, err := st.ListChunks(rawURL, dest)
+	if err != nil {
+		return 0, 0
+	}
+	var total int64
+	for _, chunk := range chunks {
+		if chunk.Status == "complete" {
+			total += chunk.Size
+		}
+	}
+	return total, len(chunks)
+}
+
+func fileSize(path string) int64 {
+	if path == "" {
+		return 0
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return fi.Size()
+}
+
+func bytesPerSecond(bytes int64, elapsed time.Duration) float64 {
+	if bytes <= 0 || elapsed <= 0 {
+		return 0
+	}
+	return float64(bytes) / elapsed.Seconds()
+}
+
+func benchWinner(results []benchResult) string {
+	var winner string
+	var best float64
+	for _, result := range results {
+		if result.Status == "error" || result.AvgBPS <= best {
+			continue
+		}
+		best = result.AvgBPS
+		winner = result.Tool
+	}
+	return winner
+}
+
+func fixedChunkSizeMB(c *config.Config) int {
+	if mode, size := effectiveChunkSize(c); mode == "fixed" {
+		return size
+	}
+	return 0
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/cmd/modfetch/bench_cmd.go
+++ b/cmd/modfetch/bench_cmd.go
@@ -235,6 +235,9 @@ func runAria2Bench(ctx context.Context, cfg *config.Config, rawURL string, heade
 	if err != nil {
 		return benchResult{Tool: "aria2", Status: "error", Error: "aria2c not found on PATH"}
 	}
+	if hasSensitiveHeaders(headers) {
+		return benchResult{Tool: "aria2", Status: "error", Error: "aria2 benchmark skipped: sensitive headers cannot be passed safely to aria2c"}
+	}
 	dir := filepath.Join(workDir, "aria2")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return benchResult{Tool: "aria2", Status: "error", Error: err.Error()}
@@ -294,6 +297,19 @@ func runAria2Bench(ctx context.Context, cfg *config.Config, rawURL string, heade
 		Error:       errText,
 		Dest:        dest,
 	}
+}
+
+func hasSensitiveHeaders(headers map[string]string) bool {
+	for name, value := range headers {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(name)) {
+		case "authorization", "cookie", "x-api-key":
+			return true
+		}
+	}
+	return false
 }
 
 func completedChunkBytes(st *state.DB, rawURL, dest string) (int64, int) {

--- a/cmd/modfetch/bench_cmd_test.go
+++ b/cmd/modfetch/bench_cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -103,6 +104,31 @@ func TestParseBenchToolsDedupesAndDefaults(t *testing.T) {
 	}
 }
 
+func TestBenchRangeServerSupportsOpenEndedRanges(t *testing.T) {
+	ts := newBenchRangeServer(t, 32)
+	defer ts.Close()
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/model.bin", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Range", "bytes=10-")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) != 22 {
+		t.Fatalf("body len = %d, want 22", len(body))
+	}
+}
+
 func writeBenchConfig(t *testing.T) string {
 	t.Helper()
 	tmp := t.TempDir()
@@ -132,15 +158,24 @@ func newBenchRangeServer(t *testing.T, size int) *httptest.Server {
 			return
 		}
 		if rng := r.Header.Get("Range"); rng != "" {
-			var start, end int
-			if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); err == nil {
+			if spec, ok := strings.CutPrefix(rng, "bytes="); ok {
+				parts := strings.SplitN(spec, "-", 2)
+				var start, end int
+				var err error
+				if len(parts) > 0 {
+					start, err = strconv.Atoi(parts[0])
+				}
+				end = len(body) - 1
+				if err == nil && len(parts) == 2 && parts[1] != "" {
+					end, err = strconv.Atoi(parts[1])
+				}
 				if end >= len(body) || end < 0 {
 					end = len(body) - 1
 				}
 				if start < 0 {
 					start = 0
 				}
-				if start <= end && start < len(body) {
+				if err == nil && start <= end && start < len(body) {
 					w.Header().Set("Content-Length", strconv.Itoa(end-start+1))
 					w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(body)))
 					w.WriteHeader(http.StatusPartialContent)

--- a/cmd/modfetch/bench_cmd_test.go
+++ b/cmd/modfetch/bench_cmd_test.go
@@ -112,6 +112,13 @@ func TestAria2BenchSkipsSensitiveHeaders(t *testing.T) {
 	if result.Status != "error" || !strings.Contains(result.Error, "sensitive headers") {
 		t.Fatalf("result = %+v, want sensitive-header error", result)
 	}
+
+	result = runAria2Bench(context.Background(), nil, "https://example.com/model.bin", map[string]string{
+		"Proxy-Authorization": "Basic secret",
+	}, t.TempDir(), time.Second)
+	if result.Status != "error" || !strings.Contains(result.Error, "sensitive headers") {
+		t.Fatalf("result = %+v, want proxy sensitive-header error", result)
+	}
 }
 
 func TestBenchRangeServerSupportsOpenEndedRanges(t *testing.T) {
@@ -136,6 +143,30 @@ func TestBenchRangeServerSupportsOpenEndedRanges(t *testing.T) {
 	}
 	if len(body) != 22 {
 		t.Fatalf("body len = %d, want 22", len(body))
+	}
+}
+
+func TestBenchReturnsErrorWhenEveryToolFails(t *testing.T) {
+	cfgPath := writeBenchConfig(t)
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = handleBench(context.Background(), []string{
+			"--config", cfgPath,
+			"--url", "https://example.com/model.bin",
+			"--tools", "not-a-tool",
+			"--duration", "1s",
+			"--json",
+		})
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "no successful benchmarks") {
+		t.Fatalf("bench error = %v, want no successful benchmarks", runErr)
+	}
+	var got benchSummary
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode bench JSON: %v\n%s", err, out)
+	}
+	if len(got.Results) != 1 || got.Results[0].Status != "error" {
+		t.Fatalf("unexpected results: %+v", got.Results)
 	}
 }
 

--- a/cmd/modfetch/bench_cmd_test.go
+++ b/cmd/modfetch/bench_cmd_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBenchModfetchRunsRealDownloadSample(t *testing.T) {
@@ -101,6 +102,15 @@ func TestParseBenchToolsDedupesAndDefaults(t *testing.T) {
 	got = parseBenchTools(" , ")
 	if len(got) != 1 || got[0] != "modfetch" {
 		t.Fatalf("empty parseBenchTools = %v, want modfetch", got)
+	}
+}
+
+func TestAria2BenchSkipsSensitiveHeaders(t *testing.T) {
+	result := runAria2Bench(context.Background(), nil, "https://example.com/model.bin", map[string]string{
+		"Authorization": "Bearer secret",
+	}, t.TempDir(), time.Second)
+	if result.Status != "error" || !strings.Contains(result.Error, "sensitive headers") {
+		t.Fatalf("result = %+v, want sensitive-header error", result)
 	}
 }
 

--- a/cmd/modfetch/bench_cmd_test.go
+++ b/cmd/modfetch/bench_cmd_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestBenchModfetchRunsRealDownloadSample(t *testing.T) {
+	ts := newBenchRangeServer(t, 512*1024)
+	defer ts.Close()
+	cfgPath := writeBenchConfig(t)
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = handleBench(context.Background(), []string{
+			"--config", cfgPath,
+			"--url", ts.URL + "/model.bin",
+			"--tools", "modfetch",
+			"--duration", "2s",
+			"--json",
+			"--profile", "default",
+		})
+	})
+	if runErr != nil {
+		t.Fatalf("bench: %v", runErr)
+	}
+	var got benchSummary
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode bench JSON: %v\n%s", err, out)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(got.Results))
+	}
+	result := got.Results[0]
+	if result.Tool != "modfetch" {
+		t.Fatalf("tool = %q, want modfetch", result.Tool)
+	}
+	if result.Status == "error" {
+		t.Fatalf("modfetch bench errored: %s", result.Error)
+	}
+	if result.Bytes <= 0 || result.AvgBPS <= 0 {
+		t.Fatalf("expected positive bytes/rate, got %+v", result)
+	}
+}
+
+func TestBenchAria2RunsWhenInstalled(t *testing.T) {
+	if _, err := exec.LookPath("aria2c"); err != nil {
+		t.Skip("aria2c not installed")
+	}
+	ts := newBenchRangeServer(t, 512*1024)
+	defer ts.Close()
+	cfgPath := writeBenchConfig(t)
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = handleBench(context.Background(), []string{
+			"--config", cfgPath,
+			"--url", ts.URL + "/model.bin",
+			"--tools", "aria2",
+			"--duration", "2s",
+			"--json",
+			"--connections", "4",
+			"--chunk-size-mb", "1",
+		})
+	})
+	if runErr != nil {
+		t.Fatalf("bench aria2: %v", runErr)
+	}
+	var got benchSummary
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode bench JSON: %v\n%s", err, out)
+	}
+	if len(got.Results) != 1 || got.Results[0].Tool != "aria2" {
+		t.Fatalf("unexpected results: %+v", got.Results)
+	}
+	if got.Results[0].Status == "error" {
+		t.Fatalf("aria2 bench errored: %s", got.Results[0].Error)
+	}
+	if got.Results[0].Bytes <= 0 {
+		t.Fatalf("aria2 bytes = %d, want > 0", got.Results[0].Bytes)
+	}
+}
+
+func TestParseBenchToolsDedupesAndDefaults(t *testing.T) {
+	got := parseBenchTools(" modfetch,aria2,modfetch ,,")
+	want := []string{"modfetch", "aria2"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("parseBenchTools = %v, want %v", got, want)
+	}
+	got = parseBenchTools(" , ")
+	if len(got) != 1 || got[0] != "modfetch" {
+		t.Fatalf("empty parseBenchTools = %v, want modfetch", got)
+	}
+}
+
+func writeBenchConfig(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yml")
+	cfgBody := "version: 1\n" +
+		"general:\n" +
+		"  data_root: " + strconv.Quote(filepath.Join(tmp, "data")) + "\n" +
+		"  download_root: " + strconv.Quote(filepath.Join(tmp, "downloads")) + "\n" +
+		"concurrency:\n" +
+		"  per_file_chunks: 4\n" +
+		"  per_host_requests: 4\n" +
+		"  chunk_size_mb: 1\n"
+	if err := os.WriteFile(cfgPath, []byte(cfgBody), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return cfgPath
+}
+
+func newBenchRangeServer(t *testing.T, size int) *httptest.Server {
+	t.Helper()
+	body := bytes.Repeat([]byte("a"), size)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		if r.Method == http.MethodHead {
+			return
+		}
+		if rng := r.Header.Get("Range"); rng != "" {
+			var start, end int
+			if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); err == nil {
+				if end >= len(body) || end < 0 {
+					end = len(body) - 1
+				}
+				if start < 0 {
+					start = 0
+				}
+				if start <= end && start < len(body) {
+					w.Header().Set("Content-Length", strconv.Itoa(end-start+1))
+					w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(body)))
+					w.WriteHeader(http.StatusPartialContent)
+					_, _ = w.Write(body[start : end+1])
+					return
+				}
+			}
+		}
+		_, _ = w.Write(body)
+	}))
+}

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -35,7 +35,7 @@ _modfetch_completions()
     local cur prev words cword
     _init_completion || return
     local presets="automatic1111 comfyui forge hf-cache ollama"
-    local cmds="config download discover starter place verify status tui library batch dedupe clean hostcaps version help completion"
+    local cmds="config download bench discover starter place verify status tui library batch dedupe clean hostcaps version help completion"
     if [[ ${cword} -eq 1 ]]; then
         COMPREPLY=( $(compgen -W "${cmds}" -- "$cur") )
         return
@@ -57,6 +57,8 @@ _modfetch_completions()
             esac ;;
         download)
             COMPREPLY=( $(compgen -W "--config --log-level --json --quiet --no-resume --url --dest --sha256 --sha256-file --batch --place --summary-json --batch-parallel --profile --connections --chunk-size-mb --dry-run --force --no-auth-preflight --extract --extract-dir --quant --list-quants" -- "$cur") ) ;;
+        bench)
+            COMPREPLY=( $(compgen -W "--config --log-level --json --url --tools --duration --profile --connections --chunk-size-mb --keep modfetch aria2" -- "$cur") ) ;;
         discover)
             if [[ ${cword} -eq 2 ]]; then
                 COMPREPLY=( $(compgen -W "search download" -- "$cur") )
@@ -141,7 +143,7 @@ const zshCompletion = `#compdef modfetch
 # zsh completion for modfetch (basic)
 _modfetch() {
   local -a cmds
-  cmds=(config download discover starter place verify status tui library batch dedupe clean hostcaps version help completion)
+  cmds=(config download bench discover starter place verify status tui library batch dedupe clean hostcaps version help completion)
   if (( CURRENT == 2 )); then
     _describe 'command' cmds
     return
@@ -166,6 +168,9 @@ _modfetch() {
       ;;
     download)
       _arguments '*:options:(--config --log-level --json --quiet --no-resume --url --dest --sha256 --sha256-file --batch --place --summary-json --batch-parallel --profile --connections --chunk-size-mb --dry-run --force --no-auth-preflight --extract --extract-dir --quant --list-quants)'
+      ;;
+    bench)
+      _arguments '*:options:(--config --log-level --json --url --tools --duration --profile --connections --chunk-size-mb --keep modfetch aria2)'
       ;;
     discover)
       if (( CURRENT == 3 )); then
@@ -262,6 +267,7 @@ compdef _modfetch modfetch
 const fishCompletion = `# fish completion for modfetch
 complete -c modfetch -f -n "__fish_use_subcommand" -a "config" -d "config ops"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "download" -d "download assets"
+complete -c modfetch -f -n "__fish_use_subcommand" -a "bench" -d "benchmark download tools"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "discover" -d "search real model providers"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "starter" -d "beginner starter downloads"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "dedupe" -d "dedupe duplicate downloads"
@@ -287,7 +293,7 @@ complete -c modfetch -n "__fish_seen_subcommand_from clean" -l include-next-to-d
 complete -c modfetch -n "__fish_seen_subcommand_from clean" -l sidecars -d "Remove orphan .sha256"
 
 # Common flags
-for cmd in download place verify status tui library dedupe clean
+for cmd in download bench place verify status tui library dedupe clean
   complete -c modfetch -n "__fish_seen_subcommand_from $cmd" -l config -d "Path to config"
   complete -c modfetch -n "__fish_seen_subcommand_from $cmd" -l log-level -d "Log level"
   complete -c modfetch -n "__fish_seen_subcommand_from $cmd" -l json -d "JSON output"
@@ -323,6 +329,13 @@ complete -c modfetch -n "__fish_seen_subcommand_from download" -l extract -d "Ex
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l extract-dir -d "Extraction directory"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l quant -d "HuggingFace quantization to download"
 complete -c modfetch -n "__fish_seen_subcommand_from download" -l list-quants -d "List HuggingFace quantizations"
+complete -c modfetch -n "__fish_seen_subcommand_from bench" -l url -d "URL or resolver URI to benchmark"
+complete -c modfetch -n "__fish_seen_subcommand_from bench" -l tools -d "Tools to benchmark"
+complete -c modfetch -n "__fish_seen_subcommand_from bench" -l duration -d "Sample duration per tool"
+complete -c modfetch -n "__fish_seen_subcommand_from bench" -l profile -d "Download tuning profile"
+complete -c modfetch -n "__fish_seen_subcommand_from bench" -l connections -d "Parallel range requests per file"
+complete -c modfetch -n "__fish_seen_subcommand_from bench" -l chunk-size-mb -d "Range chunk size in MiB"
+complete -c modfetch -n "__fish_seen_subcommand_from bench" -l keep -d "Keep benchmark downloads"
 complete -c modfetch -n "__fish_seen_subcommand_from discover" -a "search" -d "Search real model providers"
 complete -c modfetch -n "__fish_seen_subcommand_from discover" -a "download" -d "Download a selected discovery result"
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from search" -l config -d "Path to config"

--- a/cmd/modfetch/completion_test.go
+++ b/cmd/modfetch/completion_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCompletionTopLevelCommands(t *testing.T) {
 	for name, script := range completionScripts() {
-		for _, command := range []string{"config", "download", "discover", "starter", "place", "verify", "status", "tui", "batch", "dedupe", "clean", "hostcaps", "version", "help", "completion"} {
+		for _, command := range []string{"config", "download", "bench", "discover", "starter", "place", "verify", "status", "tui", "batch", "dedupe", "clean", "hostcaps", "version", "help", "completion"} {
 			want := completionCommandToken(name, command)
 			if !strings.Contains(script, want) {
 				t.Fatalf("%s completion missing top-level command %q", name, command)
@@ -20,6 +20,7 @@ func TestCompletionCurrentFlags(t *testing.T) {
 	tests := map[string][]string{
 		"config":   {"--strict", "--out"},
 		"download": {"--no-resume", "--summary-json", "--batch-parallel", "--profile", "--connections", "--chunk-size-mb", "--dry-run", "--force", "--no-auth-preflight", "--quant", "--list-quants"},
+		"bench":    {"--url", "--tools", "--duration", "--profile", "--connections", "--chunk-size-mb", "--keep"},
 		"discover": {"--provider", "--limit", "--select", "--summary-json", "--dry-run"},
 		"starter":  {"--id", "--summary-json", "--dry-run"},
 		"place":    {"--dry-run", "--preset", "--list-presets"},

--- a/cmd/modfetch/download_cmd.go
+++ b/cmd/modfetch/download_cmd.go
@@ -35,6 +35,7 @@ const (
 	defaultDownloadConnections    = 4
 	autoChunkSizeMinMB            = 1
 	autoChunkSizeMaxMB            = 64
+	adaptiveLargeThresholdBytes   = int64(1 << 30)
 	largeModelDownloadConnections = 16
 	largeModelChunkSizeMB         = 64
 )
@@ -52,7 +53,7 @@ func handleDownload(ctx context.Context, args []string) error {
 	placeFlag := fs.Bool("place", false, "place files after successful download")
 	summaryJSON := fs.Bool("summary-json", false, "print a JSON summary when a download completes")
 	batchParallel := fs.Int("batch-parallel", 0, "max parallel downloads when using --batch (default: config concurrency per_host_requests)")
-	profile := fs.String("profile", "", "download tuning profile: default or large-model")
+	profile := fs.String("profile", "", "download tuning profile: auto, default, or large-model")
 	connections := fs.Int("connections", 0, "parallel range requests per file (aria2-style; overrides concurrency.per_file_chunks)")
 	chunkSizeMB := fs.Int("chunk-size-mb", 0, "range chunk size in MiB for this invocation")
 	dryRun := fs.Bool("dry-run", false, "plan only: resolve URL/URI and compute default destination; no download")
@@ -506,6 +507,10 @@ func handleDownload(ctx context.Context, args []string) error {
 			}
 		}
 	}
+	adaptiveDecision, adaptiveErr := maybeApplyAdaptiveDownloadTuning(ctx, c, resolvedURL, headers, *profile, *connections, *chunkSizeMB)
+	if adaptiveErr != nil && strings.EqualFold(strings.TrimSpace(*profile), "auto") {
+		log.Warnf("adaptive tuning probe failed: %v", adaptiveErr)
+	}
 	// If dry-run, compute a default destination and print plan
 	if *dryRun {
 		candDest := strings.TrimSpace(*dest)
@@ -532,7 +537,12 @@ func handleDownload(ctx context.Context, args []string) error {
 				"default_dest":    candDest,
 				"connections":     effectiveDownloadConnections(c),
 				"chunk_size_mode": chunkMode,
-				"profile":         effectiveDownloadProfile(*profile),
+				"profile":         reportedDownloadProfile(*profile, adaptiveDecision),
+				"profile_source":  reportedDownloadProfileSource(*profile, adaptiveDecision),
+			}
+			if adaptiveDecision != nil && adaptiveDecision.Reason != "" {
+				summary["adaptive_reason"] = adaptiveDecision.Reason
+				summary["remote_size"] = adaptiveDecision.RemoteSize
 			}
 			if chunkSizeMB > 0 {
 				summary["chunk_size_mb"] = chunkSizeMB
@@ -551,7 +561,10 @@ func handleDownload(ctx context.Context, args []string) error {
 		fmt.Printf("  Resolver URI: %s\n", logging.SanitizeURL(*url))
 		fmt.Printf("  Resolved URL: %s\n", logging.SanitizeURL(resolvedURL))
 		fmt.Printf("  Default dest: %s\n", candDest)
-		fmt.Printf("  Profile: %s\n", effectiveDownloadProfile(*profile))
+		fmt.Printf("  Profile: %s (%s)\n", reportedDownloadProfile(*profile, adaptiveDecision), reportedDownloadProfileSource(*profile, adaptiveDecision))
+		if adaptiveDecision != nil && adaptiveDecision.Reason != "" {
+			fmt.Printf("  Adaptive: %s\n", adaptiveDecision.Reason)
+		}
 		fmt.Printf("  Connections: %d\n", effectiveDownloadConnections(c))
 		if chunkMode, chunkSizeMB := effectiveChunkSize(c); chunkMode == "fixed" {
 			fmt.Printf("  Chunk size: %d MiB\n", chunkSizeMB)
@@ -724,7 +737,7 @@ func applyDownloadTuning(c *config.Config, profile string, connections, chunkSiz
 		return errors.New("--chunk-size-mb must be >= 0")
 	}
 	switch strings.ToLower(strings.TrimSpace(profile)) {
-	case "", "default":
+	case "", "auto", "default":
 	case "large", "large-model":
 		if c.Concurrency.PerFileChunks < largeModelDownloadConnections {
 			c.Concurrency.PerFileChunks = largeModelDownloadConnections
@@ -736,7 +749,7 @@ func applyDownloadTuning(c *config.Config, profile string, connections, chunkSiz
 			c.Concurrency.ChunkSizeMB = largeModelChunkSizeMB
 		}
 	default:
-		return fmt.Errorf("unknown download profile %q (valid: default, large-model)", profile)
+		return fmt.Errorf("unknown download profile %q (valid: auto, default, large-model)", profile)
 	}
 	if connections > 0 {
 		c.Concurrency.PerFileChunks = connections
@@ -750,10 +763,111 @@ func applyDownloadTuning(c *config.Config, profile string, connections, chunkSiz
 	return nil
 }
 
+type adaptiveDownloadDecision struct {
+	Applied    bool
+	Reason     string
+	RemoteSize int64
+}
+
+func maybeApplyAdaptiveDownloadTuning(ctx context.Context, c *config.Config, rawURL string, headers map[string]string, profile string, connections, chunkSizeMB int) (*adaptiveDownloadDecision, error) {
+	if c == nil {
+		return nil, errors.New("nil config")
+	}
+	if connections > 0 || chunkSizeMB > 0 {
+		return &adaptiveDownloadDecision{Reason: "explicit tuning flags set"}, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(profile)) {
+	case "", "auto":
+	default:
+		return &adaptiveDownloadDecision{Reason: "profile is explicit"}, nil
+	}
+	meta, err := downloader.ProbeURL(ctx, c, rawURL, headers)
+	if err != nil {
+		return nil, err
+	}
+	decision := &adaptiveDownloadDecision{RemoteSize: meta.Size}
+	if shouldUseLargeModelTuning(rawURL, meta) {
+		if err := applyDownloadTuning(c, "large-model", 0, 0); err != nil {
+			return nil, err
+		}
+		decision.Applied = true
+		decision.Reason = adaptiveLargeModelReason(rawURL, meta)
+		return decision, nil
+	}
+	decision.Reason = "remote metadata does not match large-model tuning criteria"
+	return decision, nil
+}
+
+func shouldUseLargeModelTuning(rawURL string, meta downloader.ProbeMeta) bool {
+	if !meta.AcceptRange {
+		return false
+	}
+	if meta.Size >= adaptiveLargeThresholdBytes {
+		return true
+	}
+	target := meta.FinalURL
+	if target == "" {
+		target = rawURL
+	}
+	u, err := neturl.Parse(target)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	if !hostIs(host, "huggingface.co") && !strings.Contains(host, "xet") {
+		return false
+	}
+	ext := strings.ToLower(filepath.Ext(u.Path))
+	if meta.Size <= 0 {
+		switch ext {
+		case ".gguf", ".safetensors":
+			return true
+		}
+	}
+	return false
+}
+
+func adaptiveLargeModelReason(rawURL string, meta downloader.ProbeMeta) string {
+	if meta.Size >= adaptiveLargeThresholdBytes {
+		return fmt.Sprintf("range-capable object is %s; using large-model tuning", humanize.Bytes(uint64(meta.Size)))
+	}
+	target := meta.FinalURL
+	if target == "" {
+		target = rawURL
+	}
+	return fmt.Sprintf("range-capable large-model path %s; using large-model tuning", logging.SanitizeURL(target))
+}
+
+func reportedDownloadProfile(profile string, decision *adaptiveDownloadDecision) string {
+	if decision != nil && decision.Applied {
+		return "large-model"
+	}
+	switch strings.ToLower(strings.TrimSpace(profile)) {
+	case "", "auto":
+		return "auto"
+	default:
+		return effectiveDownloadProfile(profile)
+	}
+}
+
+func reportedDownloadProfileSource(profile string, decision *adaptiveDownloadDecision) string {
+	if decision != nil && decision.Applied {
+		return "auto"
+	}
+	switch strings.ToLower(strings.TrimSpace(profile)) {
+	case "":
+		return "auto"
+	default:
+		return "explicit"
+	}
+}
+
 func effectiveDownloadProfile(profile string) string {
 	switch strings.ToLower(strings.TrimSpace(profile)) {
 	case "large", "large-model":
 		return "large-model"
+	case "auto":
+		return "auto"
 	default:
 		return "default"
 	}

--- a/cmd/modfetch/download_cmd.go
+++ b/cmd/modfetch/download_cmd.go
@@ -190,7 +190,6 @@ func handleDownload(ctx context.Context, args []string) error {
 
 		for i := 0; i < parallel; i++ {
 			g.Go(func() error {
-				dl := downloader.NewAuto(c, log, st, m)
 				for {
 					select {
 					case <-gctx.Done():
@@ -296,6 +295,18 @@ func handleDownload(ctx context.Context, args []string) error {
 						var err error
 						baseNoResume := *noResume || c.General.AlwaysNoResume
 						for attempt, candidate := range candidates {
+							candidateConfig := *c
+							adaptive, adaptiveErr := maybeApplyAdaptiveDownloadTuning(gctx, &candidateConfig, candidate.url, candidate.headers, *profile, *connections, *chunkSizeMB)
+							if adaptiveErr != nil && profileWantsAuto(*profile) {
+								logMu.Lock()
+								log.Warnf("job %d: adaptive tuning probe failed for %s: %v", it.idx, logging.SanitizeURL(candidate.url), adaptiveErr)
+								logMu.Unlock()
+							} else if adaptive != nil && adaptive.Applied {
+								logMu.Lock()
+								log.Infof("job %d: adaptive tuning: %s", it.idx, adaptive.Reason)
+								logMu.Unlock()
+							}
+							dl := downloader.NewAuto(&candidateConfig, log, st, m)
 							final, sum, err = dl.Download(gctx, candidate.url, destCandidate, expected, candidate.headers, baseNoResume || attempt > 0)
 							if err == nil {
 								if attempt > 0 {
@@ -508,7 +519,7 @@ func handleDownload(ctx context.Context, args []string) error {
 		}
 	}
 	adaptiveDecision, adaptiveErr := maybeApplyAdaptiveDownloadTuning(ctx, c, resolvedURL, headers, *profile, *connections, *chunkSizeMB)
-	if adaptiveErr != nil && strings.EqualFold(strings.TrimSpace(*profile), "auto") {
+	if adaptiveErr != nil && profileWantsAuto(*profile) {
 		log.Warnf("adaptive tuning probe failed: %v", adaptiveErr)
 	}
 	// If dry-run, compute a default destination and print plan
@@ -796,6 +807,11 @@ func maybeApplyAdaptiveDownloadTuning(ctx context.Context, c *config.Config, raw
 	}
 	decision.Reason = "remote metadata does not match large-model tuning criteria"
 	return decision, nil
+}
+
+func profileWantsAuto(profile string) bool {
+	p := strings.ToLower(strings.TrimSpace(profile))
+	return p == "" || p == "auto"
 }
 
 func shouldUseLargeModelTuning(rawURL string, meta downloader.ProbeMeta) bool {

--- a/cmd/modfetch/download_cmd.go
+++ b/cmd/modfetch/download_cmd.go
@@ -541,22 +541,22 @@ func handleDownload(ctx context.Context, args []string) error {
 			candDest = filepath.Join(c.General.DownloadRoot, util.SafeFileName(base))
 		}
 		if *summaryJSON {
-			chunkMode, chunkSizeMB := effectiveChunkSize(c)
+			chunkMode, effectiveChunkMB := effectiveChunkSize(c)
 			summary := map[string]any{
 				"resolver_uri":    logging.SanitizeURL(*url),
 				"resolved_url":    logging.SanitizeURL(resolvedURL),
 				"default_dest":    candDest,
 				"connections":     effectiveDownloadConnections(c),
 				"chunk_size_mode": chunkMode,
-				"profile":         reportedDownloadProfile(*profile, adaptiveDecision),
-				"profile_source":  reportedDownloadProfileSource(*profile, adaptiveDecision),
+				"profile":         reportedDownloadProfile(*profile, *connections, *chunkSizeMB, adaptiveDecision),
+				"profile_source":  reportedDownloadProfileSource(*profile, *connections, *chunkSizeMB, adaptiveDecision),
 			}
-			if adaptiveDecision != nil && adaptiveDecision.Reason != "" {
+			if adaptiveDecision != nil && adaptiveDecision.Probed && adaptiveDecision.Reason != "" {
 				summary["adaptive_reason"] = adaptiveDecision.Reason
 				summary["remote_size"] = adaptiveDecision.RemoteSize
 			}
-			if chunkSizeMB > 0 {
-				summary["chunk_size_mb"] = chunkSizeMB
+			if effectiveChunkMB > 0 {
+				summary["chunk_size_mb"] = effectiveChunkMB
 			} else {
 				summary["chunk_size_range_mb"] = map[string]int{
 					"min": autoChunkSizeMinMB,
@@ -572,8 +572,8 @@ func handleDownload(ctx context.Context, args []string) error {
 		fmt.Printf("  Resolver URI: %s\n", logging.SanitizeURL(*url))
 		fmt.Printf("  Resolved URL: %s\n", logging.SanitizeURL(resolvedURL))
 		fmt.Printf("  Default dest: %s\n", candDest)
-		fmt.Printf("  Profile: %s (%s)\n", reportedDownloadProfile(*profile, adaptiveDecision), reportedDownloadProfileSource(*profile, adaptiveDecision))
-		if adaptiveDecision != nil && adaptiveDecision.Reason != "" {
+		fmt.Printf("  Profile: %s (%s)\n", reportedDownloadProfile(*profile, *connections, *chunkSizeMB, adaptiveDecision), reportedDownloadProfileSource(*profile, *connections, *chunkSizeMB, adaptiveDecision))
+		if adaptiveDecision != nil && adaptiveDecision.Probed && adaptiveDecision.Reason != "" {
 			fmt.Printf("  Adaptive: %s\n", adaptiveDecision.Reason)
 		}
 		fmt.Printf("  Connections: %d\n", effectiveDownloadConnections(c))
@@ -776,6 +776,7 @@ func applyDownloadTuning(c *config.Config, profile string, connections, chunkSiz
 
 type adaptiveDownloadDecision struct {
 	Applied    bool
+	Probed     bool
 	Reason     string
 	RemoteSize int64
 }
@@ -785,18 +786,21 @@ func maybeApplyAdaptiveDownloadTuning(ctx context.Context, c *config.Config, raw
 		return nil, errors.New("nil config")
 	}
 	if connections > 0 || chunkSizeMB > 0 {
-		return &adaptiveDownloadDecision{Reason: "explicit tuning flags set"}, nil
+		return nil, nil
 	}
 	switch strings.ToLower(strings.TrimSpace(profile)) {
 	case "", "auto":
 	default:
-		return &adaptiveDownloadDecision{Reason: "profile is explicit"}, nil
+		return nil, nil
+	}
+	if !shouldProbeForAdaptiveTuning(rawURL) {
+		return nil, nil
 	}
 	meta, err := downloader.ProbeURL(ctx, c, rawURL, headers)
 	if err != nil {
 		return nil, err
 	}
-	decision := &adaptiveDownloadDecision{RemoteSize: meta.Size}
+	decision := &adaptiveDownloadDecision{Probed: true, RemoteSize: meta.Size}
 	if shouldUseLargeModelTuning(rawURL, meta) {
 		if err := applyDownloadTuning(c, "large-model", 0, 0); err != nil {
 			return nil, err
@@ -812,6 +816,23 @@ func maybeApplyAdaptiveDownloadTuning(ctx context.Context, c *config.Config, raw
 func profileWantsAuto(profile string) bool {
 	p := strings.ToLower(strings.TrimSpace(profile))
 	return p == "" || p == "auto"
+}
+
+func shouldProbeForAdaptiveTuning(rawURL string) bool {
+	u, err := neturl.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	if hostIs(host, "huggingface.co") || strings.Contains(host, "xet") {
+		return true
+	}
+	switch strings.ToLower(filepath.Ext(u.Path)) {
+	case ".gguf", ".safetensors":
+		return true
+	default:
+		return false
+	}
 }
 
 func shouldUseLargeModelTuning(rawURL string, meta downloader.ProbeMeta) bool {
@@ -854,9 +875,16 @@ func adaptiveLargeModelReason(rawURL string, meta downloader.ProbeMeta) string {
 	return fmt.Sprintf("range-capable large-model path %s; using large-model tuning", logging.SanitizeURL(target))
 }
 
-func reportedDownloadProfile(profile string, decision *adaptiveDownloadDecision) string {
+func reportedDownloadProfile(profile string, connections, chunkSizeMB int, decision *adaptiveDownloadDecision) string {
 	if decision != nil && decision.Applied {
 		return "large-model"
+	}
+	switch strings.ToLower(strings.TrimSpace(profile)) {
+	case "large", "large-model":
+		return "large-model"
+	}
+	if connections > 0 || chunkSizeMB > 0 {
+		return "custom"
 	}
 	switch strings.ToLower(strings.TrimSpace(profile)) {
 	case "", "auto":
@@ -866,7 +894,10 @@ func reportedDownloadProfile(profile string, decision *adaptiveDownloadDecision)
 	}
 }
 
-func reportedDownloadProfileSource(profile string, decision *adaptiveDownloadDecision) string {
+func reportedDownloadProfileSource(profile string, connections, chunkSizeMB int, decision *adaptiveDownloadDecision) string {
+	if connections > 0 || chunkSizeMB > 0 {
+		return "explicit-flags"
+	}
 	if decision != nil && decision.Applied {
 		return "auto"
 	}

--- a/cmd/modfetch/download_cmd.go
+++ b/cmd/modfetch/download_cmd.go
@@ -489,34 +489,7 @@ func handleDownload(ctx context.Context, args []string) error {
 		resolvedURL = res.URL
 		headers = res.Headers
 	} else {
-		// Attach auth headers for direct URLs when possible, but only when
-		// sources.<provider>.token_env is explicitly configured. An empty
-		// token_env means "do not attach auth", matching the semantics in
-		// internal/resolver/{civitai,huggingface}.go and cmd/modfetch/batch_cmd.go;
-		// we deliberately do not fall back to ambient CIVITAI_TOKEN / HF_TOKEN
-		// here so users who left token_env unset never get unexpected
-		// credentials sent to direct URLs.
-		if u, err := neturl.Parse(resolvedURL); err == nil {
-			h := strings.ToLower(u.Hostname())
-			if hostIs(h, "civitai.com") && c.Sources.CivitAI.Enabled {
-				if env := strings.TrimSpace(c.Sources.CivitAI.TokenEnv); env != "" {
-					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
-						headers["Authorization"] = "Bearer " + tok
-					} else {
-						log.Warnf("CivitAI token env %s is not set; gated content will return 401. Export %s.", env, env)
-					}
-				}
-			}
-			if hostIs(h, "huggingface.co") && c.Sources.HuggingFace.Enabled {
-				if env := strings.TrimSpace(c.Sources.HuggingFace.TokenEnv); env != "" {
-					if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
-						headers["Authorization"] = "Bearer " + tok
-					} else {
-						log.Warnf("Hugging Face token env %s is not set; gated repos will return 401. Export %s and accept the repo license.", env, env)
-					}
-				}
-			}
-		}
+		headers = attachDirectProviderAuthHeaders(c, resolvedURL, headers, log)
 	}
 	adaptiveDecision, adaptiveErr := maybeApplyAdaptiveDownloadTuning(ctx, c, resolvedURL, headers, *profile, *connections, *chunkSizeMB)
 	if adaptiveErr != nil && profileWantsAuto(*profile) {
@@ -800,6 +773,9 @@ func maybeApplyAdaptiveDownloadTuning(ctx context.Context, c *config.Config, raw
 	if err != nil {
 		return nil, err
 	}
+	if emptyProbeMeta(meta) {
+		return nil, errors.New("adaptive tuning probe returned no useful remote metadata")
+	}
 	decision := &adaptiveDownloadDecision{Probed: true, RemoteSize: meta.Size}
 	if shouldUseLargeModelTuning(rawURL, meta) {
 		if err := applyDownloadTuning(c, "large-model", 0, 0); err != nil {
@@ -816,6 +792,14 @@ func maybeApplyAdaptiveDownloadTuning(ctx context.Context, c *config.Config, raw
 func profileWantsAuto(profile string) bool {
 	p := strings.ToLower(strings.TrimSpace(profile))
 	return p == "" || p == "auto"
+}
+
+func emptyProbeMeta(meta downloader.ProbeMeta) bool {
+	return meta.Size <= 0 &&
+		!meta.AcceptRange &&
+		strings.TrimSpace(meta.Filename) == "" &&
+		strings.TrimSpace(meta.ETag) == "" &&
+		strings.TrimSpace(meta.LastModified) == ""
 }
 
 func shouldProbeForAdaptiveTuning(rawURL string) bool {
@@ -949,28 +933,38 @@ func resolveBatchDownloadCandidate(ctx context.Context, c *config.Config, uri st
 		}
 		return res.URL, res.Headers, nil
 	}
-	if u, err := neturl.Parse(uri); err == nil {
+	return uri, attachDirectProviderAuthHeaders(c, uri, headers, nil), nil
+}
+
+func attachDirectProviderAuthHeaders(c *config.Config, rawURL string, headers map[string]string, log *logging.Logger) map[string]string {
+	if headers == nil {
+		headers = map[string]string{}
+	}
+	if c == nil {
+		return headers
+	}
+	if u, err := neturl.Parse(rawURL); err == nil {
 		h := strings.ToLower(u.Hostname())
-		// Only attach auth when token_env is explicitly configured. Empty
-		// token_env means "do not attach auth"; matches the existing batch
-		// import logic in cmd/modfetch/batch_cmd.go and the resolver package
-		// to avoid leaking ambient CIVITAI_TOKEN / HF_TOKEN credentials.
 		if hostIs(h, "civitai.com") && c.Sources.CivitAI.Enabled {
-			if env := strings.TrimSpace(c.Sources.CivitAI.TokenEnv); env != "" {
-				if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
-					headers["Authorization"] = "Bearer " + tok
-				}
-			}
+			attachBearerFromConfiguredEnv(headers, c.Sources.CivitAI.TokenEnv, "CivitAI", "gated content will return 401", log)
 		}
 		if hostIs(h, "huggingface.co") && c.Sources.HuggingFace.Enabled {
-			if env := strings.TrimSpace(c.Sources.HuggingFace.TokenEnv); env != "" {
-				if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
-					headers["Authorization"] = "Bearer " + tok
-				}
-			}
+			attachBearerFromConfiguredEnv(headers, c.Sources.HuggingFace.TokenEnv, "Hugging Face", "gated repos will return 401; accept the repo license if required", log)
 		}
 	}
-	return uri, headers, nil
+	return headers
+}
+
+func attachBearerFromConfiguredEnv(headers map[string]string, env, provider, missingGuidance string, log *logging.Logger) {
+	env = strings.TrimSpace(env)
+	if env == "" {
+		return
+	}
+	if tok := strings.TrimSpace(os.Getenv(env)); tok != "" {
+		headers["Authorization"] = "Bearer " + tok
+	} else if log != nil {
+		log.Warnf("%s token env %s is not set; %s. Export %s.", provider, env, missingGuidance, env)
+	}
 }
 
 // parseSHA256FromFile reads the first 64-hex token from a file (supports .sha256 "hash  filename" format).

--- a/cmd/modfetch/download_tuning_test.go
+++ b/cmd/modfetch/download_tuning_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -100,6 +102,58 @@ func TestDownloadDryRunSanitizesResolverURI(t *testing.T) {
 	}
 	if strings.Contains(out, "secret") || strings.Contains(out, "token=") {
 		t.Fatalf("dry-run JSON leaked sensitive URL material: %s", out)
+	}
+}
+
+func TestDownloadDryRunAutoTunesLargeRangeCapableObject(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.Header().Set("Content-Length", "2147483648")
+		if r.Method == http.MethodHead {
+			return
+		}
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte{0})
+	}))
+	defer ts.Close()
+
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yml")
+	cfgBody := "version: 1\n" +
+		"general:\n" +
+		"  data_root: " + filepath.Join(tmp, "data") + "\n" +
+		"  download_root: " + filepath.Join(tmp, "downloads") + "\n"
+	if err := os.WriteFile(cfgPath, []byte(cfgBody), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = handleDownload(context.Background(), []string{
+			"--config", cfgPath,
+			"--url", ts.URL + "/large.gguf",
+			"--dry-run",
+			"--summary-json",
+		})
+	})
+	if runErr != nil {
+		t.Fatalf("download dry-run: %v", runErr)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode dry-run JSON: %v\n%s", err, out)
+	}
+	if got["profile"] != "large-model" {
+		t.Fatalf("profile = %v, want large-model", got["profile"])
+	}
+	if got["profile_source"] != "auto" {
+		t.Fatalf("profile_source = %v, want auto", got["profile_source"])
+	}
+	if got["connections"] != float64(16) {
+		t.Fatalf("connections = %v, want 16", got["connections"])
+	}
+	if got["chunk_size_mb"] != float64(64) {
+		t.Fatalf("chunk_size_mb = %v, want 64", got["chunk_size_mb"])
 	}
 }
 

--- a/cmd/modfetch/download_tuning_test.go
+++ b/cmd/modfetch/download_tuning_test.go
@@ -157,6 +157,17 @@ func TestDownloadDryRunAutoTunesLargeRangeCapableObject(t *testing.T) {
 	}
 }
 
+func TestAdaptiveTuningReturnsErrorForEmptyProbeMetadata(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	cfg := &config.Config{}
+	decision, err := maybeApplyAdaptiveDownloadTuning(context.Background(), cfg, ts.URL+"/empty.gguf", nil, "", 0, 0)
+	if err == nil {
+		t.Fatalf("expected empty probe metadata error, got decision=%+v", decision)
+	}
+}
+
 func TestApplyDownloadTuningLargeModelProfile(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Concurrency.PerFileChunks = 4

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -48,6 +48,8 @@ func run(ctx context.Context, args []string) error {
 		return handleStatus(ctx, args[1:])
 	case "download":
 		return handleDownload(ctx, args[1:])
+	case "bench":
+		return handleBench(ctx, args[1:])
 	case "discover":
 		return handleDiscover(ctx, args[1:])
 	case "starter":
@@ -93,6 +95,7 @@ Commands:
   config print      Print the loaded config as JSON
   config wizard     Interactive TUI to generate a YAML config
   download          Download a file via direct URL or resolver URI (starter://, hf://, civitai://)
+  bench             Benchmark modfetch against aria2 on the same URL
   discover          Search real model providers and download a selected result
   starter           List or download beginner-safe starter artifacts
   status            Show download status (table or JSON)
@@ -554,7 +557,6 @@ func handleClean(ctx context.Context, args []string) error {
 	}
 	return nil
 }
-
 
 func isResolverURI(uri string) bool {
 	uri = strings.TrimSpace(uri)

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -95,7 +95,10 @@ modfetch download --url URL [OPTIONS]
 - `--extract` - Extract `.zip`, `.tar`, `.tar.gz`, `.tgz`, or `.7z` archives after download. 7z archives require `7zz`, `7z`, or `7za` on `PATH`.
 - `--extract-dir PATH` - Directory for extracted archive contents
 - `--batch-parallel N` - Concurrent downloads in batch mode
-- `--profile large-model` - Apply large-file tuning for DS4/GGUF-size artifacts
+- `--profile auto` - Let modfetch promote range-capable large objects to
+  large-model tuning automatically (default when omitted)
+- `--profile default` - Disable automatic tuning for this invocation
+- `--profile large-model` - Force large-file tuning for DS4/GGUF-size artifacts
   (`16` range connections and `64 MiB` chunks unless overridden)
 - `--connections N` - Parallel range requests per file, similar to aria2 `-x/-s`
 - `--chunk-size-mb N` - Range chunk size for this invocation
@@ -122,6 +125,7 @@ modfetch download --url 'hf://gpt2/README.md?rev=main'
 modfetch download --url 'hf://TheBloke/Llama-2-7B-GGUF/llama-2-7b.Q4_K_M.gguf?rev=main'
 
 # Large GGUF / Hugging Face Xet-style object
+modfetch download --url 'hf://owner/repo/model.gguf?rev=main'
 modfetch download --url 'hf://owner/repo/model.gguf?rev=main' --profile large-model
 modfetch download --url 'https://huggingface.co/owner/repo/resolve/main/model.gguf' --connections 16 --chunk-size-mb 64
 
@@ -129,6 +133,36 @@ modfetch download --url 'https://huggingface.co/owner/repo/resolve/main/model.gg
 modfetch download --url 'civitai://model/123456'
 modfetch download --url 'civitai://model/123456?version=456789'
 modfetch download --url 'civitai://model/123456?file=specific-file.safetensors'
+```
+
+### bench
+
+Run disposable timed download samples to compare modfetch with another transfer
+tool on the same URL. This is intended for real-world throughput checks before
+switching a large model transfer.
+
+**Syntax:**
+```bash
+modfetch bench --url URL [OPTIONS]
+```
+
+**Options:**
+- `--url URL` - URL or resolver URI to benchmark
+- `--tools modfetch,aria2` - Tools to run; `aria2` is skipped with an error
+  result if `aria2c` is not installed
+- `--duration 15s` - Sample duration per tool
+- `--profile auto|default|large-model` - Tuning profile for modfetch and
+  matching aria2 connection/chunk parameters
+- `--connections N` - Explicit range request count for both tools
+- `--chunk-size-mb N` - Explicit range chunk size for both tools
+- `--json` - Emit machine-readable results
+- `--keep` - Keep the temporary benchmark download directory
+
+**Examples:**
+```bash
+modfetch bench --url 'hf://owner/repo/model.gguf?rev=main' --duration 30s --json
+modfetch bench --url 'https://huggingface.co/owner/repo/resolve/main/model.gguf' \
+  --tools modfetch,aria2 --connections 16 --chunk-size-mb 64
 ```
 
 ### discover

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -8,6 +8,7 @@ Complete command-line reference for modfetch. For the visual TUI interface, see 
 - [Global Flags](#global-flags)
 - [Commands](#commands)
   - [download](#download)
+  - [bench](#bench)
   - [discover](#discover)
   - [starter](#starter)
   - [verify](#verify)

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -151,6 +151,9 @@ modfetch bench --url URL [OPTIONS]
 - `--url URL` - URL or resolver URI to benchmark
 - `--tools modfetch,aria2` - Tools to run; `aria2` is skipped with an error
   result if `aria2c` is not installed
+- Private/gated URLs: modfetch can benchmark with configured auth headers, but
+  aria2 is skipped when sensitive headers would otherwise be exposed through
+  process arguments.
 - `--duration 15s` - Sample duration per tool
 - `--profile auto|default|large-model` - Tuning profile for modfetch and
   matching aria2 connection/chunk parameters

--- a/scripts/uat/bench_compare.sh
+++ b/scripts/uat/bench_compare.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+bin="$repo_root/bin/modfetch"
+if [[ ! -x "$bin" ]]; then
+  bin="$repo_root/modfetch"
+fi
+if [[ ! -x "$bin" ]]; then
+  echo "modfetch binary not found; run make build first" >&2
+  exit 1
+fi
+
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/modfetch-bench-uat.XXXXXX")"
+trap 'rm -rf "$workdir"' EXIT
+cfg="$workdir/config.yml"
+cat >"$cfg" <<YAML
+version: 1
+general:
+  data_root: "$workdir/data"
+  download_root: "$workdir/downloads"
+concurrency:
+  per_file_chunks: 4
+  per_host_requests: 4
+  chunk_size_mb: 1
+YAML
+mkdir -p "$workdir/data" "$workdir/downloads"
+
+url="${MODFETCH_BENCH_UAT_URL:-https://proof.ovh.net/files/1Mb.dat}"
+tools="modfetch"
+if command -v aria2c >/dev/null 2>&1; then
+  tools="modfetch,aria2"
+else
+  echo "aria2c not found; running modfetch-only bench UAT" >&2
+fi
+
+"$bin" bench --config "$cfg" --url "$url" --tools "$tools" --duration "${MODFETCH_BENCH_UAT_DURATION:-3s}" --profile default --json
+
+echo "bench compare UAT passed for $tools against $url" >&2


### PR DESCRIPTION
## Summary
- add `modfetch bench` for disposable timed samples comparing modfetch and aria2 on the same URL
- add automatic large-transfer tuning for range-capable multi-GB / Hugging Face Xet-style objects
- report auto tuning decisions in dry-run JSON/text and document the new workflow

## Validation
- go test -count=1 ./cmd/modfetch -run 'TestBench|TestDownloadDryRun|TestApplyDownloadTuning|TestCompletion'
- scripts/check-docs-drift.sh
- make build
- make lint
- git diff --check
- scripts/uat/bench_compare.sh
- scripts/uat/real_download_matrix.sh
- go test -count=1 ./...
