### PR TITLE
feat: add recommendation learning and runtime hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Added
 - Added `modfetch recommend` to detect or override local hardware, rank live
   provider candidates by task and memory fit, and hand the selected resolver
   URI to the normal `download` pipeline.
+- Added recommendation learning history so selected and skipped model choices
+  influence future ranking for the same task, query, and hardware class.
+- Added runtime and placement hints to recommendations for GGUF, safetensors,
+  PyTorch, and ONNX artifacts.
 - Added `modfetch bench` to run disposable, timed download samples with
   modfetch and aria2 on the same URL, producing comparable throughput JSON.
 - Added automatic large-transfer tuning for range-capable objects, so

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@
 - **Hardware-aware recommendations** with `modfetch recommend`
 - **Task presets** for chat, coding, embeddings, and image models
 - **RAM/VRAM overrides** for planning downloads for another machine
+- **Learned ranking history** from selected and skipped recommendations
+- **Runtime hints** for llama.cpp, Ollama, LM Studio, ComfyUI, Stable Diffusion WebUI, Transformers, vLLM, and ONNX Runtime
 - **One-step handoff** from recommendation to the normal resumable download pipeline
 
 ### 🎯 Organization
@@ -124,7 +126,7 @@ The modfetch TUI provides a beautiful, full-featured interface for managing your
 ---
 
 ## Upcoming
-- **Hardware-aware recommendations**: `modfetch recommend --task coding` detects your machine, ranks live provider results by memory fit and model signals, and can download the selected result.
+- **Hardware-aware recommendations**: `modfetch recommend --task coding` detects your machine, ranks live provider results by memory fit, model signals, learned history, and runtime fit, then can download the selected result.
 
 ## What's new in v0.7.1
 - **Starter downloads**: `modfetch starter` offers beginner-safe small downloads, and `starter://` aliases work in CLI, batch, and TUI flows.

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -72,7 +72,7 @@ _modfetch_completions()
                 *) ;;
             esac ;;
         recommend)
-            COMPREPLY=( $(compgen -W "--config --log-level --json --provider --task --limit --ram-gb --vram-gb --unified-memory --select --download --dest --place --summary-json --dry-run --quiet --no-resume chat coding embedding image huggingface civitai modelscope all" -- "$cur") ) ;;
+            COMPREPLY=( $(compgen -W "--config --log-level --json --provider --task --limit --ram-gb --vram-gb --unified-memory --select --download --dest --place --summary-json --dry-run --quiet --no-resume --history --history-limit --no-learn chat coding embedding image huggingface civitai modelscope all" -- "$cur") ) ;;
         starter)
             if [[ ${cword} -eq 2 ]]; then
                 COMPREPLY=( $(compgen -W "list show download" -- "$cur") )
@@ -189,7 +189,7 @@ _modfetch() {
       fi
       ;;
     recommend)
-      _arguments '*:options:(--config --log-level --json --provider --task --limit --ram-gb --vram-gb --unified-memory --select --download --dest --place --summary-json --dry-run --quiet --no-resume chat coding embedding image huggingface civitai modelscope all)'
+      _arguments '*:options:(--config --log-level --json --provider --task --limit --ram-gb --vram-gb --unified-memory --select --download --dest --place --summary-json --dry-run --quiet --no-resume --history --history-limit --no-learn chat coding embedding image huggingface civitai modelscope all)'
       ;;
     starter)
       if (( CURRENT == 3 )); then
@@ -376,6 +376,9 @@ complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l summary-json 
 complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l dry-run -d "Plan without downloading"
 complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l quiet -d "Suppress progress and info logs"
 complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l no-resume -d "Start fresh instead of resuming"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l history -d "List recommendation history"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l history-limit -d "Recommendation history row limit"
+complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l no-learn -d "Disable recommendation history for this invocation"
 complete -c modfetch -n "__fish_seen_subcommand_from starter" -a "list" -d "List starter downloads"
 complete -c modfetch -n "__fish_seen_subcommand_from starter" -a "show" -d "Show starter details"
 complete -c modfetch -n "__fish_seen_subcommand_from starter" -a "download" -d "Download a starter"

--- a/cmd/modfetch/completion_test.go
+++ b/cmd/modfetch/completion_test.go
@@ -22,7 +22,7 @@ func TestCompletionCurrentFlags(t *testing.T) {
 		"download":  {"--no-resume", "--summary-json", "--batch-parallel", "--profile", "--connections", "--chunk-size-mb", "--dry-run", "--force", "--no-auth-preflight", "--quant", "--list-quants"},
 		"bench":     {"--url", "--tools", "--duration", "--profile", "--connections", "--chunk-size-mb", "--keep", "--history"},
 		"discover":  {"--provider", "--limit", "--select", "--summary-json", "--dry-run"},
-		"recommend": {"--provider", "--task", "--ram-gb", "--vram-gb", "--unified-memory", "--download", "--select", "--dry-run"},
+		"recommend": {"--provider", "--task", "--ram-gb", "--vram-gb", "--unified-memory", "--download", "--select", "--dry-run", "--history", "--history-limit", "--no-learn"},
 		"starter":   {"--id", "--summary-json", "--dry-run"},
 		"place":     {"--dry-run", "--preset", "--list-presets"},
 		"batch":     {"--naming-pattern"},

--- a/cmd/modfetch/recommend_cmd.go
+++ b/cmd/modfetch/recommend_cmd.go
@@ -91,7 +91,11 @@ func handleRecommend(ctx context.Context, args []string) error {
 		st, stErr = state.Open(c)
 		if stErr == nil {
 			defer func() { _ = st.Close() }()
-			feedback = recommendationFeedback(st, effectiveTask, effectiveQuery, hardwareKey)
+			var feedbackErr error
+			feedback, feedbackErr = recommendationFeedback(st, effectiveTask, effectiveQuery, hardwareKey)
+			if feedbackErr != nil {
+				return fmt.Errorf("load recommendation history: %w", feedbackErr)
+			}
 		} else if !*quiet && !*common.jsonOut {
 			fmt.Fprintf(os.Stderr, "warning: recommendation history unavailable: %v\n", stErr)
 		}
@@ -110,7 +114,9 @@ func handleRecommend(ctx context.Context, args []string) error {
 		return err
 	}
 	if st != nil {
-		recordRecommendationHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "shown", 0)
+		if err := recordRecommendationHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "shown", 0); err != nil {
+			return fmt.Errorf("record shown recommendations: %w", err)
+		}
 	}
 	if *download {
 		if len(recs) == 0 {
@@ -121,8 +127,12 @@ func handleRecommend(ctx context.Context, args []string) error {
 		}
 		selected := recs[*selectIndex-1]
 		if st != nil {
-			recordRecommendationHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "selected", selected.Index)
-			recordRecommendationHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "skipped", selected.Index)
+			if err := recordRecommendationHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "selected", selected.Index); err != nil {
+				return fmt.Errorf("record selected recommendation: %w", err)
+			}
+			if err := recordRecommendationHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "skipped", selected.Index); err != nil {
+				return fmt.Errorf("record skipped recommendations: %w", err)
+			}
 		}
 		if !*quiet && !*common.jsonOut {
 			fmt.Fprintf(os.Stderr, "Selected %d: %s (%s, fit=%s)\n", selected.Index, selected.Name, selected.URI, selected.Fit)
@@ -266,10 +276,10 @@ func recommendationHardwareKey(hw recommend.HardwareProfile) string {
 	return fmt.Sprintf("%s/%s/%dg/%s", strings.ToLower(hw.OS), strings.ToLower(hw.Arch), gb, shared)
 }
 
-func recommendationFeedback(st *state.DB, task, query, hardwareKey string) map[string]recommend.Feedback {
+func recommendationFeedback(st *state.DB, task, query, hardwareKey string) (map[string]recommend.Feedback, error) {
 	rows, err := st.RecommendationHistoryFor(task, query, hardwareKey)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	out := make(map[string]recommend.Feedback)
 	for _, row := range rows {
@@ -285,10 +295,11 @@ func recommendationFeedback(st *state.DB, task, query, hardwareKey string) map[s
 		}
 		out[key] = fb
 	}
-	return out
+	return out, nil
 }
 
-func recordRecommendationHistory(st *state.DB, task, query, hardwareKey string, recs []recommend.Recommendation, action string, selectedIndex int) {
+func recordRecommendationHistory(st *state.DB, task, query, hardwareKey string, recs []recommend.Recommendation, action string, selectedIndex int) error {
+	rows := make([]state.RecommendationHistoryRow, 0, len(recs))
 	for _, rec := range recs {
 		switch action {
 		case "selected":
@@ -300,7 +311,7 @@ func recordRecommendationHistory(st *state.DB, task, query, hardwareKey string, 
 				continue
 			}
 		}
-		_ = st.UpsertRecommendationHistory(state.RecommendationHistoryRow{
+		rows = append(rows, state.RecommendationHistoryRow{
 			Task:        task,
 			Query:       query,
 			Provider:    rec.Provider,
@@ -312,6 +323,7 @@ func recordRecommendationHistory(st *state.DB, task, query, hardwareKey string, 
 			HardwareKey: hardwareKey,
 		})
 	}
+	return st.BatchUpsertRecommendationHistory(rows)
 }
 
 func printRecommendationHistory(cfg *config.Config, limit int, jsonOut bool) error {

--- a/cmd/modfetch/recommend_cmd.go
+++ b/cmd/modfetch/recommend_cmd.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/dustin/go-humanize"
 
+	"github.com/jxwalker/modfetch/internal/config"
 	"github.com/jxwalker/modfetch/internal/discovery"
 	"github.com/jxwalker/modfetch/internal/recommend"
+	"github.com/jxwalker/modfetch/internal/state"
 )
 
 const maxHardwareOverrideGiB = 16384
@@ -41,11 +43,21 @@ func handleRecommend(ctx context.Context, args []string) error {
 	dryRun := fs.Bool("dry-run", false, "plan selected download without downloading")
 	quiet := fs.Bool("quiet", false, "suppress progress and info logs for selected download")
 	noResume := fs.Bool("no-resume", false, "start selected download fresh instead of resuming")
+	history := fs.Bool("history", false, "list persisted recommendation history")
+	historyLimit := fs.Int("history-limit", 50, "maximum recommendation history rows to list")
+	noLearn := fs.Bool("no-learn", false, "do not use or write recommendation history for this invocation")
 	flagArgs, queryArgs := splitDiscoverArgs(args, map[string]bool{
-		"json": true, "unified-memory": true, "download": true, "place": true, "summary-json": true, "dry-run": true, "quiet": true, "no-resume": true,
+		"json": true, "unified-memory": true, "download": true, "place": true, "summary-json": true, "dry-run": true, "quiet": true, "no-resume": true, "history": true, "no-learn": true,
 	})
 	if err := fs.Parse(flagArgs); err != nil {
 		return err
+	}
+	c, _, cfgErr := loadConfig(*common.configPath)
+	if *history {
+		if cfgErr != nil {
+			return cfgErr
+		}
+		return printRecommendationHistory(c, *historyLimit, *common.jsonOut)
 	}
 	hw := recommend.DetectHardware(ctx)
 	if err := validateGiBOverride("--ram-gb", *ramGB); err != nil {
@@ -66,20 +78,39 @@ func handleRecommend(ctx context.Context, args []string) error {
 		hw.UnifiedMemory = true
 	}
 	query := strings.TrimSpace(strings.Join(append(queryArgs, fs.Args()...), " "))
+	effectiveTask := recommend.NormalizeTask(*task)
+	effectiveQuery := query
+	if effectiveQuery == "" {
+		effectiveQuery = recommend.DefaultQuery(effectiveTask)
+	}
+	hardwareKey := recommendationHardwareKey(hw)
+	feedback := map[string]recommend.Feedback(nil)
+	var st *state.DB
+	if !*noLearn && cfgErr == nil {
+		var stErr error
+		st, stErr = state.Open(c)
+		if stErr == nil {
+			defer func() { _ = st.Close() }()
+			feedback = recommendationFeedback(st, effectiveTask, effectiveQuery, hardwareKey)
+		} else if !*quiet && !*common.jsonOut {
+			fmt.Fprintf(os.Stderr, "warning: recommendation history unavailable: %v\n", stErr)
+		}
+	} else if !*noLearn && cfgErr != nil && !*quiet && !*common.jsonOut {
+		fmt.Fprintf(os.Stderr, "warning: recommendation history unavailable: %v\n", cfgErr)
+	}
 	recs, hw, err := recommend.Recommend(ctx, recommend.Options{
 		Query:    query,
 		Task:     *task,
 		Provider: *provider,
 		Limit:    *limit,
 		Hardware: hw,
+		Feedback: feedback,
 	})
 	if err != nil {
 		return err
 	}
-	effectiveTask := recommend.NormalizeTask(*task)
-	effectiveQuery := query
-	if effectiveQuery == "" {
-		effectiveQuery = recommend.DefaultQuery(effectiveTask)
+	if st != nil {
+		recordRecommendationHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "shown", 0)
 	}
 	if *download {
 		if len(recs) == 0 {
@@ -89,6 +120,10 @@ func handleRecommend(ctx context.Context, args []string) error {
 			return fmt.Errorf("--select must be between 1 and %d", len(recs))
 		}
 		selected := recs[*selectIndex-1]
+		if st != nil {
+			recordRecommendationHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "selected", selected.Index)
+			recordRecommendationHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "skipped", selected.Index)
+		}
 		if !*quiet && !*common.jsonOut {
 			fmt.Fprintf(os.Stderr, "Selected %d: %s (%s, fit=%s)\n", selected.Index, selected.Name, selected.URI, selected.Fit)
 		}
@@ -181,6 +216,17 @@ func printRecommendations(summary recommendSummary, jsonOut bool) error {
 		if len(rec.Reasons) > 0 {
 			fmt.Printf("    why: %s\n", strings.Join(rec.Reasons, "; "))
 		}
+		if len(rec.RuntimeHints) > 0 {
+			hints := make([]string, 0, len(rec.RuntimeHints))
+			for _, hint := range rec.RuntimeHints {
+				value := hint.Runtime
+				if hint.PlacementPreset != "" {
+					value += " -> " + hint.PlacementPreset
+				}
+				hints = append(hints, value)
+			}
+			fmt.Printf("    runtimes: %s\n", strings.Join(hints, "; "))
+		}
 		fmt.Printf("    uri: %s\n", rec.URI)
 		fmt.Printf("    download: %s\n", rec.DownloadCommand)
 	}
@@ -200,6 +246,91 @@ func validateGiBOverride(name string, value float64) error {
 	}
 	if value > maxHardwareOverrideGiB {
 		return fmt.Errorf("%s value %.2f is unreasonably large; max is %d GiB", name, value, maxHardwareOverrideGiB)
+	}
+	return nil
+}
+
+func recommendationHardwareKey(hw recommend.HardwareProfile) string {
+	mem := hw.RAMBytes
+	if hw.VRAMBytes > mem {
+		mem = hw.VRAMBytes
+	}
+	gb := int64(0)
+	if mem > 0 {
+		gb = (mem + (1<<30 - 1)) >> 30
+	}
+	shared := "discrete"
+	if hw.UnifiedMemory {
+		shared = "unified"
+	}
+	return fmt.Sprintf("%s/%s/%dg/%s", strings.ToLower(hw.OS), strings.ToLower(hw.Arch), gb, shared)
+}
+
+func recommendationFeedback(st *state.DB, task, query, hardwareKey string) map[string]recommend.Feedback {
+	rows, err := st.RecommendationHistoryFor(task, query, hardwareKey)
+	if err != nil {
+		return nil
+	}
+	out := make(map[string]recommend.Feedback)
+	for _, row := range rows {
+		key := recommend.FeedbackKey(row.URI)
+		fb := out[key]
+		switch row.Action {
+		case "selected":
+			fb.Selected += row.Count
+		case "skipped":
+			fb.Skipped += row.Count
+		case "shown":
+			fb.Shown += row.Count
+		}
+		out[key] = fb
+	}
+	return out
+}
+
+func recordRecommendationHistory(st *state.DB, task, query, hardwareKey string, recs []recommend.Recommendation, action string, selectedIndex int) {
+	for _, rec := range recs {
+		switch action {
+		case "selected":
+			if rec.Index != selectedIndex {
+				continue
+			}
+		case "skipped":
+			if rec.Index == selectedIndex {
+				continue
+			}
+		}
+		_ = st.UpsertRecommendationHistory(state.RecommendationHistoryRow{
+			Task:        task,
+			Query:       query,
+			Provider:    rec.Provider,
+			ModelID:     rec.ModelID,
+			URI:         rec.URI,
+			Action:      action,
+			Score:       rec.Score,
+			Fit:         rec.Fit,
+			HardwareKey: hardwareKey,
+		})
+	}
+}
+
+func printRecommendationHistory(cfg *config.Config, limit int, jsonOut bool) error {
+	st, err := state.Open(cfg)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = st.Close() }()
+	rows, err := st.ListRecommendationHistory(limit)
+	if err != nil {
+		return err
+	}
+	if jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(rows)
+	}
+	for _, row := range rows {
+		fmt.Printf("%s\t%s\t%s\tcount=%d\tfit=%s\tscore=%d\t%s\n", row.Task, row.Action, row.HardwareKey, row.Count, row.Fit, row.Score, row.URI)
 	}
 	return nil
 }

--- a/cmd/modfetch/recommend_cmd.go
+++ b/cmd/modfetch/recommend_cmd.go
@@ -261,19 +261,23 @@ func validateGiBOverride(name string, value float64) error {
 }
 
 func recommendationHardwareKey(hw recommend.HardwareProfile) string {
-	mem := hw.RAMBytes
-	if hw.VRAMBytes > mem {
-		mem = hw.VRAMBytes
+	ramGB := roundedGiB(hw.RAMBytes)
+	vramGB := roundedGiB(hw.VRAMBytes)
+	switch {
+	case hw.UnifiedMemory:
+		return fmt.Sprintf("%s/%s/ram%dg/unified", strings.ToLower(hw.OS), strings.ToLower(hw.Arch), ramGB)
+	case hw.VRAMBytes > 0:
+		return fmt.Sprintf("%s/%s/vram%dg-ram%dg/discrete", strings.ToLower(hw.OS), strings.ToLower(hw.Arch), vramGB, ramGB)
+	default:
+		return fmt.Sprintf("%s/%s/ram%dg/system", strings.ToLower(hw.OS), strings.ToLower(hw.Arch), ramGB)
 	}
-	gb := int64(0)
-	if mem > 0 {
-		gb = (mem + (1<<30 - 1)) >> 30
+}
+
+func roundedGiB(bytes int64) int64 {
+	if bytes <= 0 {
+		return 0
 	}
-	shared := "discrete"
-	if hw.UnifiedMemory {
-		shared = "unified"
-	}
-	return fmt.Sprintf("%s/%s/%dg/%s", strings.ToLower(hw.OS), strings.ToLower(hw.Arch), gb, shared)
+	return (bytes + (1<<30 - 1)) >> 30
 }
 
 func recommendationFeedback(st *state.DB, task, query, hardwareKey string) (map[string]recommend.Feedback, error) {

--- a/cmd/modfetch/recommend_cmd_test.go
+++ b/cmd/modfetch/recommend_cmd_test.go
@@ -89,8 +89,18 @@ func TestRecommendationHardwareKey(t *testing.T) {
 		RAMBytes:      127<<30 + 1,
 		UnifiedMemory: true,
 	})
-	if got != "darwin/arm64/128g/unified" {
+	if got != "darwin/arm64/ram128g/unified" {
 		t.Fatalf("hardware key = %q", got)
+	}
+
+	got = recommendationHardwareKey(recommend.HardwareProfile{
+		OS:        "linux",
+		Arch:      "amd64",
+		RAMBytes:  64 << 30,
+		VRAMBytes: 8 << 30,
+	})
+	if got != "linux/amd64/vram8g-ram64g/discrete" {
+		t.Fatalf("discrete hardware key = %q", got)
 	}
 }
 

--- a/cmd/modfetch/recommend_cmd_test.go
+++ b/cmd/modfetch/recommend_cmd_test.go
@@ -105,10 +105,17 @@ func TestRecommendationFeedbackFromHistory(t *testing.T) {
 		{Index: 1, Provider: discovery.ProviderHuggingFace, ModelID: "owner/selected", URI: "hf://owner/selected/model.gguf?rev=main", Score: 100, Fit: "excellent"},
 		{Index: 2, Provider: discovery.ProviderHuggingFace, ModelID: "owner/skipped", URI: "hf://owner/skipped/model.gguf?rev=main", Score: 90, Fit: "excellent"},
 	}
-	recordRecommendationHistory(db, "coding", "qwen coder gguf", "darwin/arm64/128g/unified", recs, "selected", 1)
-	recordRecommendationHistory(db, "coding", "qwen coder gguf", "darwin/arm64/128g/unified", recs, "skipped", 1)
+	if err := recordRecommendationHistory(db, "coding", "qwen coder gguf", "darwin/arm64/128g/unified", recs, "selected", 1); err != nil {
+		t.Fatalf("record selected history: %v", err)
+	}
+	if err := recordRecommendationHistory(db, "coding", "qwen coder gguf", "darwin/arm64/128g/unified", recs, "skipped", 1); err != nil {
+		t.Fatalf("record skipped history: %v", err)
+	}
 
-	feedback := recommendationFeedback(db, "coding", "qwen coder gguf", "darwin/arm64/128g/unified")
+	feedback, err := recommendationFeedback(db, "coding", "qwen coder gguf", "darwin/arm64/128g/unified")
+	if err != nil {
+		t.Fatalf("load feedback: %v", err)
+	}
 	selected := feedback[recommend.FeedbackKey("hf://owner/selected/model.gguf?rev=main")]
 	skipped := feedback[recommend.FeedbackKey("hf://owner/skipped/model.gguf?rev=main")]
 	if selected.Selected != 1 {

--- a/cmd/modfetch/recommend_cmd_test.go
+++ b/cmd/modfetch/recommend_cmd_test.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"math"
 	"testing"
+
+	"github.com/jxwalker/modfetch/internal/discovery"
+	"github.com/jxwalker/modfetch/internal/recommend"
+	"github.com/jxwalker/modfetch/internal/state"
 )
 
 func TestValidateGiBOverride(t *testing.T) {
@@ -28,5 +34,87 @@ func TestValidateGiBOverride(t *testing.T) {
 				t.Fatalf("validateGiBOverride(%g) err = %v, wantErr %v", tt.value, err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestRecommendHistoryListsRows(t *testing.T) {
+	cfgPath := writeBenchConfig(t)
+	cfg, _, err := loadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	db, err := state.Open(cfg)
+	if err != nil {
+		t.Fatalf("open state: %v", err)
+	}
+	if err := db.UpsertRecommendationHistory(state.RecommendationHistoryRow{
+		Task:        "chat",
+		Query:       "tiny gpt2",
+		Provider:    "huggingface",
+		ModelID:     "owner/model",
+		URI:         "hf://owner/model/model.bin?rev=main",
+		Action:      "selected",
+		Score:       42,
+		Fit:         "excellent",
+		HardwareKey: "darwin/arm64/128g/unified",
+	}); err != nil {
+		t.Fatalf("upsert recommendation history: %v", err)
+	}
+	_ = db.Close()
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = handleRecommend(context.Background(), []string{
+			"--config", cfgPath,
+			"--history",
+			"--json",
+		})
+	})
+	if runErr != nil {
+		t.Fatalf("recommend history: %v", runErr)
+	}
+	var rows []state.RecommendationHistoryRow
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("decode history: %v\n%s", err, out)
+	}
+	if len(rows) != 1 || rows[0].Action != "selected" || rows[0].URI != "hf://owner/model/model.bin?rev=main" {
+		t.Fatalf("history rows = %+v", rows)
+	}
+}
+
+func TestRecommendationHardwareKey(t *testing.T) {
+	got := recommendationHardwareKey(recommend.HardwareProfile{
+		OS:            "darwin",
+		Arch:          "arm64",
+		RAMBytes:      127<<30 + 1,
+		UnifiedMemory: true,
+	})
+	if got != "darwin/arm64/128g/unified" {
+		t.Fatalf("hardware key = %q", got)
+	}
+}
+
+func TestRecommendationFeedbackFromHistory(t *testing.T) {
+	db, err := state.NewDB(t.TempDir() + "/state.db")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	recs := []recommend.Recommendation{
+		{Index: 1, Provider: discovery.ProviderHuggingFace, ModelID: "owner/selected", URI: "hf://owner/selected/model.gguf?rev=main", Score: 100, Fit: "excellent"},
+		{Index: 2, Provider: discovery.ProviderHuggingFace, ModelID: "owner/skipped", URI: "hf://owner/skipped/model.gguf?rev=main", Score: 90, Fit: "excellent"},
+	}
+	recordRecommendationHistory(db, "coding", "qwen coder gguf", "darwin/arm64/128g/unified", recs, "selected", 1)
+	recordRecommendationHistory(db, "coding", "qwen coder gguf", "darwin/arm64/128g/unified", recs, "skipped", 1)
+
+	feedback := recommendationFeedback(db, "coding", "qwen coder gguf", "darwin/arm64/128g/unified")
+	selected := feedback[recommend.FeedbackKey("hf://owner/selected/model.gguf?rev=main")]
+	skipped := feedback[recommend.FeedbackKey("hf://owner/skipped/model.gguf?rev=main")]
+	if selected.Selected != 1 {
+		t.Fatalf("selected feedback = %#v, want one selection", selected)
+	}
+	if skipped.Skipped != 1 {
+		t.Fatalf("skipped feedback = %#v, want one skip", skipped)
 	}
 }

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -202,7 +202,8 @@ such as `--config`, `--dest`, `--place`, `--dry-run`, `--quiet`, and
 Recommend concrete downloadable model files for the current machine, or for
 hardware you describe with RAM/VRAM overrides. Recommendations use live provider
 search, file metadata, inferred parameter counts and quantization names, task
-signals, and the detected memory budget.
+signals, the detected memory budget, persisted selection/skipping history, and
+runtime compatibility hints.
 
 ```bash
 modfetch recommend [QUERY] [OPTIONS]
@@ -219,6 +220,9 @@ modfetch recommend [QUERY] [OPTIONS]
 - `--select N` - 1-based recommendation number for `--download`
 - `--dest PATH`, `--place`, `--summary-json`, `--dry-run`, `--quiet`,
   `--no-resume` - forwarded to the selected download
+- `--history` - list persisted recommendation history instead of searching
+- `--history-limit N` - maximum history rows to show
+- `--no-learn` - ignore and avoid writing recommendation history
 - `--json` - emit the recommendation summary as JSON
 
 **Examples:**
@@ -231,7 +235,15 @@ modfetch recommend "llama 8b gguf" --ram-gb 32 --unified-memory --json
 
 # Select the top recommendation and show the exact download plan.
 modfetch recommend --task chat --download --select 1 --dry-run --summary-json
+
+# Inspect what modfetch has learned from prior recommendation runs.
+modfetch recommend --history
 ```
+
+Recommendation history is keyed by task, query, and a coarse hardware class, so
+choices made for a 128 GiB unified-memory Mac do not distort recommendations for
+a smaller discrete-GPU host. The history is advisory: it adjusts score ordering
+but does not hide live provider results.
 
 ### starter
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -243,8 +243,9 @@ The dry run shows the selected resolver URI, destination, remote size, range
 support, and auth state before any file is written.
 
 Recommendation output also shows likely runtimes and placement presets. After
-you select or skip results a few times, modfetch records that local preference
-history and uses it to adjust future ranking for the same task and hardware:
+you select or skip results a few times, modfetch records local preference
+history keyed by the same task, query, and hardware class, then uses that
+history to adjust future ranking for that same scope:
 
 ```bash
 modfetch recommend --history

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -242,6 +242,14 @@ modfetch recommend --task chat --download --select 1 --dry-run
 The dry run shows the selected resolver URI, destination, remote size, range
 support, and auth state before any file is written.
 
+Recommendation output also shows likely runtimes and placement presets. After
+you select or skip results a few times, modfetch records that local preference
+history and uses it to adjust future ranking for the same task and hardware:
+
+```bash
+modfetch recommend --history
+```
+
 Starter IDs also work in the TUI and regular download command as
 `starter://ID`, for example `starter://gpt2-tokenizer`.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,8 +29,8 @@ Shipped baseline:
   constraints, rank live provider results by task and memory fit, and hand the
   selected URI to the same resumable download path.
 - Recommendation history and runtime hints, so repeated choices for the same
-  task/query/hardware class influence ranking and recommendation output explains
-  likely local runtimes and placement presets.
+  task, query, and hardware class influence ranking, and recommendation output
+  explains likely local runtimes and placement presets.
 
 ## v0.7.0 Goal [DONE]
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,6 +28,9 @@ Shipped baseline:
 - Hardware-aware recommendation commands that detect or accept RAM/VRAM
   constraints, rank live provider results by task and memory fit, and hand the
   selected URI to the same resumable download path.
+- Recommendation history and runtime hints, so repeated choices for the same
+  task/query/hardware class influence ranking and recommendation output explains
+  likely local runtimes and placement presets.
 
 ## v0.7.0 Goal [DONE]
 
@@ -173,14 +176,14 @@ These are useful, but not required for the first v0.7.0 release:
 
 ## v0.8.x Direction
 
-- [NEXT] Recommendation quality feedback loop:
+- [DONE] Recommendation quality feedback loop:
   persist accepted/skipped recommendations, benchmark results, and completed
   download outcomes so future recommendations learn from real local use.
-- [PLANNED] Runtime-aware guidance:
+- [DONE] Runtime-aware guidance:
   expose placement/runtime hints for Ollama, llama.cpp, MLX, ComfyUI, and
   Stable Diffusion UIs so recommendation output explains where a model can run,
   not just whether it can be downloaded.
-- [PLANNED] Interactive recommendation flow in the TUI:
+- [NEXT] Interactive recommendation flow in the TUI:
   add a guided "choose a model" workflow that filters by task, hardware, file
   size, source, and placement target before starting a download.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -68,7 +68,9 @@ modfetch download --config ~/.config/modfetch/config.yml \
 If you do not know which repo or quantization to choose, start with
 `recommend`. It detects the current machine, searches live providers, estimates
 memory fit from file size, parameter count, and quantization metadata, and shows
-the command it would use to download each result.
+the command it would use to download each result. The output also includes
+runtime hints, such as llama.cpp/Ollama for GGUF files or ComfyUI/Stable
+Diffusion WebUI for image safetensors.
 
 ```bash
 modfetch recommend --task chat
@@ -89,6 +91,15 @@ modfetch recommend --task coding --download --select 1
 Use `--dry-run --summary-json` first when you want to verify the selected URI,
 destination, remote size, range support, and attached auth state without writing
 files.
+
+modfetch remembers selected and skipped recommendations per task, query, and
+hardware class. That history nudges future ranking without hiding fresh provider
+results:
+
+```bash
+modfetch recommend --history
+modfetch recommend --task coding --no-learn
+```
 
 #### Dry-run planning
 

--- a/internal/recommend/recommend.go
+++ b/internal/recommend/recommend.go
@@ -161,15 +161,7 @@ func ApplyFeedback(recs []Recommendation, feedback map[string]Feedback) {
 			recs[i].Reasons = append(recs[i].Reasons, fmt.Sprintf("previously skipped %d time(s)", fb.Skipped))
 		}
 	}
-	sort.SliceStable(recs, func(i, j int) bool {
-		if recs[i].Score != recs[j].Score {
-			return recs[i].Score > recs[j].Score
-		}
-		if recs[i].Fit != recs[j].Fit {
-			return fitRank(recs[i].Fit) > fitRank(recs[j].Fit)
-		}
-		return recs[i].Downloads > recs[j].Downloads
-	})
+	sort.SliceStable(recs, func(i, j int) bool { return betterRecommendation(recs[i], recs[j]) })
 	for i := range recs {
 		recs[i].Index = i + 1
 	}
@@ -189,15 +181,7 @@ func Rank(results []discovery.Result, hw HardwareProfile, task string) []Recomme
 		}
 		out = append(out, rec)
 	}
-	sort.SliceStable(out, func(i, j int) bool {
-		if out[i].Score != out[j].Score {
-			return out[i].Score > out[j].Score
-		}
-		if out[i].Fit != out[j].Fit {
-			return fitRank(out[i].Fit) > fitRank(out[j].Fit)
-		}
-		return out[i].Downloads > out[j].Downloads
-	})
+	sort.SliceStable(out, func(i, j int) bool { return betterRecommendation(out[i], out[j]) })
 	for i := range out {
 		out[i].Index = i + 1
 	}
@@ -217,6 +201,16 @@ func NormalizeTask(task string) string {
 	default:
 		return strings.ToLower(strings.TrimSpace(task))
 	}
+}
+
+func betterRecommendation(a, b Recommendation) bool {
+	if a.Score != b.Score {
+		return a.Score > b.Score
+	}
+	if a.Fit != b.Fit {
+		return fitRank(a.Fit) > fitRank(b.Fit)
+	}
+	return a.Downloads > b.Downloads
 }
 
 func DefaultQuery(task string) string {
@@ -309,14 +303,14 @@ func scoreResult(result discovery.Result, hw HardwareProfile, task string) Recom
 		MemoryBudget:      budget,
 		ParameterCount:    params,
 		Quantization:      quant,
-		RuntimeHints:      runtimeHints(result, task),
+		RuntimeHints:      runtimeHints(result, task, hw),
 		Reasons:           reasons,
 		DownloadCommand:   "modfetch download --url " + strconv.Quote(result.URI) + " --profile auto",
 		Raw:               result,
 	}
 }
 
-func runtimeHints(result discovery.Result, task string) []RuntimeHint {
+func runtimeHints(result discovery.Result, task string, hw HardwareProfile) []RuntimeHint {
 	ext := strings.ToLower(strings.TrimPrefix(result.FileType, "."))
 	if ext == "" {
 		name := strings.ToLower(firstNonEmpty(result.FileName, result.FilePath))
@@ -338,11 +332,14 @@ func runtimeHints(result discovery.Result, task string) []RuntimeHint {
 				{Runtime: "AUTOMATIC1111/Forge", Reason: "safetensors image artifacts are supported by Stable Diffusion WebUI layouts", PlacementPreset: "automatic1111"},
 			}
 		}
-		return []RuntimeHint{
+		hints := []RuntimeHint{
 			{Runtime: "Transformers", Reason: "safetensors is the preferred safe weight format for Transformers models", PlacementPreset: "hf-cache"},
-			{Runtime: "MLX", Reason: "many Hugging Face safetensors language models can be converted for Apple Silicon with mlx-lm", SetupCommand: "mlx_lm.convert --hf-path REPO --mlx-path OUT"},
 			{Runtime: "vLLM", Reason: "many safetensors causal language models can be served by vLLM"},
 		}
+		if hw.OS == "darwin" && hw.Arch == "arm64" {
+			hints = append(hints, RuntimeHint{Runtime: "MLX", Reason: "many Hugging Face safetensors language models can be converted for Apple Silicon with mlx-lm", SetupCommand: "mlx_lm.convert --hf-path REPO --mlx-path OUT"})
+		}
+		return hints
 	case "bin", "pt", "pth":
 		return []RuntimeHint{
 			{Runtime: "Transformers", Reason: "PyTorch-format weights usually require a Transformers-compatible repo layout", PlacementPreset: "hf-cache"},

--- a/internal/recommend/recommend.go
+++ b/internal/recommend/recommend.go
@@ -162,9 +162,6 @@ func ApplyFeedback(recs []Recommendation, feedback map[string]Feedback) {
 		}
 	}
 	sort.SliceStable(recs, func(i, j int) bool { return betterRecommendation(recs[i], recs[j]) })
-	for i := range recs {
-		recs[i].Index = i + 1
-	}
 }
 
 func FeedbackKey(uri string) string {

--- a/internal/recommend/recommend.go
+++ b/internal/recommend/recommend.go
@@ -31,6 +31,20 @@ type Options struct {
 	Provider string
 	Limit    int
 	Hardware HardwareProfile
+	Feedback map[string]Feedback
+}
+
+type Feedback struct {
+	Selected int
+	Skipped  int
+	Shown    int
+}
+
+type RuntimeHint struct {
+	Runtime         string `json:"runtime"`
+	Reason          string `json:"reason"`
+	PlacementPreset string `json:"placement_preset,omitempty"`
+	SetupCommand    string `json:"setup_command,omitempty"`
 }
 
 type Recommendation struct {
@@ -50,6 +64,7 @@ type Recommendation struct {
 	MemoryBudget      int64            `json:"memory_budget_bytes,omitempty"`
 	ParameterCount    string           `json:"parameter_count,omitempty"`
 	Quantization      string           `json:"quantization,omitempty"`
+	RuntimeHints      []RuntimeHint    `json:"runtime_hints,omitempty"`
 	Reasons           []string         `json:"reasons,omitempty"`
 	DownloadCommand   string           `json:"download_command"`
 	Raw               discovery.Result `json:"raw,omitempty"`
@@ -107,6 +122,7 @@ func Recommend(ctx context.Context, opts Options) ([]Recommendation, HardwarePro
 		return nil, hw, err
 	}
 	ranked := Rank(results, hw, task)
+	ApplyFeedback(ranked, opts.Feedback)
 	if len(ranked) > limit {
 		ranked = ranked[:limit]
 	}
@@ -114,6 +130,53 @@ func Recommend(ctx context.Context, opts Options) ([]Recommendation, HardwarePro
 		ranked[i].Index = i + 1
 	}
 	return ranked, hw, nil
+}
+
+func ApplyFeedback(recs []Recommendation, feedback map[string]Feedback) {
+	if len(recs) == 0 || len(feedback) == 0 {
+		return
+	}
+	for i := range recs {
+		fb, ok := feedback[FeedbackKey(recs[i].URI)]
+		if !ok {
+			continue
+		}
+		delta := fb.Selected*18 - fb.Skipped*10
+		if delta > 54 {
+			delta = 54
+		}
+		if delta < -40 {
+			delta = -40
+		}
+		if delta == 0 && fb.Shown > 0 {
+			delta = -2
+		}
+		recs[i].Score += delta
+		switch {
+		case fb.Selected > 0 && fb.Skipped > 0:
+			recs[i].Reasons = append(recs[i].Reasons, fmt.Sprintf("learned from prior selections (%d selected, %d skipped)", fb.Selected, fb.Skipped))
+		case fb.Selected > 0:
+			recs[i].Reasons = append(recs[i].Reasons, fmt.Sprintf("learned from %d prior selection(s)", fb.Selected))
+		case fb.Skipped > 0:
+			recs[i].Reasons = append(recs[i].Reasons, fmt.Sprintf("previously skipped %d time(s)", fb.Skipped))
+		}
+	}
+	sort.SliceStable(recs, func(i, j int) bool {
+		if recs[i].Score != recs[j].Score {
+			return recs[i].Score > recs[j].Score
+		}
+		if recs[i].Fit != recs[j].Fit {
+			return fitRank(recs[i].Fit) > fitRank(recs[j].Fit)
+		}
+		return recs[i].Downloads > recs[j].Downloads
+	})
+	for i := range recs {
+		recs[i].Index = i + 1
+	}
+}
+
+func FeedbackKey(uri string) string {
+	return strings.TrimSpace(uri)
 }
 
 func Rank(results []discovery.Result, hw HardwareProfile, task string) []Recommendation {
@@ -246,9 +309,50 @@ func scoreResult(result discovery.Result, hw HardwareProfile, task string) Recom
 		MemoryBudget:      budget,
 		ParameterCount:    params,
 		Quantization:      quant,
+		RuntimeHints:      runtimeHints(result, task),
 		Reasons:           reasons,
 		DownloadCommand:   "modfetch download --url " + strconv.Quote(result.URI) + " --profile auto",
 		Raw:               result,
+	}
+}
+
+func runtimeHints(result discovery.Result, task string) []RuntimeHint {
+	ext := strings.ToLower(strings.TrimPrefix(result.FileType, "."))
+	if ext == "" {
+		name := strings.ToLower(firstNonEmpty(result.FileName, result.FilePath))
+		if dot := strings.LastIndexByte(name, '.'); dot >= 0 {
+			ext = strings.TrimPrefix(name[dot:], ".")
+		}
+	}
+	switch ext {
+	case "gguf":
+		return []RuntimeHint{
+			{Runtime: "llama.cpp", Reason: "GGUF is directly runnable by llama.cpp-style runtimes", PlacementPreset: "hf-cache"},
+			{Runtime: "Ollama", Reason: "GGUF can be imported with a Modelfile", PlacementPreset: "ollama", SetupCommand: "ollama create NAME -f Modelfile"},
+			{Runtime: "LM Studio", Reason: "LM Studio can load local GGUF files"},
+		}
+	case "safetensors":
+		if NormalizeTask(task) == "image" || containsAny(strings.ToLower(strings.Join(result.Tags, " ")), "diffusion", "sdxl", "lora") {
+			return []RuntimeHint{
+				{Runtime: "ComfyUI", Reason: "safetensors image checkpoints and LoRAs belong under ComfyUI model folders", PlacementPreset: "comfyui"},
+				{Runtime: "AUTOMATIC1111/Forge", Reason: "safetensors image artifacts are supported by Stable Diffusion WebUI layouts", PlacementPreset: "automatic1111"},
+			}
+		}
+		return []RuntimeHint{
+			{Runtime: "Transformers", Reason: "safetensors is the preferred safe weight format for Transformers models", PlacementPreset: "hf-cache"},
+			{Runtime: "MLX", Reason: "many Hugging Face safetensors language models can be converted for Apple Silicon with mlx-lm", SetupCommand: "mlx_lm.convert --hf-path REPO --mlx-path OUT"},
+			{Runtime: "vLLM", Reason: "many safetensors causal language models can be served by vLLM"},
+		}
+	case "bin", "pt", "pth":
+		return []RuntimeHint{
+			{Runtime: "Transformers", Reason: "PyTorch-format weights usually require a Transformers-compatible repo layout", PlacementPreset: "hf-cache"},
+		}
+	case "onnx":
+		return []RuntimeHint{
+			{Runtime: "ONNX Runtime", Reason: "ONNX artifacts are designed for ONNX Runtime inference"},
+		}
+	default:
+		return nil
 	}
 }
 

--- a/internal/recommend/recommend_test.go
+++ b/internal/recommend/recommend_test.go
@@ -168,6 +168,29 @@ func TestRuntimeHintsForImageSafetensors(t *testing.T) {
 	}
 }
 
+func TestRuntimeHintsForSafetensorsAreHardwareAware(t *testing.T) {
+	result := discovery.Result{
+		Provider: discovery.ProviderHuggingFace,
+		ModelID:  "acme/llm",
+		Name:     "LLM",
+		FileName: "model.safetensors",
+		FileType: "safetensors",
+		URI:      "hf://acme/llm/model.safetensors?rev=main",
+	}
+
+	linux := Rank([]discovery.Result{result}, HardwareProfile{OS: "linux", Arch: "amd64", VRAMBytes: 24 << 30}, "chat")
+	for _, hint := range linux[0].RuntimeHints {
+		if hint.Runtime == "MLX" {
+			t.Fatalf("linux runtime hints include MLX: %#v", linux[0].RuntimeHints)
+		}
+	}
+
+	darwin := Rank([]discovery.Result{result}, HardwareProfile{OS: "darwin", Arch: "arm64", RAMBytes: 64 << 30, UnifiedMemory: true}, "chat")
+	if !hasRuntimeHint(darwin[0].RuntimeHints, "MLX") {
+		t.Fatalf("darwin runtime hints = %#v, want MLX", darwin[0].RuntimeHints)
+	}
+}
+
 func TestDefaultQueryForTask(t *testing.T) {
 	if got := DefaultQuery("coding"); !strings.Contains(got, "coder") {
 		t.Fatalf("coding default query = %q", got)
@@ -175,4 +198,13 @@ func TestDefaultQueryForTask(t *testing.T) {
 	if got := NormalizeTask("code"); got != "coding" {
 		t.Fatalf("NormalizeTask(code) = %q, want coding", got)
 	}
+}
+
+func hasRuntimeHint(hints []RuntimeHint, runtime string) bool {
+	for _, hint := range hints {
+		if hint.Runtime == runtime {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/recommend/recommend_test.go
+++ b/internal/recommend/recommend_test.go
@@ -69,6 +69,9 @@ func TestRankInfersQuantizationAndParams(t *testing.T) {
 	if !strings.Contains(ranked[0].DownloadCommand, "modfetch download --url") {
 		t.Fatalf("missing download command: %q", ranked[0].DownloadCommand)
 	}
+	if len(ranked[0].RuntimeHints) == 0 || ranked[0].RuntimeHints[0].Runtime != "llama.cpp" {
+		t.Fatalf("runtime hints = %#v, want llama.cpp first", ranked[0].RuntimeHints)
+	}
 }
 
 func TestRankDemotesSplitShards(t *testing.T) {
@@ -103,6 +106,65 @@ func TestRankDemotesSplitShards(t *testing.T) {
 	}
 	if !strings.Contains(strings.Join(ranked[1].Reasons, " "), "multi-part shard") {
 		t.Fatalf("missing shard reason: %#v", ranked[1].Reasons)
+	}
+}
+
+func TestApplyFeedbackBoostsPriorSelections(t *testing.T) {
+	ranked := Rank([]discovery.Result{
+		{
+			Provider:  discovery.ProviderHuggingFace,
+			ModelID:   "acme/first",
+			Name:      "First 7B Instruct",
+			FileName:  "first-7b.Q4_K_M.gguf",
+			FileType:  "gguf",
+			Size:      5 << 30,
+			Downloads: 500000,
+			URI:       "hf://acme/first/first-7b.Q4_K_M.gguf?rev=main",
+		},
+		{
+			Provider:  discovery.ProviderHuggingFace,
+			ModelID:   "acme/second",
+			Name:      "Second 7B Instruct",
+			FileName:  "second-7b.Q4_K_M.gguf",
+			FileType:  "gguf",
+			Size:      5 << 30,
+			Downloads: 1000,
+			URI:       "hf://acme/second/second-7b.Q4_K_M.gguf?rev=main",
+		},
+	}, HardwareProfile{RAMBytes: 32 << 30, UnifiedMemory: true}, "chat")
+
+	if ranked[0].ModelID != "acme/first" {
+		t.Fatalf("initial top = %s, want first", ranked[0].ModelID)
+	}
+	ApplyFeedback(ranked, map[string]Feedback{
+		FeedbackKey("hf://acme/first/first-7b.Q4_K_M.gguf?rev=main"):   {Skipped: 4},
+		FeedbackKey("hf://acme/second/second-7b.Q4_K_M.gguf?rev=main"): {Selected: 3},
+	})
+	if ranked[0].ModelID != "acme/second" {
+		t.Fatalf("feedback top = %s, want second", ranked[0].ModelID)
+	}
+	if !strings.Contains(strings.Join(ranked[0].Reasons, " "), "prior selection") {
+		t.Fatalf("missing feedback reason: %#v", ranked[0].Reasons)
+	}
+}
+
+func TestRuntimeHintsForImageSafetensors(t *testing.T) {
+	ranked := Rank([]discovery.Result{{
+		Provider: discovery.ProviderHuggingFace,
+		ModelID:  "acme/sdxl",
+		Name:     "SDXL Checkpoint",
+		FileName: "sdxl.safetensors",
+		FileType: "safetensors",
+		Tags:     []string{"stable-diffusion", "sdxl"},
+		Size:     6 << 30,
+		URI:      "hf://acme/sdxl/sdxl.safetensors?rev=main",
+	}}, HardwareProfile{VRAMBytes: 24 << 30}, "image")
+
+	if len(ranked) != 1 {
+		t.Fatalf("ranked len = %d, want 1", len(ranked))
+	}
+	if len(ranked[0].RuntimeHints) == 0 || ranked[0].RuntimeHints[0].Runtime != "ComfyUI" {
+		t.Fatalf("runtime hints = %#v, want ComfyUI first", ranked[0].RuntimeHints)
 	}
 }
 

--- a/internal/state/recommendation_history.go
+++ b/internal/state/recommendation_history.go
@@ -45,7 +45,6 @@ func (db *DB) InitRecommendationHistoryTable() error {
 		updated_at INTEGER NOT NULL,
 		UNIQUE(task, query, uri, action, hardware_key)
 	);
-	CREATE INDEX IF NOT EXISTS idx_recommendation_history_lookup ON recommendation_history(task, query, uri, hardware_key);
 	CREATE INDEX IF NOT EXISTS idx_recommendation_history_lookup_by_hardware ON recommendation_history(task, query, hardware_key, updated_at DESC);
 	CREATE INDEX IF NOT EXISTS idx_recommendation_history_updated_at ON recommendation_history(updated_at);`)
 	return err

--- a/internal/state/recommendation_history.go
+++ b/internal/state/recommendation_history.go
@@ -1,0 +1,164 @@
+package state
+
+import (
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+)
+
+type RecommendationHistoryRow struct {
+	Task         string `json:"task"`
+	Query        string `json:"query"`
+	Provider     string `json:"provider"`
+	ModelID      string `json:"model_id"`
+	URI          string `json:"uri"`
+	Action       string `json:"action"`
+	Score        int    `json:"score"`
+	Fit          string `json:"fit"`
+	HardwareKey  string `json:"hardware_key"`
+	Count        int    `json:"count"`
+	LastSelected int64  `json:"last_selected,omitempty"`
+	LastSkipped  int64  `json:"last_skipped,omitempty"`
+	LastShown    int64  `json:"last_shown,omitempty"`
+	UpdatedAt    int64  `json:"updated_at"`
+}
+
+func (db *DB) InitRecommendationHistoryTable() error {
+	if db == nil || db.SQL == nil {
+		return errors.New("nil db")
+	}
+	_, err := db.SQL.Exec(`CREATE TABLE IF NOT EXISTS recommendation_history (
+		task TEXT NOT NULL,
+		query TEXT NOT NULL,
+		provider TEXT NOT NULL,
+		model_id TEXT NOT NULL,
+		uri TEXT NOT NULL,
+		action TEXT NOT NULL,
+		score INTEGER NOT NULL,
+		fit TEXT NOT NULL,
+		hardware_key TEXT NOT NULL,
+		count INTEGER NOT NULL DEFAULT 1,
+		last_selected INTEGER,
+		last_skipped INTEGER,
+		last_shown INTEGER,
+		updated_at INTEGER NOT NULL,
+		UNIQUE(task, query, uri, action, hardware_key)
+	);
+	CREATE INDEX IF NOT EXISTS idx_recommendation_history_lookup ON recommendation_history(task, query, uri, hardware_key);
+	CREATE INDEX IF NOT EXISTS idx_recommendation_history_updated_at ON recommendation_history(updated_at);`)
+	return err
+}
+
+func (db *DB) UpsertRecommendationHistory(row RecommendationHistoryRow) error {
+	if db == nil || db.SQL == nil {
+		return errors.New("nil db")
+	}
+	row.Task = strings.ToLower(strings.TrimSpace(row.Task))
+	row.Query = strings.TrimSpace(row.Query)
+	row.Provider = strings.ToLower(strings.TrimSpace(row.Provider))
+	row.ModelID = strings.TrimSpace(row.ModelID)
+	row.URI = strings.TrimSpace(row.URI)
+	row.Action = strings.ToLower(strings.TrimSpace(row.Action))
+	row.Fit = strings.ToLower(strings.TrimSpace(row.Fit))
+	row.HardwareKey = strings.ToLower(strings.TrimSpace(row.HardwareKey))
+	if row.Task == "" || row.Query == "" || row.URI == "" || row.Action == "" || row.HardwareKey == "" {
+		return errors.New("recommendation history task, query, uri, action, and hardware key required")
+	}
+	if row.Provider == "" {
+		row.Provider = "unknown"
+	}
+	if row.Fit == "" {
+		row.Fit = "unknown"
+	}
+	if row.Count <= 0 {
+		row.Count = 1
+	}
+	now := time.Now().Unix()
+	switch row.Action {
+	case "selected":
+		row.LastSelected = now
+	case "skipped":
+		row.LastSkipped = now
+	default:
+		row.Action = "shown"
+		row.LastShown = now
+	}
+	_, err := db.SQL.Exec(`INSERT INTO recommendation_history(task, query, provider, model_id, uri, action, score, fit, hardware_key, count, last_selected, last_skipped, last_shown, updated_at)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		ON CONFLICT(task, query, uri, action, hardware_key) DO UPDATE SET
+			provider=excluded.provider,
+			model_id=excluded.model_id,
+			score=excluded.score,
+			fit=excluded.fit,
+			count=recommendation_history.count + excluded.count,
+			last_selected=COALESCE(excluded.last_selected, recommendation_history.last_selected),
+			last_skipped=COALESCE(excluded.last_skipped, recommendation_history.last_skipped),
+			last_shown=COALESCE(excluded.last_shown, recommendation_history.last_shown),
+			updated_at=excluded.updated_at`,
+		row.Task, row.Query, row.Provider, row.ModelID, row.URI, row.Action, row.Score, row.Fit, row.HardwareKey, row.Count, nullableUnix(row.LastSelected), nullableUnix(row.LastSkipped), nullableUnix(row.LastShown), now)
+	if err == nil {
+		db.NotifyChange()
+	}
+	return err
+}
+
+func (db *DB) RecommendationHistoryFor(task, query, hardwareKey string) ([]RecommendationHistoryRow, error) {
+	if db == nil || db.SQL == nil {
+		return nil, errors.New("nil db")
+	}
+	task = strings.ToLower(strings.TrimSpace(task))
+	query = strings.TrimSpace(query)
+	hardwareKey = strings.ToLower(strings.TrimSpace(hardwareKey))
+	if task == "" || query == "" || hardwareKey == "" {
+		return nil, nil
+	}
+	rows, err := db.SQL.Query(`SELECT task, query, provider, model_id, uri, action, score, fit, hardware_key, count,
+			COALESCE(last_selected, 0), COALESCE(last_skipped, 0), COALESCE(last_shown, 0), updated_at
+		FROM recommendation_history
+		WHERE task=? AND query=? AND hardware_key=?
+		ORDER BY updated_at DESC`, task, query, hardwareKey)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	return scanRecommendationHistory(rows)
+}
+
+func (db *DB) ListRecommendationHistory(limit int) ([]RecommendationHistoryRow, error) {
+	if db == nil || db.SQL == nil {
+		return nil, errors.New("nil db")
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := db.SQL.Query(`SELECT task, query, provider, model_id, uri, action, score, fit, hardware_key, count,
+			COALESCE(last_selected, 0), COALESCE(last_skipped, 0), COALESCE(last_shown, 0), updated_at
+		FROM recommendation_history
+		ORDER BY updated_at DESC
+		LIMIT ?`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	return scanRecommendationHistory(rows)
+}
+
+func scanRecommendationHistory(rows *sql.Rows) ([]RecommendationHistoryRow, error) {
+	var out []RecommendationHistoryRow
+	for rows.Next() {
+		var row RecommendationHistoryRow
+		if err := rows.Scan(&row.Task, &row.Query, &row.Provider, &row.ModelID, &row.URI, &row.Action, &row.Score, &row.Fit, &row.HardwareKey, &row.Count, &row.LastSelected, &row.LastSkipped, &row.LastShown, &row.UpdatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+func nullableUnix(v int64) any {
+	if v <= 0 {
+		return nil
+	}
+	return v
+}

--- a/internal/state/recommendation_history.go
+++ b/internal/state/recommendation_history.go
@@ -46,6 +46,7 @@ func (db *DB) InitRecommendationHistoryTable() error {
 		UNIQUE(task, query, uri, action, hardware_key)
 	);
 	CREATE INDEX IF NOT EXISTS idx_recommendation_history_lookup ON recommendation_history(task, query, uri, hardware_key);
+	CREATE INDEX IF NOT EXISTS idx_recommendation_history_lookup_by_hardware ON recommendation_history(task, query, hardware_key, updated_at DESC);
 	CREATE INDEX IF NOT EXISTS idx_recommendation_history_updated_at ON recommendation_history(updated_at);`)
 	return err
 }
@@ -54,6 +55,37 @@ func (db *DB) UpsertRecommendationHistory(row RecommendationHistoryRow) error {
 	if db == nil || db.SQL == nil {
 		return errors.New("nil db")
 	}
+	row, err := normalizeRecommendationHistoryRow(row, time.Now().Unix())
+	if err != nil {
+		return err
+	}
+	if err := upsertRecommendationHistory(db.SQL, row); err != nil {
+		return err
+	}
+	db.NotifyChange()
+	return nil
+}
+
+func (db *DB) BatchUpsertRecommendationHistory(rows []RecommendationHistoryRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	return db.WithTx(func(tx *sql.Tx) error {
+		now := time.Now().Unix()
+		for _, row := range rows {
+			normalized, err := normalizeRecommendationHistoryRow(row, now)
+			if err != nil {
+				return err
+			}
+			if err := upsertRecommendationHistory(tx, normalized); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func normalizeRecommendationHistoryRow(row RecommendationHistoryRow, now int64) (RecommendationHistoryRow, error) {
 	row.Task = strings.ToLower(strings.TrimSpace(row.Task))
 	row.Query = strings.TrimSpace(row.Query)
 	row.Provider = strings.ToLower(strings.TrimSpace(row.Provider))
@@ -63,7 +95,7 @@ func (db *DB) UpsertRecommendationHistory(row RecommendationHistoryRow) error {
 	row.Fit = strings.ToLower(strings.TrimSpace(row.Fit))
 	row.HardwareKey = strings.ToLower(strings.TrimSpace(row.HardwareKey))
 	if row.Task == "" || row.Query == "" || row.URI == "" || row.Action == "" || row.HardwareKey == "" {
-		return errors.New("recommendation history task, query, uri, action, and hardware key required")
+		return RecommendationHistoryRow{}, errors.New("recommendation history task, query, uri, action, and hardware key required")
 	}
 	if row.Provider == "" {
 		row.Provider = "unknown"
@@ -74,7 +106,6 @@ func (db *DB) UpsertRecommendationHistory(row RecommendationHistoryRow) error {
 	if row.Count <= 0 {
 		row.Count = 1
 	}
-	now := time.Now().Unix()
 	switch row.Action {
 	case "selected":
 		row.LastSelected = now
@@ -84,7 +115,16 @@ func (db *DB) UpsertRecommendationHistory(row RecommendationHistoryRow) error {
 		row.Action = "shown"
 		row.LastShown = now
 	}
-	_, err := db.SQL.Exec(`INSERT INTO recommendation_history(task, query, provider, model_id, uri, action, score, fit, hardware_key, count, last_selected, last_skipped, last_shown, updated_at)
+	row.UpdatedAt = now
+	return row, nil
+}
+
+type recommendationHistoryExecer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
+func upsertRecommendationHistory(exec recommendationHistoryExecer, row RecommendationHistoryRow) error {
+	_, err := exec.Exec(`INSERT INTO recommendation_history(task, query, provider, model_id, uri, action, score, fit, hardware_key, count, last_selected, last_skipped, last_shown, updated_at)
 		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 		ON CONFLICT(task, query, uri, action, hardware_key) DO UPDATE SET
 			provider=excluded.provider,
@@ -96,10 +136,7 @@ func (db *DB) UpsertRecommendationHistory(row RecommendationHistoryRow) error {
 			last_skipped=COALESCE(excluded.last_skipped, recommendation_history.last_skipped),
 			last_shown=COALESCE(excluded.last_shown, recommendation_history.last_shown),
 			updated_at=excluded.updated_at`,
-		row.Task, row.Query, row.Provider, row.ModelID, row.URI, row.Action, row.Score, row.Fit, row.HardwareKey, row.Count, nullableUnix(row.LastSelected), nullableUnix(row.LastSkipped), nullableUnix(row.LastShown), now)
-	if err == nil {
-		db.NotifyChange()
-	}
+		row.Task, row.Query, row.Provider, row.ModelID, row.URI, row.Action, row.Score, row.Fit, row.HardwareKey, row.Count, nullableUnix(row.LastSelected), nullableUnix(row.LastSkipped), nullableUnix(row.LastShown), row.UpdatedAt)
 	return err
 }
 

--- a/internal/state/recommendation_history_test.go
+++ b/internal/state/recommendation_history_test.go
@@ -31,13 +31,18 @@ func TestRecommendationHistoryUpsertListAndLookup(t *testing.T) {
 	if err := db.UpsertRecommendationHistory(row); err != nil {
 		t.Fatalf("upsert skipped: %v", err)
 	}
+	row.Action = "shown"
+	row.URI = "hf://owner/shown/shown.gguf?rev=main"
+	if err := db.BatchUpsertRecommendationHistory([]RecommendationHistoryRow{row}); err != nil {
+		t.Fatalf("batch upsert shown: %v", err)
+	}
 
 	lookup, err := db.RecommendationHistoryFor("coding", "qwen coder gguf", "darwin/arm64/128g/unified")
 	if err != nil {
 		t.Fatalf("lookup: %v", err)
 	}
-	if len(lookup) != 2 {
-		t.Fatalf("lookup len = %d, want 2", len(lookup))
+	if len(lookup) != 3 {
+		t.Fatalf("lookup len = %d, want 3", len(lookup))
 	}
 	var selected RecommendationHistoryRow
 	for _, got := range lookup {

--- a/internal/state/recommendation_history_test.go
+++ b/internal/state/recommendation_history_test.go
@@ -1,0 +1,59 @@
+package state
+
+import "testing"
+
+func TestRecommendationHistoryUpsertListAndLookup(t *testing.T) {
+	db, err := NewDB(t.TempDir() + "/state.db")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	row := RecommendationHistoryRow{
+		Task:        "coding",
+		Query:       "qwen coder gguf",
+		Provider:    "huggingface",
+		ModelID:     "owner/model",
+		URI:         "hf://owner/model/model.gguf?rev=main",
+		Action:      "selected",
+		Score:       100,
+		Fit:         "excellent",
+		HardwareKey: "darwin/arm64/128g/unified",
+	}
+	if err := db.UpsertRecommendationHistory(row); err != nil {
+		t.Fatalf("upsert selected: %v", err)
+	}
+	if err := db.UpsertRecommendationHistory(row); err != nil {
+		t.Fatalf("upsert selected again: %v", err)
+	}
+	row.Action = "skipped"
+	row.URI = "hf://owner/other/other.gguf?rev=main"
+	if err := db.UpsertRecommendationHistory(row); err != nil {
+		t.Fatalf("upsert skipped: %v", err)
+	}
+
+	lookup, err := db.RecommendationHistoryFor("coding", "qwen coder gguf", "darwin/arm64/128g/unified")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if len(lookup) != 2 {
+		t.Fatalf("lookup len = %d, want 2", len(lookup))
+	}
+	var selected RecommendationHistoryRow
+	for _, got := range lookup {
+		if got.Action == "selected" {
+			selected = got
+		}
+	}
+	if selected.Count != 2 || selected.LastSelected == 0 {
+		t.Fatalf("selected row = %#v, want count 2 and last_selected", selected)
+	}
+
+	listed, err := db.ListRecommendationHistory(1)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("listed len = %d, want 1", len(listed))
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -161,6 +161,9 @@ func openAtPath(path string) (*DB, error) {
 	if err := db.InitTransferHistoryTable(); err != nil {
 		return nil, err
 	}
+	if err := db.InitRecommendationHistoryTable(); err != nil {
+		return nil, err
+	}
 	ready = true
 	return db, nil
 }


### PR DESCRIPTION
## Summary
- persist recommendation history for shown, selected, and skipped model candidates
- use task/query/hardware-specific history to boost prior selections and demote skipped results
- add runtime and placement hints to recommendation output and JSON
- document `recommend --history`, `--history-limit`, `--no-learn`, and the remaining TUI selector roadmap item

## Validation
- `go test -count=1 ./...`
- `make lint`
- `scripts/check-docs-drift.sh && git diff --check`
- `make build`
- `bin/modfetch recommend "sshleifer tiny gpt2" --limit 1 --json`
- `bin/modfetch recommend --history --history-limit 3 --json`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->