### PR TITLE
chore: update package metadata for v0.8.0

### DIFF
--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = modfetch-bin
 	pkgdesc = Robust CLI/TUI downloader for LLM and Stable Diffusion assets
-	pkgver = 0.7.1
+	pkgver = 0.8.0
 	pkgrel = 1
 	url = https://github.com/jxwalker/modfetch
 	arch = x86_64
@@ -8,11 +8,11 @@ pkgbase = modfetch-bin
 	license = MIT
 	provides = modfetch
 	conflicts = modfetch
-	source = LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v0.7.1/LICENSE
+	source = LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v0.8.0/LICENSE
 	sha256sums = 73be8e0a20ff3b0a6991d6405d4d485e5ffc8dfb07a13a1f1b7afb081f57ee54
-	source_x86_64 = modfetch-0.7.1-linux-amd64::https://github.com/jxwalker/modfetch/releases/download/v0.7.1/modfetch_linux_amd64
-	sha256sums_x86_64 = c7db15650986c32cf4b1550699e624a929e21b926194a2523896fbacec95276c
-	source_aarch64 = modfetch-0.7.1-linux-arm64::https://github.com/jxwalker/modfetch/releases/download/v0.7.1/modfetch_linux_arm64
-	sha256sums_aarch64 = 893e51802932381bc14d472d94002813c491c5170f14e50573e0b30cf873c868
+	source_x86_64 = modfetch-0.8.0-linux-amd64::https://github.com/jxwalker/modfetch/releases/download/v0.8.0/modfetch_linux_amd64
+	sha256sums_x86_64 = a7bbfb6ce482b91ab1a93eb3b3aa9618b1e61b943e078bf84befc0e3114c5e2a
+	source_aarch64 = modfetch-0.8.0-linux-arm64::https://github.com/jxwalker/modfetch/releases/download/v0.8.0/modfetch_linux_arm64
+	sha256sums_aarch64 = 063f70619266d9a89ebf9178f412a50ae757977f9615d1fb8c3faa2e6771e150
 
 pkgname = modfetch-bin

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: James Walker <james@jameswalker.org.uk>
 pkgname=modfetch-bin
 _pkgname=modfetch
-pkgver=0.7.1
+pkgver=0.8.0
 pkgrel=1
 pkgdesc="Robust CLI/TUI downloader for LLM and Stable Diffusion assets"
 arch=('x86_64' 'aarch64')
@@ -14,10 +14,10 @@ source=("LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v${pkgver}
 sha256sums=('73be8e0a20ff3b0a6991d6405d4d485e5ffc8dfb07a13a1f1b7afb081f57ee54')
 
 source_x86_64=("${_pkgname}-${pkgver}-linux-amd64::https://github.com/jxwalker/modfetch/releases/download/v${pkgver}/${_pkgname}_linux_amd64")
-sha256sums_x86_64=('c7db15650986c32cf4b1550699e624a929e21b926194a2523896fbacec95276c')
+sha256sums_x86_64=('a7bbfb6ce482b91ab1a93eb3b3aa9618b1e61b943e078bf84befc0e3114c5e2a')
 
 source_aarch64=("${_pkgname}-${pkgver}-linux-arm64::https://github.com/jxwalker/modfetch/releases/download/v${pkgver}/${_pkgname}_linux_arm64")
-sha256sums_aarch64=('893e51802932381bc14d472d94002813c491c5170f14e50573e0b30cf873c868')
+sha256sums_aarch64=('063f70619266d9a89ebf9178f412a50ae757977f9615d1fb8c3faa2e6771e150')
 
 package() {
   local binary

--- a/packaging/homebrew/modfetch.rb
+++ b/packaging/homebrew/modfetch.rb
@@ -1,25 +1,25 @@
 class Modfetch < Formula
   desc "Robust CLI/TUI downloader for LLM and Stable Diffusion assets"
   homepage "https://github.com/jxwalker/modfetch"
-  version "0.7.1"
+  version "0.8.0"
   on_macos do
     on_arm do
       url "https://github.com/jxwalker/modfetch/releases/download/v#{version}/modfetch_darwin_arm64"
-      sha256 "9b1eb0498197e10616c13996839aba4648800f4ac9d6ed8f17bdc9c4a54ca464"
+      sha256 "9561c974403b7c24cdbbf7d61bdffee8cbf98c2e7eec0078dd0f7b04627348bc"
     end
     on_intel do
       url "https://github.com/jxwalker/modfetch/releases/download/v#{version}/modfetch_darwin_amd64"
-      sha256 "174f34693fcae4476633d3c670a8f3366f3002baa15ea1ad6882d3f25ede1e6b"
+      sha256 "90b390ee9f1d9a9fa0ec712c1e5d7d07ce5efc2462cd3975ff1077a3c7acf2e1"
     end
   end
   on_linux do
     on_arm do
       url "https://github.com/jxwalker/modfetch/releases/download/v#{version}/modfetch_linux_arm64"
-      sha256 "893e51802932381bc14d472d94002813c491c5170f14e50573e0b30cf873c868"
+      sha256 "063f70619266d9a89ebf9178f412a50ae757977f9615d1fb8c3faa2e6771e150"
     end
     on_intel do
       url "https://github.com/jxwalker/modfetch/releases/download/v#{version}/modfetch_linux_amd64"
-      sha256 "c7db15650986c32cf4b1550699e624a929e21b926194a2523896fbacec95276c"
+      sha256 "a7bbfb6ce482b91ab1a93eb3b3aa9618b1e61b943e078bf84befc0e3114c5e2a"
     end
   end
 


### PR DESCRIPTION
## Summary
- update in-repo AUR metadata to v0.8.0 Linux release assets
- update in-repo Homebrew formula copy to v0.8.0 checksums

## Validation
- scripts/check-aur-package.sh v0.8.0
- ruby -c packaging/homebrew/modfetch.rb
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jxwalker/codesmith/modfetch/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->