### PR TITLE
feat: add hardware-aware model recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 Added
+- Added `modfetch recommend` to detect or override local hardware, rank live
+  provider candidates by task and memory fit, and hand the selected resolver
+  URI to the normal `download` pipeline.
 - Added `modfetch bench` to run disposable, timed download samples with
   modfetch and aria2 on the same URL, producing comparable throughput JSON.
 - Added automatic large-transfer tuning for range-capable objects, so

--- a/README.md
+++ b/README.md
@@ -123,8 +123,10 @@ The modfetch TUI provides a beautiful, full-featured interface for managing your
 
 ---
 
-## What's new in v0.7.1
+## Upcoming
 - **Hardware-aware recommendations**: `modfetch recommend --task coding` detects your machine, ranks live provider results by memory fit and model signals, and can download the selected result.
+
+## What's new in v0.7.1
 - **Starter downloads**: `modfetch starter` offers beginner-safe small downloads, and `starter://` aliases work in CLI, batch, and TUI flows.
 - **Real provider discovery**: `modfetch discover search` and `modfetch discover download` search live providers and hand selected files to the normal download pipeline.
 - **ModelScope discovery**: ModelScope results now participate in discovery alongside HuggingFace and CivitAI where public provider access allows it.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ║   SHA256 Integrity Verification                           ║
 ║   Rich TUI with Model Library Browser                     ║
 ║   Smart Classification & Auto-Placement                   ║
+║   Hardware-Aware Model Recommendations                    ║
 ║   10-100x Faster with Indexed Model Discovery             ║
 ╚═══════════════════════════════════════════════════════════╝
 ```
@@ -48,6 +49,12 @@
 - **Detailed view** with specs, descriptions, tags, and links
 - **Filter by type and source** (LLM, LoRA, VAE, Checkpoint, etc.)
 - **ModelScope and Ollama source support** with registry-backed enrichment; see the [Library Guide](docs/LIBRARY.md#metadata-sources)
+
+### 🧭 Model Selection
+- **Hardware-aware recommendations** with `modfetch recommend`
+- **Task presets** for chat, coding, embeddings, and image models
+- **RAM/VRAM overrides** for planning downloads for another machine
+- **One-step handoff** from recommendation to the normal resumable download pipeline
 
 ### 🎯 Organization
 - **Automatic placement** into app directories
@@ -117,6 +124,7 @@ The modfetch TUI provides a beautiful, full-featured interface for managing your
 ---
 
 ## What's new in v0.7.1
+- **Hardware-aware recommendations**: `modfetch recommend --task coding` detects your machine, ranks live provider results by memory fit and model signals, and can download the selected result.
 - **Starter downloads**: `modfetch starter` offers beginner-safe small downloads, and `starter://` aliases work in CLI, batch, and TUI flows.
 - **Real provider discovery**: `modfetch discover search` and `modfetch discover download` search live providers and hand selected files to the normal download pipeline.
 - **ModelScope discovery**: ModelScope results now participate in discovery alongside HuggingFace and CivitAI where public provider access allows it.

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -35,7 +35,7 @@ _modfetch_completions()
     local cur prev words cword
     _init_completion || return
     local presets="automatic1111 comfyui forge hf-cache ollama"
-    local cmds="config download bench discover starter place verify status tui library batch dedupe clean hostcaps version help completion"
+    local cmds="config download bench discover recommend starter place verify status tui library batch dedupe clean hostcaps version help completion"
     if [[ ${cword} -eq 1 ]]; then
         COMPREPLY=( $(compgen -W "${cmds}" -- "$cur") )
         return
@@ -71,6 +71,8 @@ _modfetch_completions()
                     COMPREPLY=( $(compgen -W "--config --log-level --json --provider --limit --select --dest --place --summary-json --dry-run --quiet --no-resume huggingface civitai modelscope all" -- "$cur") ) ;;
                 *) ;;
             esac ;;
+        recommend)
+            COMPREPLY=( $(compgen -W "--config --log-level --json --provider --task --limit --ram-gb --vram-gb --unified-memory --select --download --dest --place --summary-json --dry-run --quiet --no-resume chat coding embedding image huggingface civitai modelscope all" -- "$cur") ) ;;
         starter)
             if [[ ${cword} -eq 2 ]]; then
                 COMPREPLY=( $(compgen -W "list show download" -- "$cur") )
@@ -143,7 +145,7 @@ const zshCompletion = `#compdef modfetch
 # zsh completion for modfetch (basic)
 _modfetch() {
   local -a cmds
-  cmds=(config download bench discover starter place verify status tui library batch dedupe clean hostcaps version help completion)
+  cmds=(config download bench discover recommend starter place verify status tui library batch dedupe clean hostcaps version help completion)
   if (( CURRENT == 2 )); then
     _describe 'command' cmds
     return
@@ -185,6 +187,9 @@ _modfetch() {
             ;;
         esac
       fi
+      ;;
+    recommend)
+      _arguments '*:options:(--config --log-level --json --provider --task --limit --ram-gb --vram-gb --unified-memory --select --download --dest --place --summary-json --dry-run --quiet --no-resume chat coding embedding image huggingface civitai modelscope all)'
       ;;
     starter)
       if (( CURRENT == 3 )); then
@@ -269,6 +274,7 @@ complete -c modfetch -f -n "__fish_use_subcommand" -a "config" -d "config ops"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "download" -d "download assets"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "bench" -d "benchmark download tools"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "discover" -d "search real model providers"
+complete -c modfetch -f -n "__fish_use_subcommand" -a "recommend" -d "recommend models for hardware"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "starter" -d "beginner starter downloads"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "dedupe" -d "dedupe duplicate downloads"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "place" -d "place files"
@@ -293,7 +299,7 @@ complete -c modfetch -n "__fish_seen_subcommand_from clean" -l include-next-to-d
 complete -c modfetch -n "__fish_seen_subcommand_from clean" -l sidecars -d "Remove orphan .sha256"
 
 # Common flags
-for cmd in download bench place verify status tui library dedupe clean
+for cmd in download bench recommend place verify status tui library dedupe clean
   complete -c modfetch -n "__fish_seen_subcommand_from $cmd" -l config -d "Path to config"
   complete -c modfetch -n "__fish_seen_subcommand_from $cmd" -l log-level -d "Log level"
   complete -c modfetch -n "__fish_seen_subcommand_from $cmd" -l json -d "JSON output"
@@ -356,6 +362,20 @@ complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_s
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l dry-run -d "Plan without downloading"
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l quiet -d "Suppress progress and info logs"
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l no-resume -d "Start fresh instead of resuming"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l provider -a "huggingface civitai modelscope all" -d "Provider"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l task -a "chat coding embedding image" -d "Use case"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l limit -d "Recommendation limit"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l ram-gb -d "Override RAM in GiB"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l vram-gb -d "Override VRAM in GiB"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l unified-memory -d "Treat RAM as unified memory"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l select -d "Selected recommendation index"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l download -d "Download selected recommendation"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l dest -d "Destination path"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l place -d "Place after download"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l summary-json -d "Print completion summary as JSON"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l dry-run -d "Plan without downloading"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l quiet -d "Suppress progress and info logs"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l no-resume -d "Start fresh instead of resuming"
 complete -c modfetch -n "__fish_seen_subcommand_from starter" -a "list" -d "List starter downloads"
 complete -c modfetch -n "__fish_seen_subcommand_from starter" -a "show" -d "Show starter details"
 complete -c modfetch -n "__fish_seen_subcommand_from starter" -a "download" -d "Download a starter"

--- a/cmd/modfetch/completion_test.go
+++ b/cmd/modfetch/completion_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCompletionTopLevelCommands(t *testing.T) {
 	for name, script := range completionScripts() {
-		for _, command := range []string{"config", "download", "bench", "discover", "recommend", "starter", "place", "verify", "status", "tui", "batch", "dedupe", "clean", "hostcaps", "version", "help", "completion"} {
+		for _, command := range []string{"config", "download", "bench", "discover", "recommend", "starter", "place", "verify", "status", "tui", "library", "batch", "dedupe", "clean", "hostcaps", "version", "help", "completion"} {
 			want := completionCommandToken(name, command)
 			if !strings.Contains(script, want) {
 				t.Fatalf("%s completion missing top-level command %q", name, command)

--- a/cmd/modfetch/completion_test.go
+++ b/cmd/modfetch/completion_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCompletionTopLevelCommands(t *testing.T) {
 	for name, script := range completionScripts() {
-		for _, command := range []string{"config", "download", "bench", "discover", "starter", "place", "verify", "status", "tui", "batch", "dedupe", "clean", "hostcaps", "version", "help", "completion"} {
+		for _, command := range []string{"config", "download", "bench", "discover", "recommend", "starter", "place", "verify", "status", "tui", "batch", "dedupe", "clean", "hostcaps", "version", "help", "completion"} {
 			want := completionCommandToken(name, command)
 			if !strings.Contains(script, want) {
 				t.Fatalf("%s completion missing top-level command %q", name, command)
@@ -18,17 +18,18 @@ func TestCompletionTopLevelCommands(t *testing.T) {
 
 func TestCompletionCurrentFlags(t *testing.T) {
 	tests := map[string][]string{
-		"config":   {"--strict", "--out"},
-		"download": {"--no-resume", "--summary-json", "--batch-parallel", "--profile", "--connections", "--chunk-size-mb", "--dry-run", "--force", "--no-auth-preflight", "--quant", "--list-quants"},
-		"bench":    {"--url", "--tools", "--duration", "--profile", "--connections", "--chunk-size-mb", "--keep", "--history"},
-		"discover": {"--provider", "--limit", "--select", "--summary-json", "--dry-run"},
-		"starter":  {"--id", "--summary-json", "--dry-run"},
-		"place":    {"--dry-run", "--preset", "--list-presets"},
-		"batch":    {"--naming-pattern"},
-		"hostcaps": {"--config", "--list", "--clear", "--clear-all", "--json"},
-		"tui":      {"--json", "--snapshot"},
-		"clean":    {"--days", "--dry-run", "--dest", "--include-next-to-dest", "--sidecars"},
-		"library":  {"--target"},
+		"config":    {"--strict", "--out"},
+		"download":  {"--no-resume", "--summary-json", "--batch-parallel", "--profile", "--connections", "--chunk-size-mb", "--dry-run", "--force", "--no-auth-preflight", "--quant", "--list-quants"},
+		"bench":     {"--url", "--tools", "--duration", "--profile", "--connections", "--chunk-size-mb", "--keep", "--history"},
+		"discover":  {"--provider", "--limit", "--select", "--summary-json", "--dry-run"},
+		"recommend": {"--provider", "--task", "--ram-gb", "--vram-gb", "--unified-memory", "--download", "--select", "--dry-run"},
+		"starter":   {"--id", "--summary-json", "--dry-run"},
+		"place":     {"--dry-run", "--preset", "--list-presets"},
+		"batch":     {"--naming-pattern"},
+		"hostcaps":  {"--config", "--list", "--clear", "--clear-all", "--json"},
+		"tui":       {"--json", "--snapshot"},
+		"clean":     {"--days", "--dry-run", "--dest", "--include-next-to-dest", "--sidecars"},
+		"library":   {"--target"},
 	}
 
 	for name, script := range completionScripts() {

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -52,6 +52,8 @@ func run(ctx context.Context, args []string) error {
 		return handleBench(ctx, args[1:])
 	case "discover":
 		return handleDiscover(ctx, args[1:])
+	case "recommend":
+		return handleRecommend(ctx, args[1:])
 	case "starter":
 		return handleStarter(ctx, args[1:])
 	case "place":
@@ -97,6 +99,7 @@ Commands:
   download          Download a file via direct URL or resolver URI (starter://, hf://, civitai://)
   bench             Benchmark modfetch against aria2 on the same URL
   discover          Search real model providers and download a selected result
+  recommend         Recommend model files for this hardware
   starter           List or download beginner-safe starter artifacts
   status            Show download status (table or JSON)
   place             Place a file into configured app directories

--- a/cmd/modfetch/recommend_cmd.go
+++ b/cmd/modfetch/recommend_cmd.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/dustin/go-humanize"
+
+	"github.com/jxwalker/modfetch/internal/discovery"
+	"github.com/jxwalker/modfetch/internal/recommend"
+)
+
+type recommendSummary struct {
+	Query           string                     `json:"query"`
+	Task            string                     `json:"task"`
+	Hardware        recommend.HardwareProfile  `json:"hardware"`
+	Recommendations []recommend.Recommendation `json:"recommendations"`
+}
+
+func handleRecommend(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("recommend", flag.ContinueOnError)
+	common := addCommonConfigLogFlags(fs, "print hardware-fit recommendations as JSON")
+	provider := fs.String("provider", discovery.ProviderHuggingFace, "provider: huggingface|civitai|modelscope|all")
+	task := fs.String("task", "chat", "use case: chat|coding|embedding|image")
+	limit := fs.Int("limit", 5, "maximum recommendations to show")
+	ramGB := fs.Float64("ram-gb", 0, "override detected system RAM in GiB")
+	vramGB := fs.Float64("vram-gb", 0, "override detected dedicated VRAM in GiB")
+	unified := fs.Bool("unified-memory", false, "treat RAM as unified CPU/GPU memory")
+	selectIndex := fs.Int("select", 1, "1-based recommendation to use with --download")
+	download := fs.Bool("download", false, "download the selected recommendation through the normal download pipeline")
+	dest := fs.String("dest", "", "destination path when used with --download")
+	placeFlag := fs.Bool("place", false, "place after successful download")
+	summaryJSON := fs.Bool("summary-json", false, "print download completion summary as JSON")
+	dryRun := fs.Bool("dry-run", false, "plan selected download without downloading")
+	quiet := fs.Bool("quiet", false, "suppress progress and info logs for selected download")
+	noResume := fs.Bool("no-resume", false, "start selected download fresh instead of resuming")
+	flagArgs, queryArgs := splitDiscoverArgs(args, map[string]bool{
+		"json": true, "unified-memory": true, "download": true, "place": true, "summary-json": true, "dry-run": true, "quiet": true, "no-resume": true,
+	})
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	hw := recommend.DetectHardware(ctx)
+	if *ramGB > 0 {
+		hw.RAMBytes = gibToBytes(*ramGB)
+		hw.Source = "override"
+	}
+	if *vramGB > 0 {
+		hw.VRAMBytes = gibToBytes(*vramGB)
+		hw.Source = "override"
+	}
+	if *unified {
+		hw.UnifiedMemory = true
+	}
+	query := strings.TrimSpace(strings.Join(append(queryArgs, fs.Args()...), " "))
+	recs, hw, err := recommend.Recommend(ctx, recommend.Options{
+		Query:    query,
+		Task:     *task,
+		Provider: *provider,
+		Limit:    *limit,
+		Hardware: hw,
+	})
+	if err != nil {
+		return err
+	}
+	effectiveTask := recommend.NormalizeTask(*task)
+	effectiveQuery := query
+	if effectiveQuery == "" {
+		effectiveQuery = recommend.DefaultQuery(effectiveTask)
+	}
+	if *download {
+		if len(recs) == 0 {
+			return fmt.Errorf("no recommendations for %q", effectiveQuery)
+		}
+		if *selectIndex < 1 || *selectIndex > len(recs) {
+			return fmt.Errorf("--select must be between 1 and %d", len(recs))
+		}
+		selected := recs[*selectIndex-1]
+		if !*quiet && !*common.jsonOut {
+			fmt.Fprintf(os.Stderr, "Selected %d: %s (%s, fit=%s)\n", selected.Index, selected.Name, selected.URI, selected.Fit)
+		}
+		downloadArgs := []string{
+			"--config", *common.configPath,
+			"--log-level", *common.logLevel,
+			"--url", selected.URI,
+			"--profile", "auto",
+		}
+		if *common.jsonOut {
+			downloadArgs = append(downloadArgs, "--json")
+		}
+		if strings.TrimSpace(*dest) != "" {
+			downloadArgs = append(downloadArgs, "--dest", *dest)
+		}
+		if *placeFlag {
+			downloadArgs = append(downloadArgs, "--place")
+		}
+		if *summaryJSON {
+			downloadArgs = append(downloadArgs, "--summary-json")
+		}
+		if *dryRun {
+			downloadArgs = append(downloadArgs, "--dry-run")
+		}
+		if *quiet {
+			downloadArgs = append(downloadArgs, "--quiet")
+		}
+		if *noResume {
+			downloadArgs = append(downloadArgs, "--no-resume")
+		}
+		return handleDownload(ctx, downloadArgs)
+	}
+	return printRecommendations(recommendSummary{
+		Query:           effectiveQuery,
+		Task:            effectiveTask,
+		Hardware:        hw,
+		Recommendations: recs,
+	}, *common.jsonOut)
+}
+
+func printRecommendations(summary recommendSummary, jsonOut bool) error {
+	if jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(summary)
+	}
+	if len(summary.Recommendations) == 0 {
+		fmt.Println("No matching model recommendations found.")
+		return nil
+	}
+	budget := recommend.MemoryBudgetBytes(summary.Hardware)
+	fmt.Printf("Hardware: %s/%s", summary.Hardware.OS, summary.Hardware.Arch)
+	if summary.Hardware.RAMBytes > 0 {
+		fmt.Printf("  RAM=%s", humanize.Bytes(uint64(summary.Hardware.RAMBytes)))
+	}
+	if summary.Hardware.VRAMBytes > 0 {
+		fmt.Printf("  VRAM=%s", humanize.Bytes(uint64(summary.Hardware.VRAMBytes)))
+	}
+	if summary.Hardware.UnifiedMemory {
+		fmt.Print("  unified-memory")
+	}
+	if budget > 0 {
+		fmt.Printf("  usable-budget=%s", humanize.Bytes(uint64(budget)))
+	}
+	fmt.Println()
+	fmt.Printf("Recommendations for %q (%s):\n", summary.Query, summary.Task)
+	for _, rec := range summary.Recommendations {
+		size := "-"
+		if rec.Size > 0 {
+			size = humanize.Bytes(uint64(rec.Size))
+		}
+		required := "-"
+		if rec.EstimatedRequired > 0 {
+			required = humanize.Bytes(uint64(rec.EstimatedRequired))
+		}
+		fmt.Printf("%2d. %-40s fit=%-9s score=%3d size=%-10s need=%s\n", rec.Index, trimDisplay(rec.Name, 40), rec.Fit, rec.Score, size, required)
+		meta := []string{}
+		if rec.ParameterCount != "" {
+			meta = append(meta, rec.ParameterCount)
+		}
+		if rec.Quantization != "" {
+			meta = append(meta, rec.Quantization)
+		}
+		if rec.FileType != "" {
+			meta = append(meta, rec.FileType)
+		}
+		if len(meta) > 0 {
+			fmt.Printf("    %s\n", strings.Join(meta, " · "))
+		}
+		if len(rec.Reasons) > 0 {
+			fmt.Printf("    why: %s\n", strings.Join(rec.Reasons, "; "))
+		}
+		fmt.Printf("    uri: %s\n", rec.URI)
+		fmt.Printf("    download: %s\n", rec.DownloadCommand)
+	}
+	return nil
+}
+
+func gibToBytes(v float64) int64 {
+	return int64(v * 1024 * 1024 * 1024)
+}

--- a/cmd/modfetch/recommend_cmd.go
+++ b/cmd/modfetch/recommend_cmd.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 
@@ -13,6 +14,8 @@ import (
 	"github.com/jxwalker/modfetch/internal/discovery"
 	"github.com/jxwalker/modfetch/internal/recommend"
 )
+
+const maxHardwareOverrideGiB = 16384
 
 type recommendSummary struct {
 	Query           string                     `json:"query"`
@@ -45,6 +48,12 @@ func handleRecommend(ctx context.Context, args []string) error {
 		return err
 	}
 	hw := recommend.DetectHardware(ctx)
+	if err := validateGiBOverride("--ram-gb", *ramGB); err != nil {
+		return err
+	}
+	if err := validateGiBOverride("--vram-gb", *vramGB); err != nil {
+		return err
+	}
 	if *ramGB > 0 {
 		hw.RAMBytes = gibToBytes(*ramGB)
 		hw.Source = "override"
@@ -180,4 +189,17 @@ func printRecommendations(summary recommendSummary, jsonOut bool) error {
 
 func gibToBytes(v float64) int64 {
 	return int64(v * 1024 * 1024 * 1024)
+}
+
+func validateGiBOverride(name string, value float64) error {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return fmt.Errorf("%s must be a finite GiB value", name)
+	}
+	if value < 0 {
+		return fmt.Errorf("%s must be non-negative", name)
+	}
+	if value > maxHardwareOverrideGiB {
+		return fmt.Errorf("%s value %.2f is unreasonably large; max is %d GiB", name, value, maxHardwareOverrideGiB)
+	}
+	return nil
 }

--- a/cmd/modfetch/recommend_cmd_test.go
+++ b/cmd/modfetch/recommend_cmd_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+func TestValidateGiBOverride(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   float64
+		wantErr bool
+	}{
+		{name: "unset", value: 0},
+		{name: "fractional", value: 0.5},
+		{name: "max", value: maxHardwareOverrideGiB},
+		{name: "negative", value: -1, wantErr: true},
+		{name: "too large", value: maxHardwareOverrideGiB + 1, wantErr: true},
+		{name: "nan", value: math.NaN(), wantErr: true},
+		{name: "inf", value: math.Inf(1), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGiBOverride("--ram-gb", tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateGiBOverride(%g) err = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/modfetch/recommend_cmd_test.go
+++ b/cmd/modfetch/recommend_cmd_test.go
@@ -17,6 +17,7 @@ func TestValidateGiBOverride(t *testing.T) {
 		{name: "negative", value: -1, wantErr: true},
 		{name: "too large", value: maxHardwareOverrideGiB + 1, wantErr: true},
 		{name: "nan", value: math.NaN(), wantErr: true},
+		{name: "-inf", value: math.Inf(-1), wantErr: true},
 		{name: "inf", value: math.Inf(1), wantErr: true},
 	}
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -10,6 +10,7 @@ Complete command-line reference for modfetch. For the visual TUI interface, see 
   - [download](#download)
   - [bench](#bench)
   - [discover](#discover)
+  - [recommend](#recommend)
   - [starter](#starter)
   - [verify](#verify)
   - [place](#place)
@@ -36,6 +37,7 @@ modfetch provides a rich CLI for downloading, verifying, and managing AI models.
 modfetch download --url URL       # Download a file
 modfetch discover search "tiny gpt2"
 modfetch discover download "sshleifer/tiny-gpt2" --select 1
+modfetch recommend --task coding   # Pick a model that fits this machine
 modfetch verify --all              # Verify all downloads
 modfetch place --path FILE         # Place model into app
 modfetch clean --days 7            # Clean old partials
@@ -194,6 +196,42 @@ files, or the TUI new-download modal. `discover download` searches first, picks
 the `--select` result number, and then delegates to `download`, so normal flags
 such as `--config`, `--dest`, `--place`, `--dry-run`, `--quiet`, and
 `--summary-json` still apply.
+
+### recommend
+
+Recommend concrete downloadable model files for the current machine, or for
+hardware you describe with RAM/VRAM overrides. Recommendations use live provider
+search, file metadata, inferred parameter counts and quantization names, task
+signals, and the detected memory budget.
+
+```bash
+modfetch recommend [QUERY] [OPTIONS]
+```
+
+**Options:**
+- `--provider huggingface|civitai|modelscope|all` - provider search scope
+- `--task chat|coding|embedding|image` - intended use case
+- `--limit N` - number of recommendations to show
+- `--ram-gb N` - override detected system RAM in GiB
+- `--vram-gb N` - override detected dedicated VRAM in GiB
+- `--unified-memory` - treat system RAM as shared CPU/GPU memory
+- `--download` - pass the selected recommendation to `download`
+- `--select N` - 1-based recommendation number for `--download`
+- `--dest PATH`, `--place`, `--summary-json`, `--dry-run`, `--quiet`,
+  `--no-resume` - forwarded to the selected download
+- `--json` - emit the recommendation summary as JSON
+
+**Examples:**
+```bash
+# Let modfetch detect this machine and pick coding-friendly models.
+modfetch recommend --task coding
+
+# Plan for another host with 32 GiB unified memory.
+modfetch recommend "llama 8b gguf" --ram-gb 32 --unified-memory --json
+
+# Select the top recommendation and show the exact download plan.
+modfetch recommend --task chat --download --select 1 --dry-run --summary-json
+```
 
 ### starter
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -230,6 +230,18 @@ modfetch discover search "sshleifer/tiny-gpt2"
 modfetch discover download "sshleifer/tiny-gpt2" --select 1
 ```
 
+If you want modfetch to choose a model that fits your hardware, use
+`recommend`:
+
+```bash
+modfetch recommend --task chat
+modfetch recommend --task coding
+modfetch recommend --task chat --download --select 1 --dry-run
+```
+
+The dry run shows the selected resolver URI, destination, remote size, range
+support, and auth state before any file is written.
+
 Starter IDs also work in the TUI and regular download command as
 `starter://ID`, for example `starter://gpt2-tokenizer`.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,6 +25,9 @@ Shipped baseline:
   uses `CHANGELOG.md` sections for GitHub Release notes.
 - Beginner-friendly starter aliases and real-provider discovery commands for
   users who do not already know the exact model URL to download.
+- Hardware-aware recommendation commands that detect or accept RAM/VRAM
+  constraints, rank live provider results by task and memory fit, and hand the
+  selected URI to the same resumable download path.
 
 ## v0.7.0 Goal [DONE]
 
@@ -163,6 +166,23 @@ These are useful, but not required for the first v0.7.0 release:
   `modfetch tui --snapshot` exits without launching the Bubble Tea interface
   and `--snapshot --json` emits script-friendly downloads, library, and config
   state.
+- [DONE] Hardware-aware model recommendation:
+  `modfetch recommend` provides an llmfit-style path from user task and local
+  hardware to ranked provider results, with JSON output and one-step dry-run or
+  download handoff.
+
+## v0.8.x Direction
+
+- [NEXT] Recommendation quality feedback loop:
+  persist accepted/skipped recommendations, benchmark results, and completed
+  download outcomes so future recommendations learn from real local use.
+- [PLANNED] Runtime-aware guidance:
+  expose placement/runtime hints for Ollama, llama.cpp, MLX, ComfyUI, and
+  Stable Diffusion UIs so recommendation output explains where a model can run,
+  not just whether it can be downloaded.
+- [PLANNED] Interactive recommendation flow in the TUI:
+  add a guided "choose a model" workflow that filters by task, hardware, file
+  size, source, and placement target before starting a download.
 
 ## Completed Release History
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -4,7 +4,7 @@ This guide walks you through configuration, common workflows, and tips to get th
 
 - Build: `make build` (produces `./bin/modfetch`)
 - Config file path can be passed with `--config` or via the environment variable `MODFETCH_CONFIG`.
-- Current release: v0.7.1. The examples below include the Hugging Face shorthand URI form fixed in v0.6.3, the v0.7.0 library maintenance workflows, and the v0.7.1 starter and discovery commands.
+- Current release: v0.7.1. The examples below include the Hugging Face shorthand URI form fixed in v0.6.3, the v0.7.0 library maintenance workflows, and the v0.7.1 starter, discovery, and recommendation commands.
 
 ## Configure
 
@@ -62,6 +62,33 @@ modfetch download --config ~/.config/modfetch/config.yml \
   --url 'hf://org/repo?rev=main&quant=Q4_K_M'
 modfetch download --config ~/.config/modfetch/config.yml \
   --url 'civitai://model/123456?file=myfile.safetensors'
+
+### Recommend a model for your hardware
+
+If you do not know which repo or quantization to choose, start with
+`recommend`. It detects the current machine, searches live providers, estimates
+memory fit from file size, parameter count, and quantization metadata, and shows
+the command it would use to download each result.
+
+```bash
+modfetch recommend --task chat
+modfetch recommend --task coding
+modfetch recommend "llama 8b gguf" --ram-gb 32 --unified-memory --json
+```
+
+The `--task` flag tunes ranking for `chat`, `coding`, `embedding`, or `image`
+models. To plan for a different host, use `--ram-gb`, `--vram-gb`, and
+`--unified-memory`.
+
+When you like a result, download it through the same resumable pipeline:
+
+```bash
+modfetch recommend --task coding --download --select 1
+```
+
+Use `--dry-run --summary-json` first when you want to verify the selected URI,
+destination, remote size, range support, and attached auth state without writing
+files.
 
 #### Dry-run planning
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -4,7 +4,7 @@ This guide walks you through configuration, common workflows, and tips to get th
 
 - Build: `make build` (produces `./bin/modfetch`)
 - Config file path can be passed with `--config` or via the environment variable `MODFETCH_CONFIG`.
-- Current release: v0.7.1. The examples below include the Hugging Face shorthand URI form fixed in v0.6.3, the v0.7.0 library maintenance workflows, and the v0.7.1 starter, discovery, and recommendation commands.
+- Current release: v0.7.1. The examples below include the Hugging Face shorthand URI form fixed in v0.6.3, the v0.7.0 library maintenance workflows, and the v0.7.1 starter, discovery, and recommendation command.
 
 ## Configure
 

--- a/internal/recommend/recommend.go
+++ b/internal/recommend/recommend.go
@@ -1,0 +1,555 @@
+package recommend
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/jxwalker/modfetch/internal/discovery"
+)
+
+type HardwareProfile struct {
+	OS            string `json:"os"`
+	Arch          string `json:"arch"`
+	CPU           string `json:"cpu,omitempty"`
+	RAMBytes      int64  `json:"ram_bytes,omitempty"`
+	VRAMBytes     int64  `json:"vram_bytes,omitempty"`
+	UnifiedMemory bool   `json:"unified_memory,omitempty"`
+	Source        string `json:"source,omitempty"`
+}
+
+type Options struct {
+	Query    string
+	Task     string
+	Provider string
+	Limit    int
+	Hardware HardwareProfile
+}
+
+type Recommendation struct {
+	Index             int              `json:"index"`
+	Provider          string           `json:"provider"`
+	ModelID           string           `json:"model_id"`
+	Name              string           `json:"name"`
+	URI               string           `json:"uri"`
+	FileName          string           `json:"file_name,omitempty"`
+	FileType          string           `json:"file_type,omitempty"`
+	Size              int64            `json:"size,omitempty"`
+	Downloads         int64            `json:"downloads,omitempty"`
+	Likes             int64            `json:"likes,omitempty"`
+	Score             int              `json:"score"`
+	Fit               string           `json:"fit"`
+	EstimatedRequired int64            `json:"estimated_required_bytes,omitempty"`
+	MemoryBudget      int64            `json:"memory_budget_bytes,omitempty"`
+	ParameterCount    string           `json:"parameter_count,omitempty"`
+	Quantization      string           `json:"quantization,omitempty"`
+	Reasons           []string         `json:"reasons,omitempty"`
+	DownloadCommand   string           `json:"download_command"`
+	Raw               discovery.Result `json:"raw,omitempty"`
+}
+
+func DetectHardware(ctx context.Context) HardwareProfile {
+	hw := HardwareProfile{
+		OS:     runtime.GOOS,
+		Arch:   runtime.GOARCH,
+		Source: "runtime",
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		hw.Source = "sysctl"
+		hw.RAMBytes = readDarwinInt(ctx, "hw.memsize")
+		hw.CPU = readDarwinString(ctx, "machdep.cpu.brand_string")
+		if runtime.GOARCH == "arm64" {
+			hw.UnifiedMemory = true
+		}
+	case "linux":
+		hw.Source = "procfs"
+		hw.RAMBytes = readLinuxMemTotal()
+		hw.CPU = readLinuxCPU()
+	}
+	return hw
+}
+
+func Recommend(ctx context.Context, opts Options) ([]Recommendation, HardwareProfile, error) {
+	hw := opts.Hardware
+	if hw.OS == "" && hw.Arch == "" && hw.RAMBytes == 0 && hw.VRAMBytes == 0 {
+		hw = DetectHardware(ctx)
+	}
+	query := strings.TrimSpace(opts.Query)
+	task := NormalizeTask(opts.Task)
+	if query == "" {
+		query = DefaultQuery(task)
+	}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 5
+	}
+	searchLimit := limit * 3
+	if searchLimit < 8 {
+		searchLimit = 8
+	}
+	if searchLimit > 25 {
+		searchLimit = 25
+	}
+	provider := strings.TrimSpace(opts.Provider)
+	if provider == "" {
+		provider = discovery.ProviderHuggingFace
+	}
+	results, err := discovery.Search(ctx, discovery.Options{Provider: provider, Query: query, Limit: searchLimit})
+	if err != nil {
+		return nil, hw, err
+	}
+	ranked := Rank(results, hw, task)
+	if len(ranked) > limit {
+		ranked = ranked[:limit]
+	}
+	for i := range ranked {
+		ranked[i].Index = i + 1
+	}
+	return ranked, hw, nil
+}
+
+func Rank(results []discovery.Result, hw HardwareProfile, task string) []Recommendation {
+	task = NormalizeTask(task)
+	out := make([]Recommendation, 0, len(results))
+	for _, result := range results {
+		rec := scoreResult(result, hw, task)
+		if rec.URI == "" {
+			continue
+		}
+		out = append(out, rec)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Fit != out[j].Fit {
+			return fitRank(out[i].Fit) > fitRank(out[j].Fit)
+		}
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].Downloads > out[j].Downloads
+	})
+	for i := range out {
+		out[i].Index = i + 1
+	}
+	return out
+}
+
+func NormalizeTask(task string) string {
+	switch strings.ToLower(strings.TrimSpace(task)) {
+	case "", "chat", "general", "assistant":
+		return "chat"
+	case "code", "coding", "programming", "developer":
+		return "coding"
+	case "embed", "embedding", "embeddings":
+		return "embedding"
+	case "image", "sd", "stable-diffusion":
+		return "image"
+	default:
+		return strings.ToLower(strings.TrimSpace(task))
+	}
+}
+
+func DefaultQuery(task string) string {
+	switch NormalizeTask(task) {
+	case "coding":
+		return "qwen coder gguf"
+	case "embedding":
+		return "embedding model"
+	case "image":
+		return "stable diffusion safetensors"
+	default:
+		return "llama instruct gguf"
+	}
+}
+
+func MemoryBudgetBytes(hw HardwareProfile) int64 {
+	if hw.VRAMBytes > 0 && !hw.UnifiedMemory {
+		return int64(float64(hw.VRAMBytes) * 0.88)
+	}
+	if hw.RAMBytes <= 0 {
+		return 0
+	}
+	if hw.UnifiedMemory {
+		return int64(float64(hw.RAMBytes) * 0.72)
+	}
+	return int64(float64(hw.RAMBytes) * 0.55)
+}
+
+func scoreResult(result discovery.Result, hw HardwareProfile, task string) Recommendation {
+	text := strings.Join([]string{result.Name, result.ModelID, result.FileName, result.FilePath, strings.Join(result.Tags, " "), result.Pipeline, result.Description}, " ")
+	params := inferParameterCount(text)
+	quant := inferQuantization(text)
+	required := estimateRequiredBytes(result.Size, params, quant)
+	budget := MemoryBudgetBytes(hw)
+	fit := fitStatus(required, budget)
+	score := 0
+	var reasons []string
+
+	switch fit {
+	case "excellent":
+		score += 35
+		reasons = append(reasons, "comfortable memory fit")
+	case "good":
+		score += 28
+		reasons = append(reasons, "good memory fit")
+	case "tight":
+		score += 12
+		reasons = append(reasons, "fits, but leaves limited headroom")
+	case "too_large":
+		score -= 60
+		reasons = append(reasons, "likely too large for this hardware")
+	default:
+		reasons = append(reasons, "unknown size; fit is estimated from metadata")
+	}
+
+	score += taskScore(text, task, &reasons)
+	score += formatScore(result.FileType, result.FileName, &reasons)
+	if isSplitShard(text) {
+		score -= 80
+		reasons = append(reasons, "multi-part shard; prefer a single complete artifact for beginner downloads")
+	}
+	score += quantScore(quant, fit, &reasons)
+	score += parameterScore(params, fit, &reasons)
+	score += popularityScore(result.Downloads, result.Likes)
+
+	if result.Provider == discovery.ProviderHuggingFace {
+		score += 8
+	}
+	if result.URI == "" {
+		score -= 100
+	}
+
+	name := strings.TrimSpace(result.Name)
+	if name == "" {
+		name = result.ModelID
+	}
+	return Recommendation{
+		Provider:          result.Provider,
+		ModelID:           result.ModelID,
+		Name:              name,
+		URI:               result.URI,
+		FileName:          firstNonEmpty(result.FileName, pathBase(result.FilePath)),
+		FileType:          result.FileType,
+		Size:              result.Size,
+		Downloads:         result.Downloads,
+		Likes:             result.Likes,
+		Score:             score,
+		Fit:               fit,
+		EstimatedRequired: required,
+		MemoryBudget:      budget,
+		ParameterCount:    params,
+		Quantization:      quant,
+		Reasons:           reasons,
+		DownloadCommand:   "modfetch download --url " + strconv.Quote(result.URI) + " --profile auto",
+		Raw:               result,
+	}
+}
+
+func taskScore(text, task string, reasons *[]string) int {
+	lower := strings.ToLower(text)
+	switch NormalizeTask(task) {
+	case "coding":
+		if containsAny(lower, "coder", "coding", "code", "starcoder", "deepseek", "qwen") {
+			*reasons = append(*reasons, "coding-oriented model signals")
+			return 24
+		}
+		return -4
+	case "embedding":
+		if containsAny(lower, "embed", "embedding", "bge", "gte", "e5") {
+			*reasons = append(*reasons, "embedding model signals")
+			return 28
+		}
+		return -20
+	case "image":
+		if containsAny(lower, "stable-diffusion", "sdxl", "flux", "diffusion", "checkpoint") {
+			*reasons = append(*reasons, "image model signals")
+			return 24
+		}
+		return -12
+	default:
+		if containsAny(lower, "instruct", "chat", "llama", "qwen", "mistral", "gemma") {
+			*reasons = append(*reasons, "general chat/instruct signals")
+			return 16
+		}
+	}
+	return 0
+}
+
+func formatScore(fileType, fileName string, reasons *[]string) int {
+	ext := strings.ToLower(strings.TrimPrefix(fileType, "."))
+	name := strings.ToLower(fileName)
+	if ext == "" {
+		if dot := strings.LastIndexByte(name, '.'); dot >= 0 {
+			ext = strings.TrimPrefix(name[dot:], ".")
+		}
+	}
+	switch ext {
+	case "gguf":
+		*reasons = append(*reasons, "GGUF is ready for local llama.cpp-style runtimes")
+		return 18
+	case "safetensors":
+		return 8
+	case "bin", "pt", "pth":
+		return -4
+	default:
+		return 0
+	}
+}
+
+func quantScore(quant, fit string, reasons *[]string) int {
+	switch strings.ToUpper(quant) {
+	case "Q4_K_M", "Q5_K_M":
+		*reasons = append(*reasons, "strong quality/size quantization")
+		return 18
+	case "Q4_0", "Q4_1", "Q5_0", "Q5_1", "Q6_K":
+		return 12
+	case "Q8_0":
+		if fit == "excellent" || fit == "good" {
+			return 10
+		}
+		return -5
+	case "Q2_K", "Q3_K_S":
+		return -16
+	case "FP16", "F16", "BF16":
+		if fit == "excellent" {
+			return 8
+		}
+		return -12
+	}
+	return 0
+}
+
+func parameterScore(params, fit string, reasons *[]string) int {
+	b := parseBillions(params)
+	if b <= 0 || fit == "too_large" {
+		return 0
+	}
+	switch {
+	case b >= 30:
+		*reasons = append(*reasons, "large parameter count that still fits")
+		return 18
+	case b >= 13:
+		return 14
+	case b >= 7:
+		return 10
+	case b >= 3:
+		return 4
+	default:
+		return 0
+	}
+}
+
+func popularityScore(downloads, likes int64) int {
+	score := 0
+	if downloads > 0 {
+		score += int(math.Min(18, math.Log10(float64(downloads)+1)*4))
+	}
+	if likes > 0 {
+		score += int(math.Min(8, math.Log10(float64(likes)+1)*2))
+	}
+	return score
+}
+
+func fitStatus(required, budget int64) string {
+	if required <= 0 || budget <= 0 {
+		return "unknown"
+	}
+	ratio := float64(required) / float64(budget)
+	switch {
+	case ratio <= 0.60:
+		return "excellent"
+	case ratio <= 0.85:
+		return "good"
+	case ratio <= 1.00:
+		return "tight"
+	default:
+		return "too_large"
+	}
+}
+
+func estimateRequiredBytes(size int64, params, quant string) int64 {
+	if size > 0 {
+		return int64(float64(size) * 1.25)
+	}
+	b := parseBillions(params)
+	if b <= 0 {
+		return 0
+	}
+	bits := quantBits(quant)
+	if bits <= 0 {
+		bits = 8
+	}
+	weights := b * 1_000_000_000 * (float64(bits) / 8.0)
+	return int64(weights*1.20) + 1_000_000_000
+}
+
+func quantBits(quant string) int {
+	q := strings.ToUpper(quant)
+	switch {
+	case strings.HasPrefix(q, "Q2"):
+		return 2
+	case strings.HasPrefix(q, "Q3"):
+		return 3
+	case strings.HasPrefix(q, "Q4"), q == "4BIT":
+		return 4
+	case strings.HasPrefix(q, "Q5"):
+		return 5
+	case strings.HasPrefix(q, "Q6"):
+		return 6
+	case strings.HasPrefix(q, "Q8"), q == "8BIT":
+		return 8
+	case q == "FP16" || q == "F16" || q == "BF16":
+		return 16
+	case q == "FP32" || q == "F32":
+		return 32
+	default:
+		return 0
+	}
+}
+
+var (
+	paramPattern = regexp.MustCompile(`(?i)(\d+(?:\.\d+)?)\s*[-_ ]?b\b`)
+	quantPattern = regexp.MustCompile(`(?i)\b(q[2-8](?:[_-]k)?(?:[_-][sm])?|q[2-8][_ -]?[01]|fp16|fp32|f16|f32|bf16|4bit|8bit|awq|gptq)\b`)
+	shardPattern = regexp.MustCompile(`(?i)(?:^|[-_.])\d{5}-of-\d{5}(?:[-_.]|$)`)
+)
+
+func inferParameterCount(text string) string {
+	m := paramPattern.FindStringSubmatch(text)
+	if len(m) < 2 {
+		return ""
+	}
+	return strings.ToUpper(strings.TrimSpace(m[1] + "B"))
+}
+
+func inferQuantization(text string) string {
+	m := quantPattern.FindStringSubmatch(text)
+	if len(m) < 2 {
+		return ""
+	}
+	return strings.ToUpper(strings.NewReplacer("-", "_", " ", "_").Replace(m[1]))
+}
+
+func isSplitShard(text string) bool {
+	return shardPattern.MatchString(text)
+}
+
+func parseBillions(params string) float64 {
+	params = strings.TrimSuffix(strings.ToUpper(strings.TrimSpace(params)), "B")
+	v, err := strconv.ParseFloat(params, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+func fitRank(fit string) int {
+	switch fit {
+	case "excellent":
+		return 4
+	case "good":
+		return 3
+	case "tight":
+		return 2
+	case "unknown":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func readDarwinInt(ctx context.Context, key string) int64 {
+	out, err := exec.CommandContext(ctx, "sysctl", "-n", key).Output()
+	if err != nil {
+		return 0
+	}
+	value, _ := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 64)
+	return value
+}
+
+func readDarwinString(ctx context.Context, key string) string {
+	out, err := exec.CommandContext(ctx, "sysctl", "-n", key).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func readLinuxMemTotal() int64 {
+	body, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(body), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "MemTotal:" {
+			kb, _ := strconv.ParseInt(fields[1], 10, 64)
+			return kb * 1024
+		}
+	}
+	return 0
+}
+
+func readLinuxCPU() string {
+	body, err := os.ReadFile("/proc/cpuinfo")
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(body), "\n") {
+		if key, value, ok := strings.Cut(line, ":"); ok && strings.TrimSpace(key) == "model name" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func containsAny(text string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(text, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func pathBase(p string) string {
+	p = strings.TrimRight(strings.TrimSpace(p), "/")
+	if p == "" {
+		return ""
+	}
+	if i := strings.LastIndexByte(p, '/'); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}
+
+func FormatBytes(n int64) string {
+	if n <= 0 {
+		return "-"
+	}
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/internal/recommend/recommend.go
+++ b/internal/recommend/recommend.go
@@ -127,11 +127,11 @@ func Rank(results []discovery.Result, hw HardwareProfile, task string) []Recomme
 		out = append(out, rec)
 	}
 	sort.SliceStable(out, func(i, j int) bool {
-		if out[i].Fit != out[j].Fit {
-			return fitRank(out[i].Fit) > fitRank(out[j].Fit)
-		}
 		if out[i].Score != out[j].Score {
 			return out[i].Score > out[j].Score
+		}
+		if out[i].Fit != out[j].Fit {
+			return fitRank(out[i].Fit) > fitRank(out[j].Fit)
 		}
 		return out[i].Downloads > out[j].Downloads
 	})

--- a/internal/recommend/recommend_test.go
+++ b/internal/recommend/recommend_test.go
@@ -1,0 +1,116 @@
+package recommend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jxwalker/modfetch/internal/discovery"
+)
+
+func TestRankPrefersHardwareFitAndTask(t *testing.T) {
+	hw := HardwareProfile{RAMBytes: 32 << 30, UnifiedMemory: true}
+	results := []discovery.Result{
+		{
+			Provider:  discovery.ProviderHuggingFace,
+			ModelID:   "acme/huge-70b",
+			Name:      "Huge 70B Instruct",
+			FileName:  "huge-70b.Q4_K_M.gguf",
+			FileType:  "gguf",
+			Size:      42 << 30,
+			Downloads: 900000,
+			URI:       "hf://acme/huge-70b/huge-70b.Q4_K_M.gguf?rev=main",
+		},
+		{
+			Provider:  discovery.ProviderHuggingFace,
+			ModelID:   "acme/qwen-coder-7b",
+			Name:      "Qwen Coder 7B Instruct",
+			FileName:  "qwen-coder-7b.Q4_K_M.gguf",
+			FileType:  "gguf",
+			Size:      5 << 30,
+			Downloads: 100000,
+			URI:       "hf://acme/qwen-coder-7b/qwen-coder-7b.Q4_K_M.gguf?rev=main",
+		},
+	}
+
+	ranked := Rank(results, hw, "coding")
+	if len(ranked) != 2 {
+		t.Fatalf("ranked len = %d, want 2", len(ranked))
+	}
+	if ranked[0].ModelID != "acme/qwen-coder-7b" {
+		t.Fatalf("top recommendation = %s, want coder model", ranked[0].ModelID)
+	}
+	if ranked[0].Fit != "excellent" {
+		t.Fatalf("fit = %s, want excellent", ranked[0].Fit)
+	}
+	if ranked[1].Fit != "too_large" {
+		t.Fatalf("huge fit = %s, want too_large", ranked[1].Fit)
+	}
+}
+
+func TestRankInfersQuantizationAndParams(t *testing.T) {
+	ranked := Rank([]discovery.Result{{
+		Provider: discovery.ProviderHuggingFace,
+		ModelID:  "acme/tiny",
+		Name:     "Tiny 3B",
+		FilePath: "models/tiny-3b.Q5_K_M.gguf",
+		FileType: "gguf",
+		URI:      "hf://acme/tiny/models/tiny-3b.Q5_K_M.gguf?rev=main",
+	}}, HardwareProfile{RAMBytes: 16 << 30, UnifiedMemory: true}, "chat")
+
+	if len(ranked) != 1 {
+		t.Fatalf("ranked len = %d, want 1", len(ranked))
+	}
+	if ranked[0].ParameterCount != "3B" {
+		t.Fatalf("params = %q, want 3B", ranked[0].ParameterCount)
+	}
+	if ranked[0].Quantization != "Q5_K_M" {
+		t.Fatalf("quant = %q, want Q5_K_M", ranked[0].Quantization)
+	}
+	if !strings.Contains(ranked[0].DownloadCommand, "modfetch download --url") {
+		t.Fatalf("missing download command: %q", ranked[0].DownloadCommand)
+	}
+}
+
+func TestRankDemotesSplitShards(t *testing.T) {
+	ranked := Rank([]discovery.Result{
+		{
+			Provider:  discovery.ProviderHuggingFace,
+			ModelID:   "acme/coder-32b",
+			Name:      "Coder 32B",
+			FilePath:  "coder-32b-q4_k_m-00003-of-00003.gguf",
+			FileType:  "gguf",
+			Size:      4 << 30,
+			Downloads: 900000,
+			URI:       "hf://acme/coder-32b/coder-32b-q4_k_m-00003-of-00003.gguf?rev=main",
+		},
+		{
+			Provider:  discovery.ProviderHuggingFace,
+			ModelID:   "acme/coder-14b",
+			Name:      "Coder 14B",
+			FilePath:  "coder-14b-q4_k_m.gguf",
+			FileType:  "gguf",
+			Size:      9 << 30,
+			Downloads: 100000,
+			URI:       "hf://acme/coder-14b/coder-14b-q4_k_m.gguf?rev=main",
+		},
+	}, HardwareProfile{RAMBytes: 64 << 30, UnifiedMemory: true}, "coding")
+
+	if len(ranked) != 2 {
+		t.Fatalf("ranked len = %d, want 2", len(ranked))
+	}
+	if ranked[0].ModelID != "acme/coder-14b" {
+		t.Fatalf("top recommendation = %s, want complete single artifact", ranked[0].ModelID)
+	}
+	if !strings.Contains(strings.Join(ranked[1].Reasons, " "), "multi-part shard") {
+		t.Fatalf("missing shard reason: %#v", ranked[1].Reasons)
+	}
+}
+
+func TestDefaultQueryForTask(t *testing.T) {
+	if got := DefaultQuery("coding"); !strings.Contains(got, "coder") {
+		t.Fatalf("coding default query = %q", got)
+	}
+	if got := NormalizeTask("code"); got != "coding" {
+		t.Fatalf("NormalizeTask(code) = %q, want coding", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add `modfetch recommend` for hardware-aware model recommendations from live provider discovery
- detect local RAM/CPU/unified-memory, support RAM/VRAM overrides, task presets, JSON output, and selected download handoff
- rank by memory fit, task signals, format, quantization, popularity, and demote split shards for beginner-safe recommendations
- document the new noob model-selection flow in README, CLI guide, quickstart, user guide, changelog, and roadmap

## Validation
- `go test -count=1 ./...`
- `make lint`
- `make build`
- `scripts/check-docs-drift.sh && git diff --check`
- `bin/modfetch recommend "sshleifer tiny gpt2" --limit 3 --json`
- `bin/modfetch recommend --task coding --limit 3 --ram-gb 128 --unified-memory`
- `bin/modfetch recommend "sshleifer tiny gpt2" --limit 1 --download --dry-run --summary-json --quiet`
- `bin/modfetch recommend "sshleifer tiny gpt2" --limit 1 --download --select 1 --dest /tmp/modfetch-recommend-smoke.4BFZ7b/pytorch_model.bin --summary-json --quiet --no-resume`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->