### PR TITLE
feat: add live adaptive transfer history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Added
 - Added automatic large-transfer tuning for range-capable objects, so
   `download` can promote very large Hugging Face/Xet-style files to
   large-model settings without requiring YAML edits.
+- Added live adaptive chunk concurrency that ramps up on sustained throughput,
+  backs off on stalls or 429 responses, and seeds future transfers from
+  persisted per-host benchmark history.
+- Added persisted transfer history from `modfetch bench` and completed
+  modfetch downloads so future auto-tuned downloads can start from previously
+  observed good connection counts.
 - Added `modfetch download --profile large-model`, `--connections`, and
   `--chunk-size-mb` for aria2-style one-shot tuning of very large model
   downloads without editing YAML.

--- a/README.md
+++ b/README.md
@@ -384,7 +384,8 @@ modfetch library scan --repair-stale
         modfetch download --config /path/to/config.yml --url 'hf://org/repo/path?rev=main' --dry-run
         modfetch download --config /path/to/config.yml --url 'https://example.com/file.bin' --dry-run --summary-json
   - Large model tuning: the default `--profile auto` promotes range-capable objects around 1 GiB or larger to large-model settings. Use `--profile large-model` to force DS4/GGUF tuning, `--profile default` to disable auto-tuning, or explicit aria2-style range tuning with `--connections 16 --chunk-size-mb 64`.
-  - Benchmark transfers: use `modfetch bench --url <URL> --tools modfetch,aria2 --duration 30s --json` to run disposable samples against the same URL before committing to a huge download.
+  - Adaptive transfers: chunked downloads now start from persisted per-host history when available, ramp up while throughput is healthy, and back off on stalls or 429 responses.
+  - Benchmark transfers: use `modfetch bench --url <URL> --tools modfetch,aria2 --duration 30s --json` to run disposable samples against the same URL before committing to a huge download. Use `modfetch bench --history` to inspect the persisted host/tuning history that feeds future adaptive starts.
   - On completion, a summary is printed (dest, size, SHA256, duration, average speed)
   - Cancel with Ctrl+C (SIGINT/SIGTERM); staged partial files and completed chunks are preserved for resume. Use `--no-resume` or `modfetch clean` when you want to discard staged data.
 - Place artifacts into apps:

--- a/cmd/modfetch/bench_cmd.go
+++ b/cmd/modfetch/bench_cmd.go
@@ -53,18 +53,22 @@ func handleBench(ctx context.Context, args []string) error {
 	connections := fs.Int("connections", 0, "parallel range requests per file")
 	chunkSizeMB := fs.Int("chunk-size-mb", 0, "range chunk size in MiB")
 	keep := fs.Bool("keep", false, "keep temporary benchmark downloads")
+	history := fs.Bool("history", false, "list persisted transfer benchmark history")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+	c, _, err := loadConfig(*common.configPath)
+	if err != nil {
+		return err
+	}
+	if *history {
+		return printBenchHistory(c, *common.jsonOut)
 	}
 	if strings.TrimSpace(*urlFlag) == "" {
 		return errors.New("--url is required")
 	}
 	if *durationFlag <= 0 {
 		return errors.New("--duration must be > 0")
-	}
-	c, _, err := loadConfig(*common.configPath)
-	if err != nil {
-		return err
 	}
 	if err := applyDownloadTuning(c, *profile, *connections, *chunkSizeMB); err != nil {
 		return err
@@ -109,6 +113,9 @@ func handleBench(ctx context.Context, args []string) error {
 	}
 	if *keep {
 		summary.WorkDir = workDir
+	}
+	if err := recordBenchHistory(c, resolvedURL, results); err != nil && !*common.jsonOut {
+		log.Warnf("benchmark history was not saved: %v", err)
 	}
 	if *common.jsonOut {
 		enc := json.NewEncoder(os.Stdout)
@@ -384,6 +391,66 @@ func fixedChunkSizeMB(c *config.Config) int {
 		return size
 	}
 	return 0
+}
+
+func recordBenchHistory(c *config.Config, rawURL string, results []benchResult) error {
+	st, err := state.Open(c)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = st.Close() }()
+	host := downloader.HostFromURLForHistory(rawURL)
+	if host == "" {
+		return nil
+	}
+	for _, result := range results {
+		if result.Status == "error" {
+			continue
+		}
+		status := result.Status
+		if status == "" {
+			status = "unknown"
+		}
+		if err := st.UpsertTransferHistory(state.TransferHistoryRow{
+			Host:        host,
+			Tool:        result.Tool,
+			Connections: result.Connections,
+			ChunkSizeMB: result.ChunkSizeMB,
+			AvgBPS:      result.AvgBPS,
+			RateLimited: false,
+			LastStatus:  status,
+			LastError:   result.Error,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printBenchHistory(c *config.Config, jsonOut bool) error {
+	st, err := state.Open(c)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = st.Close() }()
+	rows, err := st.ListTransferHistory()
+	if err != nil {
+		return err
+	}
+	if jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(rows)
+	}
+	for _, row := range rows {
+		rateLimited := ""
+		if row.RateLimited {
+			rateLimited = "\trate_limited=true"
+		}
+		fmt.Printf("%s\t%s\tconnections=%d\tchunk=%dMiB\tavg=%s/s\tsamples=%d\tstatus=%s%s\n",
+			row.Host, row.Tool, row.Connections, row.ChunkSizeMB, humanize.Bytes(uint64(row.AvgBPS)), row.Samples, row.LastStatus, rateLimited)
+	}
+	return nil
 }
 
 func maxInt64(a, b int64) int64 {

--- a/cmd/modfetch/bench_cmd.go
+++ b/cmd/modfetch/bench_cmd.go
@@ -31,6 +31,7 @@ type benchResult struct {
 	AvgBPS      float64 `json:"avg_bps"`
 	Connections int     `json:"connections,omitempty"`
 	ChunkSizeMB int     `json:"chunk_size_mb,omitempty"`
+	RateLimited bool    `json:"rate_limited,omitempty"`
 	Error       string  `json:"error,omitempty"`
 	Dest        string  `json:"dest,omitempty"`
 }
@@ -224,14 +225,27 @@ func runModfetchBench(ctx context.Context, base *config.Config, log *logging.Log
 		status = "error"
 		errText = err.Error()
 	}
+	connections := effectiveDownloadConnections(&cfg)
+	chunkSizeMB := fixedChunkSizeMB(&cfg)
+	rateLimited := false
+	if history, ok, hErr := st.BestTransferHistory(downloader.HostFromURLForHistory(rawURL), "modfetch"); hErr == nil && ok {
+		if history.Connections > 0 {
+			connections = history.Connections
+		}
+		if history.ChunkSizeMB >= 0 {
+			chunkSizeMB = history.ChunkSizeMB
+		}
+		rateLimited = history.RateLimited
+	}
 	return benchResult{
 		Tool:        "modfetch",
 		Status:      status,
 		Bytes:       bytes,
 		Duration:    elapsed.Seconds(),
 		AvgBPS:      bytesPerSecond(bytes, elapsed),
-		Connections: effectiveDownloadConnections(&cfg),
-		ChunkSizeMB: fixedChunkSizeMB(&cfg),
+		Connections: connections,
+		ChunkSizeMB: chunkSizeMB,
+		RateLimited: rateLimited,
 		Error:       errText,
 		Dest:        dest,
 	}
@@ -417,7 +431,7 @@ func recordBenchHistory(c *config.Config, rawURL string, results []benchResult) 
 			Connections: result.Connections,
 			ChunkSizeMB: result.ChunkSizeMB,
 			AvgBPS:      result.AvgBPS,
-			RateLimited: false,
+			RateLimited: result.RateLimited,
 			LastStatus:  status,
 			LastError:   result.Error,
 		}); err != nil {

--- a/cmd/modfetch/bench_cmd_test.go
+++ b/cmd/modfetch/bench_cmd_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,6 +16,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jxwalker/modfetch/internal/state"
 )
 
 func TestBenchModfetchRunsRealDownloadSample(t *testing.T) {
@@ -52,6 +55,27 @@ func TestBenchModfetchRunsRealDownloadSample(t *testing.T) {
 	}
 	if result.Bytes <= 0 || result.AvgBPS <= 0 {
 		t.Fatalf("expected positive bytes/rate, got %+v", result)
+	}
+
+	cfg, _, err := loadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	st, err := state.Open(cfg)
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	u, err := neturl.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	best, ok, err := st.BestTransferHistory(u.Hostname(), "modfetch")
+	if err != nil {
+		t.Fatalf("best history: %v", err)
+	}
+	if !ok || best.AvgBPS <= 0 {
+		t.Fatalf("expected persisted modfetch history, got ok=%v best=%+v", ok, best)
 	}
 }
 

--- a/cmd/modfetch/bench_cmd_test.go
+++ b/cmd/modfetch/bench_cmd_test.go
@@ -117,6 +117,48 @@ func TestBenchAria2RunsWhenInstalled(t *testing.T) {
 	}
 }
 
+func TestBenchHistoryListsRowsWithoutURL(t *testing.T) {
+	cfgPath := writeBenchConfig(t)
+	cfg, _, err := loadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	st, err := state.Open(cfg)
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	if err := st.UpsertTransferHistory(state.TransferHistoryRow{
+		Host:        "example.com",
+		Tool:        "modfetch",
+		Connections: 4,
+		ChunkSizeMB: 1,
+		AvgBPS:      1234,
+		LastStatus:  "complete",
+	}); err != nil {
+		t.Fatalf("upsert history: %v", err)
+	}
+	_ = st.Close()
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = handleBench(context.Background(), []string{
+			"--config", cfgPath,
+			"--history",
+			"--json",
+		})
+	})
+	if runErr != nil {
+		t.Fatalf("bench history: %v", runErr)
+	}
+	var rows []state.TransferHistoryRow
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("decode history JSON: %v\n%s", err, out)
+	}
+	if len(rows) != 1 || rows[0].Host != "example.com" || rows[0].Tool != "modfetch" {
+		t.Fatalf("history rows = %+v", rows)
+	}
+}
+
 func TestParseBenchToolsDedupesAndDefaults(t *testing.T) {
 	got := parseBenchTools(" modfetch,aria2,modfetch ,,")
 	want := []string{"modfetch", "aria2"}

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -58,7 +58,7 @@ _modfetch_completions()
         download)
             COMPREPLY=( $(compgen -W "--config --log-level --json --quiet --no-resume --url --dest --sha256 --sha256-file --batch --place --summary-json --batch-parallel --profile --connections --chunk-size-mb --dry-run --force --no-auth-preflight --extract --extract-dir --quant --list-quants" -- "$cur") ) ;;
         bench)
-            COMPREPLY=( $(compgen -W "--config --log-level --json --url --tools --duration --profile --connections --chunk-size-mb --keep modfetch aria2" -- "$cur") ) ;;
+            COMPREPLY=( $(compgen -W "--config --log-level --json --url --tools --duration --profile --connections --chunk-size-mb --keep --history modfetch aria2" -- "$cur") ) ;;
         discover)
             if [[ ${cword} -eq 2 ]]; then
                 COMPREPLY=( $(compgen -W "search download" -- "$cur") )
@@ -170,7 +170,7 @@ _modfetch() {
       _arguments '*:options:(--config --log-level --json --quiet --no-resume --url --dest --sha256 --sha256-file --batch --place --summary-json --batch-parallel --profile --connections --chunk-size-mb --dry-run --force --no-auth-preflight --extract --extract-dir --quant --list-quants)'
       ;;
     bench)
-      _arguments '*:options:(--config --log-level --json --url --tools --duration --profile --connections --chunk-size-mb --keep modfetch aria2)'
+      _arguments '*:options:(--config --log-level --json --url --tools --duration --profile --connections --chunk-size-mb --keep --history modfetch aria2)'
       ;;
     discover)
       if (( CURRENT == 3 )); then
@@ -336,6 +336,7 @@ complete -c modfetch -n "__fish_seen_subcommand_from bench" -l profile -d "Downl
 complete -c modfetch -n "__fish_seen_subcommand_from bench" -l connections -d "Parallel range requests per file"
 complete -c modfetch -n "__fish_seen_subcommand_from bench" -l chunk-size-mb -d "Range chunk size in MiB"
 complete -c modfetch -n "__fish_seen_subcommand_from bench" -l keep -d "Keep benchmark downloads"
+complete -c modfetch -n "__fish_seen_subcommand_from bench" -l history -d "List persisted benchmark history"
 complete -c modfetch -n "__fish_seen_subcommand_from discover" -a "search" -d "Search real model providers"
 complete -c modfetch -n "__fish_seen_subcommand_from discover" -a "download" -d "Download a selected discovery result"
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from search" -l config -d "Path to config"

--- a/cmd/modfetch/completion_test.go
+++ b/cmd/modfetch/completion_test.go
@@ -20,7 +20,7 @@ func TestCompletionCurrentFlags(t *testing.T) {
 	tests := map[string][]string{
 		"config":   {"--strict", "--out"},
 		"download": {"--no-resume", "--summary-json", "--batch-parallel", "--profile", "--connections", "--chunk-size-mb", "--dry-run", "--force", "--no-auth-preflight", "--quant", "--list-quants"},
-		"bench":    {"--url", "--tools", "--duration", "--profile", "--connections", "--chunk-size-mb", "--keep"},
+		"bench":    {"--url", "--tools", "--duration", "--profile", "--connections", "--chunk-size-mb", "--keep", "--history"},
 		"discover": {"--provider", "--limit", "--select", "--summary-json", "--dry-run"},
 		"starter":  {"--id", "--summary-json", "--dry-run"},
 		"place":    {"--dry-run", "--preset", "--list-presets"},

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -97,7 +97,10 @@ modfetch download --url URL [OPTIONS]
 - `--extract-dir PATH` - Directory for extracted archive contents
 - `--batch-parallel N` - Concurrent downloads in batch mode
 - `--profile auto` - Let modfetch promote range-capable large objects to
-  large-model tuning automatically (default when omitted)
+  large-model tuning automatically (default when omitted). Chunked downloads
+  then adapt in flight: modfetch starts from persisted per-host history when
+  available, ramps up on sustained throughput, and backs off on stalls or HTTP
+  429 responses.
 - `--profile default` - Disable automatic tuning for this invocation
 - `--profile large-model` - Force large-file tuning for DS4/GGUF-size artifacts
   (`16` range connections and `64 MiB` chunks unless overridden)
@@ -161,12 +164,15 @@ modfetch bench --url URL [OPTIONS]
 - `--chunk-size-mb N` - Explicit range chunk size for both tools
 - `--json` - Emit machine-readable results
 - `--keep` - Keep the temporary benchmark download directory
+- `--history` - List persisted per-host transfer history collected from
+  benchmark samples and completed modfetch downloads
 
 **Examples:**
 ```bash
 modfetch bench --url 'hf://owner/repo/model.gguf?rev=main' --duration 30s --json
 modfetch bench --url 'https://huggingface.co/owner/repo/resolve/main/model.gguf' \
   --tools modfetch,aria2 --connections 16 --chunk-size-mb 64
+modfetch bench --history --json
 ```
 
 ### discover

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -143,8 +143,8 @@ modfetch download --url 'civitai://model/123456?file=specific-file.safetensors'
 
 Run disposable timed download samples to compare modfetch with another transfer
 tool on the same URL, or inspect the transfer history learned from prior runs.
-Benchmark mode is intended for real-world throughput checks before switching a
-large model transfer.
+Benchmark mode is intended for real-world throughput checks before switching to
+a large model transfer.
 
 **Syntax:**
 ```bash

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -142,16 +142,18 @@ modfetch download --url 'civitai://model/123456?file=specific-file.safetensors'
 ### bench
 
 Run disposable timed download samples to compare modfetch with another transfer
-tool on the same URL. This is intended for real-world throughput checks before
-switching a large model transfer.
+tool on the same URL, or inspect the transfer history learned from prior runs.
+Benchmark mode is intended for real-world throughput checks before switching a
+large model transfer.
 
 **Syntax:**
 ```bash
 modfetch bench --url URL [OPTIONS]
+modfetch bench --history [--json]
 ```
 
 **Options:**
-- `--url URL` - URL or resolver URI to benchmark
+- `--url URL` - URL or resolver URI to benchmark in URL-driven mode
 - `--tools modfetch,aria2` - Tools to run; `aria2` is skipped with an error
   result if `aria2c` is not installed
 - Private/gated URLs: modfetch can benchmark with configured auth headers, but
@@ -164,8 +166,9 @@ modfetch bench --url URL [OPTIONS]
 - `--chunk-size-mb N` - Explicit range chunk size for both tools
 - `--json` - Emit machine-readable results
 - `--keep` - Keep the temporary benchmark download directory
-- `--history` - List persisted per-host transfer history collected from
-  benchmark samples and completed modfetch downloads
+- `--history` - Switch to URL-free history mode and list persisted per-host
+  transfer history collected from benchmark samples and completed modfetch
+  downloads. `--url` is not required in this mode.
 
 **Examples:**
 ```bash

--- a/internal/downloader/adaptive.go
+++ b/internal/downloader/adaptive.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -31,9 +32,9 @@ type adaptiveTransferController struct {
 	limit          int
 	max            int
 	active         int
-	totalBytes     int64
-	windowBytes    int64
-	lastProgress   time.Time
+	totalBytes     atomic.Int64
+	windowBytes    atomic.Int64
+	lastProgress   atomic.Int64
 	lastAdjust     time.Time
 	windowStarted  time.Time
 	emaBPS         float64
@@ -56,13 +57,13 @@ func newAdaptiveTransferController(cfg *config.Config, log *logging.Logger, st *
 		host:           strings.ToLower(host),
 		limit:          initialAdaptiveLimit(st, host, max),
 		max:            max,
-		lastProgress:   now,
 		lastAdjust:     now,
 		windowStarted:  now,
 		changed:        make(chan struct{}),
 		stopCh:         make(chan struct{}),
 		monitorStopped: make(chan struct{}),
 	}
+	c.lastProgress.Store(now.UnixNano())
 	go c.monitor()
 	return c
 }
@@ -73,11 +74,7 @@ func initialAdaptiveLimit(st *state.DB, host string, max int) int {
 	}
 	if st != nil {
 		if row, ok, err := st.BestTransferHistory(strings.ToLower(host), "modfetch"); err == nil && ok && row.Connections > 0 {
-			connections := row.Connections
-			if row.RateLimited {
-				connections = (connections + 1) / 2
-			}
-			return clampInt(connections, adaptiveMinLimit, max)
+			return clampInt(row.Connections, adaptiveMinLimit, max)
 		}
 	}
 	if max <= 4 {
@@ -121,12 +118,10 @@ func (c *adaptiveTransferController) observeBytes(n int64) {
 	if n <= 0 {
 		return
 	}
-	c.mu.Lock()
 	now := time.Now()
-	c.totalBytes += n
-	c.windowBytes += n
-	c.lastProgress = now
-	c.mu.Unlock()
+	c.totalBytes.Add(n)
+	c.windowBytes.Add(n)
+	c.lastProgress.Store(now.UnixNano())
 }
 
 func (c *adaptiveTransferController) observeRateLimit() {
@@ -136,7 +131,7 @@ func (c *adaptiveTransferController) observeRateLimit() {
 	c.limit = clampInt((c.limit+1)/2, adaptiveMinLimit, c.max)
 	c.lastAdjust = time.Now()
 	c.windowStarted = c.lastAdjust
-	c.windowBytes = 0
+	c.windowBytes.Store(0)
 	c.notifyLocked()
 	c.mu.Unlock()
 	if old != c.limit && c.log != nil {
@@ -176,11 +171,11 @@ func (c *adaptiveTransferController) adjust() {
 	host := c.host
 	logReason := ""
 	logBPS := 0.0
-	if c.active > 0 && now.Sub(c.lastProgress) >= adaptiveStallWindow {
+	if c.active > 0 && now.Sub(time.Unix(0, c.lastProgress.Load())) >= adaptiveStallWindow {
 		c.limit = clampInt((c.limit+1)/2, adaptiveMinLimit, c.max)
 		c.lastAdjust = now
 		c.windowStarted = now
-		c.windowBytes = 0
+		c.windowBytes.Store(0)
 		next := c.limit
 		if next != old {
 			c.notifyLocked()
@@ -190,7 +185,8 @@ func (c *adaptiveTransferController) adjust() {
 		c.logLimitChange(logReason, host, old, next, 0)
 		return
 	}
-	bps := float64(c.windowBytes) / elapsed.Seconds()
+	windowBytes := c.windowBytes.Load()
+	bps := float64(windowBytes) / elapsed.Seconds()
 	if bps <= 0 {
 		c.mu.Unlock()
 		return
@@ -202,7 +198,7 @@ func (c *adaptiveTransferController) adjust() {
 	}
 	if now.Sub(c.lastAdjust) < adaptiveProgressWindow {
 		c.windowStarted = now
-		c.windowBytes = 0
+		c.windowBytes.Store(0)
 		c.mu.Unlock()
 		return
 	}
@@ -219,7 +215,7 @@ func (c *adaptiveTransferController) adjust() {
 		logBPS = bps
 	}
 	c.windowStarted = now
-	c.windowBytes = 0
+	c.windowBytes.Store(0)
 	next := c.limit
 	if next != old {
 		c.notifyLocked()
@@ -254,9 +250,7 @@ func (c *adaptiveTransferController) finalLimit() int {
 }
 
 func (c *adaptiveTransferController) total() int64 {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.totalBytes
+	return c.totalBytes.Load()
 }
 
 func (c *adaptiveTransferController) notifyLocked() {

--- a/internal/downloader/adaptive.go
+++ b/internal/downloader/adaptive.go
@@ -27,6 +27,7 @@ type adaptiveTransferController struct {
 	host string
 
 	mu             sync.Mutex
+	changed        chan struct{}
 	limit          int
 	max            int
 	active         int
@@ -58,6 +59,7 @@ func newAdaptiveTransferController(cfg *config.Config, log *logging.Logger, st *
 		lastProgress:   now,
 		lastAdjust:     now,
 		windowStarted:  now,
+		changed:        make(chan struct{}),
 		stopCh:         make(chan struct{}),
 		monitorStopped: make(chan struct{}),
 	}
@@ -96,11 +98,12 @@ func (c *adaptiveTransferController) acquire(ctx context.Context) error {
 			c.mu.Unlock()
 			return nil
 		}
+		changed := c.changed
 		c.mu.Unlock()
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(25 * time.Millisecond):
+		case <-changed:
 		}
 	}
 }
@@ -110,6 +113,7 @@ func (c *adaptiveTransferController) release() {
 	if c.active > 0 {
 		c.active--
 	}
+	c.notifyLocked()
 	c.mu.Unlock()
 }
 
@@ -133,6 +137,7 @@ func (c *adaptiveTransferController) observeRateLimit() {
 	c.lastAdjust = time.Now()
 	c.windowStarted = c.lastAdjust
 	c.windowBytes = 0
+	c.notifyLocked()
 	c.mu.Unlock()
 	if old != c.limit && c.log != nil {
 		c.log.Warnf("adaptive transfer: 429 backoff for %s, connections %d -> %d", c.host, old, c.limit)
@@ -157,26 +162,37 @@ func (c *adaptiveTransferController) monitor() {
 
 func (c *adaptiveTransferController) adjust() {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if c.stopped {
+		c.mu.Unlock()
 		return
 	}
 	now := time.Now()
 	elapsed := now.Sub(c.windowStarted)
 	if elapsed <= 0 {
+		c.mu.Unlock()
 		return
 	}
 	old := c.limit
+	host := c.host
+	logReason := ""
+	logBPS := 0.0
 	if c.active > 0 && now.Sub(c.lastProgress) >= adaptiveStallWindow {
 		c.limit = clampInt((c.limit+1)/2, adaptiveMinLimit, c.max)
 		c.lastAdjust = now
 		c.windowStarted = now
 		c.windowBytes = 0
-		c.logLimitChangeLocked("stall backoff", old, c.limit, 0)
+		next := c.limit
+		if next != old {
+			c.notifyLocked()
+			logReason = "stall backoff"
+		}
+		c.mu.Unlock()
+		c.logLimitChange(logReason, host, old, next, 0)
 		return
 	}
 	bps := float64(c.windowBytes) / elapsed.Seconds()
 	if bps <= 0 {
+		c.mu.Unlock()
 		return
 	}
 	if c.emaBPS == 0 {
@@ -187,21 +203,29 @@ func (c *adaptiveTransferController) adjust() {
 	if now.Sub(c.lastAdjust) < adaptiveProgressWindow {
 		c.windowStarted = now
 		c.windowBytes = 0
+		c.mu.Unlock()
 		return
 	}
 	switch {
 	case c.limit > adaptiveMinLimit && c.emaBPS > 0 && bps < c.emaBPS*0.55:
 		c.limit--
 		c.lastAdjust = now
+		logReason = "throughput"
+		logBPS = bps
 	case c.active >= c.limit && c.limit < c.max && bps >= c.emaBPS*0.90:
 		c.limit++
 		c.lastAdjust = now
+		logReason = "throughput"
+		logBPS = bps
 	}
 	c.windowStarted = now
 	c.windowBytes = 0
-	if c.limit != old {
-		c.logLimitChangeLocked("throughput", old, c.limit, bps)
+	next := c.limit
+	if next != old {
+		c.notifyLocked()
 	}
+	c.mu.Unlock()
+	c.logLimitChange(logReason, host, old, next, logBPS)
 }
 
 func (c *adaptiveTransferController) stop() {
@@ -212,6 +236,7 @@ func (c *adaptiveTransferController) stop() {
 	}
 	c.stopped = true
 	close(c.stopCh)
+	c.notifyLocked()
 	c.mu.Unlock()
 	<-c.monitorStopped
 }
@@ -228,15 +253,26 @@ func (c *adaptiveTransferController) finalLimit() int {
 	return c.limit
 }
 
-func (c *adaptiveTransferController) logLimitChangeLocked(reason string, old, next int, bps float64) {
-	if old == next || c.log == nil {
+func (c *adaptiveTransferController) total() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.totalBytes
+}
+
+func (c *adaptiveTransferController) notifyLocked() {
+	close(c.changed)
+	c.changed = make(chan struct{})
+}
+
+func (c *adaptiveTransferController) logLimitChange(reason, host string, old, next int, bps float64) {
+	if reason == "" || old == next || c.log == nil {
 		return
 	}
 	if bps > 0 {
-		c.log.Infof("adaptive transfer: %s for %s, connections %d -> %d at %s/s", reason, c.host, old, next, humanize.Bytes(uint64(bps)))
+		c.log.Infof("adaptive transfer: %s for %s, connections %d -> %d at %s/s", reason, host, old, next, humanize.Bytes(uint64(bps)))
 		return
 	}
-	c.log.Infof("adaptive transfer: %s for %s, connections %d -> %d", reason, c.host, old, next)
+	c.log.Infof("adaptive transfer: %s for %s, connections %d -> %d", reason, host, old, next)
 }
 
 type adaptiveProgressReader struct {

--- a/internal/downloader/adaptive.go
+++ b/internal/downloader/adaptive.go
@@ -1,0 +1,294 @@
+package downloader
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dustin/go-humanize"
+
+	"github.com/jxwalker/modfetch/internal/config"
+	"github.com/jxwalker/modfetch/internal/logging"
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+const (
+	adaptiveMinLimit       = 1
+	adaptiveProgressWindow = 2 * time.Second
+	adaptiveStallWindow    = 3 * time.Second
+)
+
+type adaptiveTransferController struct {
+	cfg  *config.Config
+	log  *logging.Logger
+	st   *state.DB
+	host string
+
+	mu             sync.Mutex
+	limit          int
+	max            int
+	active         int
+	totalBytes     int64
+	windowBytes    int64
+	lastProgress   time.Time
+	lastAdjust     time.Time
+	windowStarted  time.Time
+	emaBPS         float64
+	rateLimited    bool
+	stopped        bool
+	stopCh         chan struct{}
+	monitorStopped chan struct{}
+}
+
+func newAdaptiveTransferController(cfg *config.Config, log *logging.Logger, st *state.DB, rawURL string, max int) *adaptiveTransferController {
+	if max <= 0 {
+		max = 1
+	}
+	host := hostFromURL(rawURL)
+	now := time.Now()
+	c := &adaptiveTransferController{
+		cfg:            cfg,
+		log:            log,
+		st:             st,
+		host:           strings.ToLower(host),
+		limit:          initialAdaptiveLimit(st, host, max),
+		max:            max,
+		lastProgress:   now,
+		lastAdjust:     now,
+		windowStarted:  now,
+		stopCh:         make(chan struct{}),
+		monitorStopped: make(chan struct{}),
+	}
+	go c.monitor()
+	return c
+}
+
+func initialAdaptiveLimit(st *state.DB, host string, max int) int {
+	if max <= adaptiveMinLimit {
+		return max
+	}
+	if st != nil {
+		if row, ok, err := st.BestTransferHistory(strings.ToLower(host), "modfetch"); err == nil && ok && row.Connections > 0 {
+			connections := row.Connections
+			if row.RateLimited {
+				connections = (connections + 1) / 2
+			}
+			return clampInt(connections, adaptiveMinLimit, max)
+		}
+	}
+	if max <= 4 {
+		return max
+	}
+	return 4
+}
+
+func (c *adaptiveTransferController) acquire(ctx context.Context) error {
+	for {
+		c.mu.Lock()
+		if c.stopped {
+			c.mu.Unlock()
+			return context.Canceled
+		}
+		if c.active < c.limit {
+			c.active++
+			c.mu.Unlock()
+			return nil
+		}
+		c.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+}
+
+func (c *adaptiveTransferController) release() {
+	c.mu.Lock()
+	if c.active > 0 {
+		c.active--
+	}
+	c.mu.Unlock()
+}
+
+func (c *adaptiveTransferController) observeBytes(n int64) {
+	if n <= 0 {
+		return
+	}
+	c.mu.Lock()
+	now := time.Now()
+	c.totalBytes += n
+	c.windowBytes += n
+	c.lastProgress = now
+	c.mu.Unlock()
+}
+
+func (c *adaptiveTransferController) observeRateLimit() {
+	c.mu.Lock()
+	c.rateLimited = true
+	old := c.limit
+	c.limit = clampInt((c.limit+1)/2, adaptiveMinLimit, c.max)
+	c.lastAdjust = time.Now()
+	c.windowStarted = c.lastAdjust
+	c.windowBytes = 0
+	c.mu.Unlock()
+	if old != c.limit && c.log != nil {
+		c.log.Warnf("adaptive transfer: 429 backoff for %s, connections %d -> %d", c.host, old, c.limit)
+	}
+}
+
+func (c *adaptiveTransferController) monitor() {
+	ticker := time.NewTicker(adaptiveProgressWindow)
+	defer func() {
+		ticker.Stop()
+		close(c.monitorStopped)
+	}()
+	for {
+		select {
+		case <-ticker.C:
+			c.adjust()
+		case <-c.stopCh:
+			return
+		}
+	}
+}
+
+func (c *adaptiveTransferController) adjust() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.stopped {
+		return
+	}
+	now := time.Now()
+	elapsed := now.Sub(c.windowStarted)
+	if elapsed <= 0 {
+		return
+	}
+	old := c.limit
+	if c.active > 0 && now.Sub(c.lastProgress) >= adaptiveStallWindow {
+		c.limit = clampInt((c.limit+1)/2, adaptiveMinLimit, c.max)
+		c.lastAdjust = now
+		c.windowStarted = now
+		c.windowBytes = 0
+		c.logLimitChangeLocked("stall backoff", old, c.limit, 0)
+		return
+	}
+	bps := float64(c.windowBytes) / elapsed.Seconds()
+	if bps <= 0 {
+		return
+	}
+	if c.emaBPS == 0 {
+		c.emaBPS = bps
+	} else {
+		c.emaBPS = 0.70*c.emaBPS + 0.30*bps
+	}
+	if now.Sub(c.lastAdjust) < adaptiveProgressWindow {
+		c.windowStarted = now
+		c.windowBytes = 0
+		return
+	}
+	switch {
+	case c.limit > adaptiveMinLimit && c.emaBPS > 0 && bps < c.emaBPS*0.55:
+		c.limit--
+		c.lastAdjust = now
+	case c.active >= c.limit && c.limit < c.max && bps >= c.emaBPS*0.90:
+		c.limit++
+		c.lastAdjust = now
+	}
+	c.windowStarted = now
+	c.windowBytes = 0
+	if c.limit != old {
+		c.logLimitChangeLocked("throughput", old, c.limit, bps)
+	}
+}
+
+func (c *adaptiveTransferController) stop() {
+	c.mu.Lock()
+	if c.stopped {
+		c.mu.Unlock()
+		return
+	}
+	c.stopped = true
+	close(c.stopCh)
+	c.mu.Unlock()
+	<-c.monitorStopped
+}
+
+func (c *adaptiveTransferController) wasRateLimited() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.rateLimited
+}
+
+func (c *adaptiveTransferController) finalLimit() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.limit
+}
+
+func (c *adaptiveTransferController) logLimitChangeLocked(reason string, old, next int, bps float64) {
+	if old == next || c.log == nil {
+		return
+	}
+	if bps > 0 {
+		c.log.Infof("adaptive transfer: %s for %s, connections %d -> %d at %s/s", reason, c.host, old, next, humanize.Bytes(uint64(bps)))
+		return
+	}
+	c.log.Infof("adaptive transfer: %s for %s, connections %d -> %d", reason, c.host, old, next)
+}
+
+type adaptiveProgressReader struct {
+	r       io.Reader
+	onBytes func(int64)
+}
+
+func (r *adaptiveProgressReader) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	if n > 0 && r.onBytes != nil {
+		r.onBytes(int64(n))
+	}
+	return n, err
+}
+
+func recordModfetchTransferHistory(st *state.DB, rawURL string, connections, chunkSizeMB int, bytes int64, elapsed time.Duration, status string, rateLimited bool, lastErr string) {
+	if st == nil || bytes <= 0 || elapsed <= 0 {
+		return
+	}
+	host := strings.ToLower(hostFromURL(rawURL))
+	if host == "" {
+		return
+	}
+	_ = st.UpsertTransferHistory(state.TransferHistoryRow{
+		Host:        host,
+		Tool:        "modfetch",
+		Connections: connections,
+		ChunkSizeMB: chunkSizeMB,
+		AvgBPS:      float64(bytes) / elapsed.Seconds(),
+		RateLimited: rateLimited,
+		LastStatus:  status,
+		LastError:   lastErr,
+	})
+}
+
+func chunkSizeMBForHistory(cfg *config.Config) int {
+	if cfg == nil || cfg.Concurrency.ChunkSizeMB <= 0 {
+		return 0
+	}
+	return cfg.Concurrency.ChunkSizeMB
+}
+
+func HostFromURLForHistory(rawURL string) string {
+	return strings.ToLower(hostFromURL(rawURL))
+}
+
+func clampInt(v, min, max int) int {
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
+	return v
+}

--- a/internal/downloader/adaptive_test.go
+++ b/internal/downloader/adaptive_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/jxwalker/modfetch/internal/state"
 )
@@ -52,8 +53,40 @@ func TestInitialAdaptiveLimitUsesTransferHistory(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("upsert limited history: %v", err)
 	}
-	if got := initialAdaptiveLimit(db2, "limited.example", 16); got != 6 {
-		t.Fatalf("rate-limited initial limit = %d, want 6", got)
+	if got := initialAdaptiveLimit(db2, "limited.example", 16); got != 12 {
+		t.Fatalf("rate-limited initial limit = %d, want stored final limit 12", got)
+	}
+}
+
+func TestAdaptiveAdjustRampAndBackoff(t *testing.T) {
+	c := newAdaptiveTransferController(nil, nil, nil, "https://example.com/model.bin", 8)
+	defer c.stop()
+
+	c.mu.Lock()
+	c.limit = 4
+	c.active = 4
+	c.windowStarted = time.Now().Add(-2 * adaptiveProgressWindow)
+	c.lastAdjust = time.Now().Add(-2 * adaptiveProgressWindow)
+	c.emaBPS = 50
+	c.mu.Unlock()
+	c.windowBytes.Store(200)
+	c.lastProgress.Store(time.Now().UnixNano())
+	c.adjust()
+	if got := c.finalLimit(); got != 5 {
+		t.Fatalf("ramp limit = %d, want 5", got)
+	}
+
+	c.mu.Lock()
+	c.active = 5
+	c.windowStarted = time.Now().Add(-2 * adaptiveProgressWindow)
+	c.lastAdjust = time.Now().Add(-2 * adaptiveProgressWindow)
+	c.emaBPS = 1000
+	c.mu.Unlock()
+	c.windowBytes.Store(100)
+	c.lastProgress.Store(time.Now().UnixNano())
+	c.adjust()
+	if got := c.finalLimit(); got != 4 {
+		t.Fatalf("backoff limit = %d, want 4", got)
 	}
 }
 

--- a/internal/downloader/adaptive_test.go
+++ b/internal/downloader/adaptive_test.go
@@ -1,0 +1,78 @@
+package downloader
+
+import (
+	"bytes"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+func TestInitialAdaptiveLimitUsesTransferHistory(t *testing.T) {
+	db, err := state.NewDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.UpsertTransferHistory(state.TransferHistoryRow{
+		Host:        "example.com",
+		Tool:        "modfetch",
+		Connections: 12,
+		ChunkSizeMB: 64,
+		AvgBPS:      1024,
+		LastStatus:  "complete",
+	}); err != nil {
+		t.Fatalf("upsert history: %v", err)
+	}
+
+	if got := initialAdaptiveLimit(db, "example.com", 16); got != 12 {
+		t.Fatalf("initial limit = %d, want 12", got)
+	}
+	if got := initialAdaptiveLimit(db, "example.com", 8); got != 8 {
+		t.Fatalf("clamped initial limit = %d, want 8", got)
+	}
+	if got := initialAdaptiveLimit(db, "missing.example", 16); got != 4 {
+		t.Fatalf("default ramp start = %d, want 4", got)
+	}
+
+	db2, err := state.NewDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("state2: %v", err)
+	}
+	defer func() { _ = db2.Close() }()
+	if err := db2.UpsertTransferHistory(state.TransferHistoryRow{
+		Host:        "limited.example",
+		Tool:        "modfetch",
+		Connections: 12,
+		AvgBPS:      2048,
+		RateLimited: true,
+		LastStatus:  "complete",
+	}); err != nil {
+		t.Fatalf("upsert limited history: %v", err)
+	}
+	if got := initialAdaptiveLimit(db2, "limited.example", 16); got != 6 {
+		t.Fatalf("rate-limited initial limit = %d, want 6", got)
+	}
+}
+
+func TestAdaptiveProgressReaderReportsBytes(t *testing.T) {
+	var observed int64
+	r := &adaptiveProgressReader{
+		r: bytes.NewBufferString("abcdef"),
+		onBytes: func(n int64) {
+			observed += n
+		},
+	}
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "abcdef" {
+		t.Fatalf("read body = %q", got)
+	}
+	if observed != 6 {
+		t.Fatalf("observed bytes = %d, want 6", observed)
+	}
+}

--- a/internal/downloader/chunked.go
+++ b/internal/downloader/chunked.go
@@ -475,7 +475,7 @@ func (e *Chunked) Download(ctx context.Context, url, destPath, expectedSHA strin
 	_ = fsyncDir(filepath.Dir(destPath))
 	completed = true
 	_ = e.st.UpsertDownload(state.DownloadRow{URL: url, Dest: destPath, ExpectedSHA256: expectedSHA, ActualSHA256: finalSHA, ETag: h.etag, LastModified: h.lastMod, Size: h.size, Status: "complete"})
-	recordModfetchTransferHistory(e.st, url, adaptive.finalLimit(), chunkSizeMBForHistory(e.cfg), h.size, time.Since(startTime), "complete", adaptive.wasRateLimited(), "")
+	recordModfetchTransferHistory(e.st, url, adaptive.finalLimit(), chunkSizeMBForHistory(e.cfg), adaptive.total(), time.Since(startTime), "complete", adaptive.wasRateLimited(), "")
 	if e.metrics != nil {
 		e.metrics.IncDownloadsSuccess()
 		e.metrics.ObserveDownloadSeconds(time.Since(startTime).Seconds())

--- a/internal/downloader/chunked.go
+++ b/internal/downloader/chunked.go
@@ -318,15 +318,19 @@ func (e *Chunked) Download(ctx context.Context, url, destPath, expectedSHA strin
 	if ph := e.cfg.Concurrency.PerHostRequests; ph > 0 && perFile > ph {
 		perFile = ph
 	}
-	sem := make(chan struct{}, perFile)
+	adaptive := newAdaptiveTransferController(e.cfg, e.log, e.st, url, perFile)
+	defer adaptive.stop()
 	var wg sync.WaitGroup
 	var dErr error
 	var dMu sync.Mutex
 
 	downloadOne := func(c state.ChunkRow) {
 		defer wg.Done()
-		sem <- struct{}{}
-		defer func() { <-sem }()
+		if err := adaptive.acquire(ctx); err != nil {
+			setErr(&dErr, &dMu, err)
+			return
+		}
+		defer adaptive.release()
 
 		select {
 		case <-ctx.Done():
@@ -342,7 +346,7 @@ func (e *Chunked) Download(ctx context.Context, url, destPath, expectedSHA strin
 			setErr(&dErr, &dMu, err)
 			return
 		}
-		sha, err := e.fetchChunk(ctx, url, destPath, h, f, c, headers, perDownloadLimiter)
+		sha, err := e.fetchChunk(ctx, url, destPath, h, f, c, headers, perDownloadLimiter, adaptive)
 		if err != nil {
 			setErr(&dErr, &dMu, err)
 			return
@@ -376,7 +380,7 @@ func (e *Chunked) Download(ctx context.Context, url, destPath, expectedSHA strin
 		// re-download this chunk
 		e.log.WarnfThrottled(fmt.Sprintf("repair:%s|%s", url, destPath), 2*time.Second, "chunk %d sha mismatch on self-check; re-fetching", c.Index)
 		_ = e.st.UpdateChunkStatus(url, destPath, c.Index, "dirty")
-		sha3, err := e.fetchChunk(ctx, url, destPath, h, f, c, headers, perDownloadLimiter)
+		sha3, err := e.fetchChunk(ctx, url, destPath, h, f, c, headers, perDownloadLimiter, adaptive)
 		if err != nil {
 			return "", "", err
 		}
@@ -405,7 +409,7 @@ func (e *Chunked) Download(ctx context.Context, url, destPath, expectedSHA strin
 			// re-download this chunk
 			e.log.Debugf("chunk %d sha mismatch; re-fetching", c.Index)
 			_ = e.st.UpdateChunkStatus(url, destPath, c.Index, "dirty")
-			sha3, err := e.fetchChunk(ctx, url, destPath, h, f, c, headers, perDownloadLimiter)
+			sha3, err := e.fetchChunk(ctx, url, destPath, h, f, c, headers, perDownloadLimiter, adaptive)
 			if err != nil {
 				return "", "", err
 			}
@@ -466,6 +470,7 @@ func (e *Chunked) Download(ctx context.Context, url, destPath, expectedSHA strin
 	_ = fsyncDir(filepath.Dir(destPath))
 	completed = true
 	_ = e.st.UpsertDownload(state.DownloadRow{URL: url, Dest: destPath, ExpectedSHA256: expectedSHA, ActualSHA256: finalSHA, ETag: h.etag, LastModified: h.lastMod, Size: h.size, Status: "complete"})
+	recordModfetchTransferHistory(e.st, url, adaptive.finalLimit(), chunkSizeMBForHistory(e.cfg), h.size, time.Since(startTime), "complete", adaptive.wasRateLimited(), "")
 	if e.metrics != nil {
 		e.metrics.IncDownloadsSuccess()
 		e.metrics.ObserveDownloadSeconds(time.Since(startTime).Seconds())
@@ -474,7 +479,7 @@ func (e *Chunked) Download(ctx context.Context, url, destPath, expectedSHA strin
 	return destPath, finalSHA, nil
 }
 
-func (e *Chunked) fetchChunk(ctx context.Context, url string, destPath string, h headInfo, f *os.File, c state.ChunkRow, headers map[string]string, perDownloadLimiter *bandwidthLimiter) (string, error) {
+func (e *Chunked) fetchChunk(ctx context.Context, url string, destPath string, h headInfo, f *os.File, c state.ChunkRow, headers map[string]string, perDownloadLimiter *bandwidthLimiter, adaptive *adaptiveTransferController) (string, error) {
 	// retry loop
 	max := e.cfg.Concurrency.MaxRetries
 	if max <= 0 {
@@ -485,7 +490,7 @@ func (e *Chunked) fetchChunk(ctx context.Context, url string, destPath string, h
 		if ctx.Err() != nil {
 			return "", ctx.Err()
 		}
-		sha, err := e.tryFetchChunk(ctx, url, h, f, c, headers, perDownloadLimiter)
+		sha, err := e.tryFetchChunk(ctx, url, h, f, c, headers, perDownloadLimiter, adaptive)
 		if err == nil {
 			return sha, nil
 		}
@@ -494,6 +499,9 @@ func (e *Chunked) fetchChunk(ctx context.Context, url string, destPath string, h
 		}
 		lastErr = err
 		// backoff or honor Retry-After for 429 if enabled
+		if _, ok := err.(rateLimitedError); ok && adaptive != nil {
+			adaptive.observeRateLimit()
+		}
 		if rle, ok := err.(rateLimitedError); ok && e.cfg.Network.RetryOnRateLimit {
 			if e.metrics != nil {
 				e.metrics.IncRetries(1)
@@ -567,7 +575,7 @@ func (e *Chunked) fetchChunk(ctx context.Context, url string, destPath string, h
 	return "", lastErr
 }
 
-func (e *Chunked) tryFetchChunk(ctx context.Context, url string, h headInfo, f *os.File, c state.ChunkRow, headers map[string]string, perDownloadLimiter *bandwidthLimiter) (string, error) {
+func (e *Chunked) tryFetchChunk(ctx context.Context, url string, h headInfo, f *os.File, c state.ChunkRow, headers map[string]string, perDownloadLimiter *bandwidthLimiter, adaptive *adaptiveTransferController) (string, error) {
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	req.Header.Set("User-Agent", userAgent(e.cfg))
 	for k, v := range headers {
@@ -613,8 +621,11 @@ func (e *Chunked) tryFetchChunk(ctx context.Context, url string, h headInfo, f *
 	hasher := sha256.New()
 	ow := &offsetWriterAt{w: f, off: c.Start}
 	mw := io.MultiWriter(ow, hasher)
-	body := newThrottledReader(ctx, resp.Body, perDownloadLimiter, e.globalLimiter)
-	written, err := io.CopyN(mw, body, c.Size)
+	source := newThrottledReader(ctx, resp.Body, perDownloadLimiter, e.globalLimiter)
+	if adaptive != nil {
+		source = &adaptiveProgressReader{r: source, onBytes: adaptive.observeBytes}
+	}
+	written, err := io.CopyN(mw, source, c.Size)
 	if e.metrics != nil && written > 0 {
 		e.metrics.AddBytes(written)
 	}

--- a/internal/downloader/chunked.go
+++ b/internal/downloader/chunked.go
@@ -320,6 +320,11 @@ func (e *Chunked) Download(ctx context.Context, url, destPath, expectedSHA strin
 	}
 	adaptive := newAdaptiveTransferController(e.cfg, e.log, e.st, url, perFile)
 	defer adaptive.stop()
+	defer func() {
+		if !completed && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			recordModfetchTransferHistory(e.st, url, adaptive.finalLimit(), chunkSizeMBForHistory(e.cfg), adaptive.total(), time.Since(startTime), "sampled", adaptive.wasRateLimited(), ctx.Err().Error())
+		}
+	}()
 	var wg sync.WaitGroup
 	var dErr error
 	var dMu sync.Mutex

--- a/internal/downloader/downloader_http_test.go
+++ b/internal/downloader/downloader_http_test.go
@@ -111,6 +111,16 @@ func TestChunked_RangeWithTransient429(t *testing.T) {
 	if len(sha) != 64 {
 		t.Fatalf("sha len: %d", len(sha))
 	}
+	history, ok, err := st.BestTransferHistory(hostFromURL(url), "modfetch")
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected transfer history")
+	}
+	if !history.RateLimited {
+		t.Fatalf("history should record rate limit, got %+v", history)
+	}
 }
 
 // Test fallback when HEAD/Range are not supported (no Accept-Ranges)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -158,6 +158,9 @@ func openAtPath(path string) (*DB, error) {
 	if err := db.InitMetadataTable(); err != nil {
 		return nil, err
 	}
+	if err := db.InitTransferHistoryTable(); err != nil {
+		return nil, err
+	}
 	ready = true
 	return db, nil
 }

--- a/internal/state/transfer_history.go
+++ b/internal/state/transfer_history.go
@@ -48,7 +48,7 @@ func (db *DB) UpsertTransferHistory(row TransferHistoryRow) error {
 	}
 	row.Host = strings.ToLower(strings.TrimSpace(row.Host))
 	row.Tool = strings.ToLower(strings.TrimSpace(row.Tool))
-	row.LastStatus = strings.TrimSpace(row.LastStatus)
+	row.LastStatus = strings.ToLower(strings.TrimSpace(row.LastStatus))
 	if row.Host == "" || row.Tool == "" {
 		return errors.New("transfer history host and tool required")
 	}
@@ -71,7 +71,7 @@ func (db *DB) UpsertTransferHistory(row TransferHistoryRow) error {
 			avg_bps=((transfer_history.avg_bps * CASE WHEN transfer_history.samples >= 20 THEN 19 ELSE transfer_history.samples END) + excluded.avg_bps) /
 				(CASE WHEN transfer_history.samples >= 20 THEN 20 ELSE transfer_history.samples + 1 END),
 			samples=CASE WHEN transfer_history.samples >= 20 THEN 20 ELSE transfer_history.samples + 1 END,
-			rate_limited=CASE WHEN excluded.rate_limited != 0 THEN 1 ELSE transfer_history.rate_limited END,
+			rate_limited=excluded.rate_limited,
 			last_status=excluded.last_status,
 			last_error=excluded.last_error,
 			updated_at=excluded.updated_at`,

--- a/internal/state/transfer_history.go
+++ b/internal/state/transfer_history.go
@@ -1,0 +1,133 @@
+package state
+
+import (
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+)
+
+type TransferHistoryRow struct {
+	Host        string  `json:"host"`
+	Tool        string  `json:"tool"`
+	Connections int     `json:"connections"`
+	ChunkSizeMB int     `json:"chunk_size_mb"`
+	AvgBPS      float64 `json:"avg_bps"`
+	Samples     int     `json:"samples"`
+	RateLimited bool    `json:"rate_limited"`
+	LastStatus  string  `json:"last_status"`
+	LastError   string  `json:"last_error,omitempty"`
+	UpdatedAt   int64   `json:"updated_at"`
+}
+
+func (db *DB) InitTransferHistoryTable() error {
+	if db == nil || db.SQL == nil {
+		return errors.New("nil db")
+	}
+	_, err := db.SQL.Exec(`CREATE TABLE IF NOT EXISTS transfer_history (
+		host TEXT NOT NULL,
+		tool TEXT NOT NULL,
+		connections INTEGER NOT NULL,
+		chunk_size_mb INTEGER NOT NULL,
+		avg_bps REAL NOT NULL,
+		samples INTEGER NOT NULL,
+		rate_limited INTEGER NOT NULL DEFAULT 0,
+		last_status TEXT NOT NULL,
+		last_error TEXT,
+		updated_at INTEGER NOT NULL,
+		UNIQUE(host, tool, connections, chunk_size_mb)
+	);
+	CREATE INDEX IF NOT EXISTS idx_transfer_history_host_tool ON transfer_history(host, tool);
+	CREATE INDEX IF NOT EXISTS idx_transfer_history_updated_at ON transfer_history(updated_at);`)
+	return err
+}
+
+func (db *DB) UpsertTransferHistory(row TransferHistoryRow) error {
+	if db == nil || db.SQL == nil {
+		return errors.New("nil db")
+	}
+	row.Host = strings.ToLower(strings.TrimSpace(row.Host))
+	row.Tool = strings.ToLower(strings.TrimSpace(row.Tool))
+	row.LastStatus = strings.TrimSpace(row.LastStatus)
+	if row.Host == "" || row.Tool == "" {
+		return errors.New("transfer history host and tool required")
+	}
+	if row.Connections <= 0 {
+		row.Connections = 1
+	}
+	if row.ChunkSizeMB < 0 {
+		row.ChunkSizeMB = 0
+	}
+	if row.AvgBPS < 0 {
+		row.AvgBPS = 0
+	}
+	if row.LastStatus == "" {
+		row.LastStatus = "unknown"
+	}
+	now := time.Now().Unix()
+	_, err := db.SQL.Exec(`INSERT INTO transfer_history(host, tool, connections, chunk_size_mb, avg_bps, samples, rate_limited, last_status, last_error, updated_at)
+		VALUES(?,?,?,?,?,?,?,?,?,?)
+		ON CONFLICT(host, tool, connections, chunk_size_mb) DO UPDATE SET
+			avg_bps=((transfer_history.avg_bps * transfer_history.samples) + excluded.avg_bps) / (transfer_history.samples + 1),
+			samples=transfer_history.samples + 1,
+			rate_limited=CASE WHEN excluded.rate_limited != 0 THEN 1 ELSE transfer_history.rate_limited END,
+			last_status=excluded.last_status,
+			last_error=excluded.last_error,
+			updated_at=excluded.updated_at`,
+		row.Host, row.Tool, row.Connections, row.ChunkSizeMB, row.AvgBPS, 1, boolToInt(row.RateLimited), row.LastStatus, row.LastError, now)
+	if err == nil {
+		db.NotifyChange()
+	}
+	return err
+}
+
+func (db *DB) BestTransferHistory(host, tool string) (TransferHistoryRow, bool, error) {
+	if db == nil || db.SQL == nil {
+		return TransferHistoryRow{}, false, errors.New("nil db")
+	}
+	host = strings.ToLower(strings.TrimSpace(host))
+	tool = strings.ToLower(strings.TrimSpace(tool))
+	if host == "" || tool == "" {
+		return TransferHistoryRow{}, false, nil
+	}
+	row := db.SQL.QueryRow(`SELECT host, tool, connections, chunk_size_mb, avg_bps, samples, rate_limited, last_status, COALESCE(last_error, ''), updated_at
+		FROM transfer_history
+		WHERE host=? AND tool=? AND avg_bps > 0 AND last_status != 'error'
+		ORDER BY rate_limited ASC, avg_bps DESC, samples DESC, updated_at DESC
+		LIMIT 1`, host, tool)
+	var out TransferHistoryRow
+	var rateLimited int
+	switch err := row.Scan(&out.Host, &out.Tool, &out.Connections, &out.ChunkSizeMB, &out.AvgBPS, &out.Samples, &rateLimited, &out.LastStatus, &out.LastError, &out.UpdatedAt); err {
+	case sql.ErrNoRows:
+		return TransferHistoryRow{}, false, nil
+	case nil:
+		out.RateLimited = rateLimited != 0
+		return out, true, nil
+	default:
+		return TransferHistoryRow{}, false, err
+	}
+}
+
+func (db *DB) ListTransferHistory() ([]TransferHistoryRow, error) {
+	if db == nil || db.SQL == nil {
+		return nil, errors.New("nil db")
+	}
+	rows, err := db.SQL.Query(`SELECT host, tool, connections, chunk_size_mb, avg_bps, samples, rate_limited, last_status, COALESCE(last_error, ''), updated_at
+		FROM transfer_history
+		ORDER BY host, tool, rate_limited ASC, avg_bps DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []TransferHistoryRow
+	for rows.Next() {
+		var row TransferHistoryRow
+		var rateLimited int
+		if err := rows.Scan(&row.Host, &row.Tool, &row.Connections, &row.ChunkSizeMB, &row.AvgBPS, &row.Samples, &rateLimited, &row.LastStatus, &row.LastError, &row.UpdatedAt); err != nil {
+			return nil, err
+		}
+		row.RateLimited = rateLimited != 0
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}

--- a/internal/state/transfer_history.go
+++ b/internal/state/transfer_history.go
@@ -68,8 +68,9 @@ func (db *DB) UpsertTransferHistory(row TransferHistoryRow) error {
 	_, err := db.SQL.Exec(`INSERT INTO transfer_history(host, tool, connections, chunk_size_mb, avg_bps, samples, rate_limited, last_status, last_error, updated_at)
 		VALUES(?,?,?,?,?,?,?,?,?,?)
 		ON CONFLICT(host, tool, connections, chunk_size_mb) DO UPDATE SET
-			avg_bps=((transfer_history.avg_bps * transfer_history.samples) + excluded.avg_bps) / (transfer_history.samples + 1),
-			samples=transfer_history.samples + 1,
+			avg_bps=((transfer_history.avg_bps * CASE WHEN transfer_history.samples >= 20 THEN 19 ELSE transfer_history.samples END) + excluded.avg_bps) /
+				(CASE WHEN transfer_history.samples >= 20 THEN 20 ELSE transfer_history.samples + 1 END),
+			samples=CASE WHEN transfer_history.samples >= 20 THEN 20 ELSE transfer_history.samples + 1 END,
 			rate_limited=CASE WHEN excluded.rate_limited != 0 THEN 1 ELSE transfer_history.rate_limited END,
 			last_status=excluded.last_status,
 			last_error=excluded.last_error,

--- a/internal/state/transfer_history_test.go
+++ b/internal/state/transfer_history_test.go
@@ -63,3 +63,38 @@ func TestTransferHistoryUpsertBestAndList(t *testing.T) {
 		t.Fatalf("rows len = %d, want 3", len(rows))
 	}
 }
+
+func TestTransferHistoryWeightedAverageCapsSamples(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	for i := 0; i < 25; i++ {
+		if err := db.UpsertTransferHistory(TransferHistoryRow{
+			Host:        "example.com",
+			Tool:        "modfetch",
+			Connections: 4,
+			ChunkSizeMB: 8,
+			AvgBPS:      float64(100 + i),
+			LastStatus:  "complete",
+		}); err != nil {
+			t.Fatalf("upsert %d: %v", i, err)
+		}
+	}
+
+	best, ok, err := db.BestTransferHistory("example.com", "modfetch")
+	if err != nil {
+		t.Fatalf("best: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected history")
+	}
+	if best.Samples != 20 {
+		t.Fatalf("samples = %d, want capped 20", best.Samples)
+	}
+	if best.AvgBPS <= 100 || best.AvgBPS >= 124 {
+		t.Fatalf("avg_bps = %f, want bounded weighted average", best.AvgBPS)
+	}
+}

--- a/internal/state/transfer_history_test.go
+++ b/internal/state/transfer_history_test.go
@@ -97,4 +97,23 @@ func TestTransferHistoryWeightedAverageCapsSamples(t *testing.T) {
 	if best.AvgBPS <= 100 || best.AvgBPS >= 124 {
 		t.Fatalf("avg_bps = %f, want bounded weighted average", best.AvgBPS)
 	}
+
+	if err := db.UpsertTransferHistory(TransferHistoryRow{
+		Host:        "example.com",
+		Tool:        "modfetch",
+		Connections: 4,
+		ChunkSizeMB: 8,
+		AvgBPS:      500,
+		RateLimited: true,
+		LastStatus:  "complete",
+	}); err != nil {
+		t.Fatalf("upsert rate-limited conflict: %v", err)
+	}
+	best, ok, err = db.BestTransferHistory("example.com", "modfetch")
+	if err != nil {
+		t.Fatalf("best after rate limit: %v", err)
+	}
+	if !ok || !best.RateLimited {
+		t.Fatalf("expected sticky rate limit, got ok=%v best=%+v", ok, best)
+	}
 }

--- a/internal/state/transfer_history_test.go
+++ b/internal/state/transfer_history_test.go
@@ -1,0 +1,65 @@
+package state
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestTransferHistoryUpsertBestAndList(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.UpsertTransferHistory(TransferHistoryRow{
+		Host:        "Example.COM",
+		Tool:        "modfetch",
+		Connections: 4,
+		ChunkSizeMB: 8,
+		AvgBPS:      100,
+		LastStatus:  "complete",
+	}); err != nil {
+		t.Fatalf("upsert slow: %v", err)
+	}
+	if err := db.UpsertTransferHistory(TransferHistoryRow{
+		Host:        "example.com",
+		Tool:        "modfetch",
+		Connections: 8,
+		ChunkSizeMB: 16,
+		AvgBPS:      200,
+		LastStatus:  "complete",
+	}); err != nil {
+		t.Fatalf("upsert fast: %v", err)
+	}
+	if err := db.UpsertTransferHistory(TransferHistoryRow{
+		Host:        "example.com",
+		Tool:        "modfetch",
+		Connections: 16,
+		ChunkSizeMB: 64,
+		AvgBPS:      500,
+		RateLimited: true,
+		LastStatus:  "complete",
+	}); err != nil {
+		t.Fatalf("upsert rate limited: %v", err)
+	}
+
+	best, ok, err := db.BestTransferHistory("EXAMPLE.com", "modfetch")
+	if err != nil {
+		t.Fatalf("best: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected best history")
+	}
+	if best.Connections != 8 || best.ChunkSizeMB != 16 {
+		t.Fatalf("best = %+v, want connections=8 chunk=16", best)
+	}
+
+	rows, err := db.ListTransferHistory()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("rows len = %d, want 3", len(rows))
+	}
+}

--- a/internal/state/transfer_history_test.go
+++ b/internal/state/transfer_history_test.go
@@ -114,6 +114,25 @@ func TestTransferHistoryWeightedAverageCapsSamples(t *testing.T) {
 		t.Fatalf("best after rate limit: %v", err)
 	}
 	if !ok || !best.RateLimited {
-		t.Fatalf("expected sticky rate limit, got ok=%v best=%+v", ok, best)
+		t.Fatalf("expected rate limit after limited sample, got ok=%v best=%+v", ok, best)
+	}
+
+	if err := db.UpsertTransferHistory(TransferHistoryRow{
+		Host:        "example.com",
+		Tool:        "modfetch",
+		Connections: 4,
+		ChunkSizeMB: 8,
+		AvgBPS:      600,
+		RateLimited: false,
+		LastStatus:  "Complete",
+	}); err != nil {
+		t.Fatalf("upsert clean conflict: %v", err)
+	}
+	best, ok, err = db.BestTransferHistory("example.com", "modfetch")
+	if err != nil {
+		t.Fatalf("best after clean sample: %v", err)
+	}
+	if !ok || best.RateLimited || best.LastStatus != "complete" {
+		t.Fatalf("expected clean normalized history, got ok=%v best=%+v", ok, best)
 	}
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -84,6 +84,10 @@ func initTestSchema(db *state.DB) error {
 		return fmt.Errorf("init metadata table: %w", err)
 	}
 
+	if err := db.InitTransferHistoryTable(); err != nil {
+		return fmt.Errorf("init transfer history table: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- add persisted per-host transfer history for benchmark results and completed modfetch chunked downloads
- add a live adaptive chunk-concurrency controller that seeds from history, ramps up on healthy saturated throughput, backs off on stalls or throughput drops, and halves concurrency on 429s
- add `modfetch bench --history` plus docs/completions so users can inspect learned transfer behavior

## Validation
- `go test -count=1 ./...`
- `make lint`
- `scripts/check-docs-drift.sh && git diff --check`
- `make build`
- `scripts/uat/bench_compare.sh`
- `scripts/uat/real_download_matrix.sh`
- CLI persisted-history readback using `bin/modfetch bench --history --json` after a live `proof.ovh.net` benchmark

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->