### PR TITLE
feat: add guided TUI recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+Added
+- Added a guided TUI recommendation flow opened with `G`, so users can choose a
+  model by task, detected or overridden hardware budget, provider, runtime or
+  placement target, and maximum file size before starting a normal resumable
+  download.
+
 ## v0.8.0 — 2026-05-13
 
 Added

--- a/README.md
+++ b/README.md
@@ -126,14 +126,12 @@ The modfetch TUI provides a beautiful, full-featured interface for managing your
 ---
 
 ## Upcoming
-- **Recommendation refinements**: richer result inspection and runtime-specific
-  setup guidance after the guided TUI recommendation flow starts a download.
-
-## Unreleased
 - **Guided TUI recommendations**: press `G` in the TUI to choose a model by
   task, detected or overridden hardware budget, provider, runtime or placement
   target, and maximum file size, then start the same resumable download path
   used by `modfetch download`.
+- **Recommendation refinements**: richer result inspection and runtime-specific
+  setup guidance after the guided TUI recommendation flow starts a download.
 
 ## What's new in v0.8.0
 - **Hardware-aware recommendations**: `modfetch recommend --task coding` detects

--- a/README.md
+++ b/README.md
@@ -126,9 +126,14 @@ The modfetch TUI provides a beautiful, full-featured interface for managing your
 ---
 
 ## Upcoming
-- **Guided TUI recommendations**: bring the `modfetch recommend` ranking flow into
-  the TUI so new users can choose by task, hardware fit, provider, runtime, and
-  placement target before starting a download.
+- **Recommendation refinements**: richer result inspection and runtime-specific
+  setup guidance after the guided TUI recommendation flow starts a download.
+
+## Unreleased
+- **Guided TUI recommendations**: press `G` in the TUI to choose a model by
+  task, detected or overridden hardware budget, provider, runtime or placement
+  target, and maximum file size, then start the same resumable download path
+  used by `modfetch download`.
 
 ## What's new in v0.8.0
 - **Hardware-aware recommendations**: `modfetch recommend --task coding` detects

--- a/cmd/modfetch/recommend_cmd.go
+++ b/cmd/modfetch/recommend_cmd.go
@@ -83,7 +83,7 @@ func handleRecommend(ctx context.Context, args []string) error {
 	if effectiveQuery == "" {
 		effectiveQuery = recommend.DefaultQuery(effectiveTask)
 	}
-	hardwareKey := recommendationHardwareKey(hw)
+	hardwareKey := recommend.HardwareKey(hw)
 	feedback := map[string]recommend.Feedback(nil)
 	var st *state.DB
 	if !*noLearn && cfgErr == nil {
@@ -92,7 +92,7 @@ func handleRecommend(ctx context.Context, args []string) error {
 		if stErr == nil {
 			defer func() { _ = st.Close() }()
 			var feedbackErr error
-			feedback, feedbackErr = recommendationFeedback(st, effectiveTask, effectiveQuery, hardwareKey)
+			feedback, feedbackErr = recommend.FeedbackFromHistory(st, effectiveTask, effectiveQuery, hardwareKey)
 			if feedbackErr != nil {
 				return fmt.Errorf("load recommendation history: %w", feedbackErr)
 			}
@@ -114,7 +114,7 @@ func handleRecommend(ctx context.Context, args []string) error {
 		return err
 	}
 	if st != nil {
-		if err := recordRecommendationHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "shown", 0); err != nil {
+		if err := recommend.RecordHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "shown", 0); err != nil {
 			return fmt.Errorf("record shown recommendations: %w", err)
 		}
 	}
@@ -127,10 +127,10 @@ func handleRecommend(ctx context.Context, args []string) error {
 		}
 		selected := recs[*selectIndex-1]
 		if st != nil {
-			if err := recordRecommendationHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "selected", selected.Index); err != nil {
+			if err := recommend.RecordHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "selected", selected.Index); err != nil {
 				return fmt.Errorf("record selected recommendation: %w", err)
 			}
-			if err := recordRecommendationHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "skipped", selected.Index); err != nil {
+			if err := recommend.RecordHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "skipped", selected.Index); err != nil {
 				return fmt.Errorf("record skipped recommendations: %w", err)
 			}
 		}
@@ -258,76 +258,6 @@ func validateGiBOverride(name string, value float64) error {
 		return fmt.Errorf("%s value %.2f is unreasonably large; max is %d GiB", name, value, maxHardwareOverrideGiB)
 	}
 	return nil
-}
-
-func recommendationHardwareKey(hw recommend.HardwareProfile) string {
-	ramGB := roundedGiB(hw.RAMBytes)
-	vramGB := roundedGiB(hw.VRAMBytes)
-	switch {
-	case hw.UnifiedMemory:
-		return fmt.Sprintf("%s/%s/ram%dg/unified", strings.ToLower(hw.OS), strings.ToLower(hw.Arch), ramGB)
-	case hw.VRAMBytes > 0:
-		return fmt.Sprintf("%s/%s/vram%dg-ram%dg/discrete", strings.ToLower(hw.OS), strings.ToLower(hw.Arch), vramGB, ramGB)
-	default:
-		return fmt.Sprintf("%s/%s/ram%dg/system", strings.ToLower(hw.OS), strings.ToLower(hw.Arch), ramGB)
-	}
-}
-
-func roundedGiB(bytes int64) int64 {
-	if bytes <= 0 {
-		return 0
-	}
-	return (bytes + (1<<30 - 1)) >> 30
-}
-
-func recommendationFeedback(st *state.DB, task, query, hardwareKey string) (map[string]recommend.Feedback, error) {
-	rows, err := st.RecommendationHistoryFor(task, query, hardwareKey)
-	if err != nil {
-		return nil, err
-	}
-	out := make(map[string]recommend.Feedback)
-	for _, row := range rows {
-		key := recommend.FeedbackKey(row.URI)
-		fb := out[key]
-		switch row.Action {
-		case "selected":
-			fb.Selected += row.Count
-		case "skipped":
-			fb.Skipped += row.Count
-		case "shown":
-			fb.Shown += row.Count
-		}
-		out[key] = fb
-	}
-	return out, nil
-}
-
-func recordRecommendationHistory(st *state.DB, task, query, hardwareKey string, recs []recommend.Recommendation, action string, selectedIndex int) error {
-	rows := make([]state.RecommendationHistoryRow, 0, len(recs))
-	for _, rec := range recs {
-		switch action {
-		case "selected":
-			if rec.Index != selectedIndex {
-				continue
-			}
-		case "skipped":
-			if rec.Index == selectedIndex {
-				continue
-			}
-		}
-		rows = append(rows, state.RecommendationHistoryRow{
-			Task:        task,
-			Query:       query,
-			Provider:    rec.Provider,
-			ModelID:     rec.ModelID,
-			URI:         rec.URI,
-			Action:      action,
-			Score:       rec.Score,
-			Fit:         rec.Fit,
-			HardwareKey: hardwareKey,
-		})
-	}
-	return st.BatchUpsertRecommendationHistory(rows)
 }
 
 func printRecommendationHistory(cfg *config.Config, limit int, jsonOut bool) error {

--- a/cmd/modfetch/recommend_cmd_test.go
+++ b/cmd/modfetch/recommend_cmd_test.go
@@ -83,7 +83,7 @@ func TestRecommendHistoryListsRows(t *testing.T) {
 }
 
 func TestRecommendationHardwareKey(t *testing.T) {
-	got := recommendationHardwareKey(recommend.HardwareProfile{
+	got := recommend.HardwareKey(recommend.HardwareProfile{
 		OS:            "darwin",
 		Arch:          "arm64",
 		RAMBytes:      127<<30 + 1,
@@ -93,7 +93,7 @@ func TestRecommendationHardwareKey(t *testing.T) {
 		t.Fatalf("hardware key = %q", got)
 	}
 
-	got = recommendationHardwareKey(recommend.HardwareProfile{
+	got = recommend.HardwareKey(recommend.HardwareProfile{
 		OS:        "linux",
 		Arch:      "amd64",
 		RAMBytes:  64 << 30,
@@ -115,14 +115,14 @@ func TestRecommendationFeedbackFromHistory(t *testing.T) {
 		{Index: 1, Provider: discovery.ProviderHuggingFace, ModelID: "owner/selected", URI: "hf://owner/selected/model.gguf?rev=main", Score: 100, Fit: "excellent"},
 		{Index: 2, Provider: discovery.ProviderHuggingFace, ModelID: "owner/skipped", URI: "hf://owner/skipped/model.gguf?rev=main", Score: 90, Fit: "excellent"},
 	}
-	if err := recordRecommendationHistory(db, "coding", "qwen coder gguf", "darwin/arm64/128g/unified", recs, "selected", 1); err != nil {
+	if err := recommend.RecordHistory(db, "coding", "qwen coder gguf", "darwin/arm64/128g/unified", recs, "selected", 1); err != nil {
 		t.Fatalf("record selected history: %v", err)
 	}
-	if err := recordRecommendationHistory(db, "coding", "qwen coder gguf", "darwin/arm64/128g/unified", recs, "skipped", 1); err != nil {
+	if err := recommend.RecordHistory(db, "coding", "qwen coder gguf", "darwin/arm64/128g/unified", recs, "skipped", 1); err != nil {
 		t.Fatalf("record skipped history: %v", err)
 	}
 
-	feedback, err := recommendationFeedback(db, "coding", "qwen coder gguf", "darwin/arm64/128g/unified")
+	feedback, err := recommend.FeedbackFromHistory(db, "coding", "qwen coder gguf", "darwin/arm64/128g/unified")
 	if err != nil {
 		t.Fatalf("load feedback: %v", err)
 	}

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -230,6 +230,12 @@ modfetch discover search "sshleifer/tiny-gpt2"
 modfetch discover download "sshleifer/tiny-gpt2" --select 1
 ```
 
+Inside the TUI, press `G` to choose a model without copying a URL. The guided
+flow filters live provider results by task, detected or overridden hardware,
+provider, runtime or placement target, and maximum file size. Press `Enter` on
+the selected recommendation to start the same resumable download pipeline used
+by the CLI.
+
 If you want modfetch to choose a model that fits your hardware, use
 `recommend`:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -183,9 +183,13 @@ These are useful, but not required for the first v0.7.0 release:
   expose placement/runtime hints for Ollama, llama.cpp, MLX, ComfyUI, and
   Stable Diffusion UIs so recommendation output explains where a model can run,
   not just whether it can be downloaded.
-- [NEXT] Interactive recommendation flow in the TUI:
+- [DONE] Interactive recommendation flow in the TUI:
   add a guided "choose a model" workflow that filters by task, hardware, file
   size, source, and placement target before starting a download.
+- [NEXT] Recommendation result inspection:
+  add richer TUI detail views for recommendation rationale, runtime setup
+  commands, placement prerequisites, and dry-run transfer metadata before the
+  user starts a large download.
 
 ## Completed Release History
 

--- a/docs/TUI_ANALYSIS_SUMMARY.txt
+++ b/docs/TUI_ANALYSIS_SUMMARY.txt
@@ -5,7 +5,7 @@
 
 PROJECT: modfetch - CLI+TUI for downloading LLM/Stable Diffusion models
 VERSION: v0.8.0
-ANALYSIS DATE: 2026-04-29
+ANALYSIS DATE: 2026-05-14
 
 ================================================================================
 1. CURRENT OVERVIEW
@@ -29,6 +29,7 @@ modfetch now ships one maintained TUI entry point:
     - Settings rendering in internal/tui/settings_view.go
     - Non-interactive snapshot assembly in cmd/modfetch/tui_cmd.go
     - Modal handling in internal/tui/modals.go
+    - Guided recommendation flow in internal/tui/recommend_flow.go
     - Shared TUI URL normalization in internal/tui/url_resolution.go
     - UI preference persistence in internal/tui/ui_state.go
 
@@ -60,6 +61,15 @@ Library management:
   - Selected-entry catalog export through the shared library export path
   - Scan progress and stale-record repair support
 
+Recommendation workflow:
+  - `G` opens a guided model picker from any tab
+  - The flow filters by task, hardware budget, provider, runtime or placement
+    target, maximum file size, and optional query
+  - Results reuse the same recommendation ranking and history helpers as the
+    CLI
+  - Selecting a result creates a normal pending row and starts the existing
+    resumable download path
+
 Configuration visibility:
   - Read-only settings view for directory roots, placement mode, source tokens,
     download settings, and placement rules
@@ -85,6 +95,8 @@ findings are no longer current:
   - There are no user-facing TUI selector flags.
   - Modal and library confirmation paths handle both Enter key forms.
   - CivitAI page normalization has a shared helper in internal/tui/url_resolution.go.
+  - The guided recommendation flow is isolated in internal/tui/recommend_flow.go
+    and delegates downloads back to the existing TUI action path.
   - TUI selection and filter behavior is covered by focused tests in
     internal/tui/model_test.go, internal/tui/library_test.go, and
     internal/tui/navigation_test.go.
@@ -108,6 +120,8 @@ Current TUI test coverage includes:
   - Settings rendering
   - Non-interactive TUI snapshot JSON/text output against a real SQLite state
     database
+  - Guided recommendation filtering, rendering, history recording, and download
+    handoff against a real SQLite state database
   - Inspector behavior
   - UI-state persistence
   - Config wizard validation
@@ -126,6 +140,7 @@ Keep future TUI changes in the current package structure:
 
   - Place rendering changes in the relevant *_view.go file.
   - Define modal behavior in modals.go.
+  - Keep guided recommendation behavior in recommend_flow.go.
   - Handle library mutations and confirmations in library_actions.go.
   - Implement shared resolver/page normalization in url_resolution.go.
   - Add focused tests beside the touched behavior.
@@ -137,10 +152,10 @@ Keep future TUI changes in the current package structure:
 ================================================================================
 
 The current v0.8.0 TUI is a single, maintained interface with download
-management, library maintenance, settings inspection, bulk operations, and
-state persistence. Non-interactive snapshot hooks now expose the same persisted
-state for scripts without starting the Bubble Tea program. The older
-dual-implementation comparison has been superseded by the current package
-layout and test coverage.
+management, guided model recommendations, library maintenance, settings
+inspection, bulk operations, and state persistence. Non-interactive snapshot
+hooks expose the same persisted state for scripts without starting the Bubble
+Tea program. The older dual-implementation comparison has been superseded by
+the current package layout and test coverage.
 
 ================================================================================

--- a/docs/TUI_GUIDE.md
+++ b/docs/TUI_GUIDE.md
@@ -95,12 +95,14 @@ help overlay.
 - `5` or `L` - Switch to Library tab
 - `6` or `M` - Switch to Settings tab
 - `j`/`k` or arrow keys - Navigate up/down
+- `G` - Open guided model recommendations
 - `?` - Toggle help overlay
 - `q` - Quit
 
 ### Download Tab Keys
 
 - `n` - Start a new download
+- `G` - Choose a recommended model by task, hardware, provider, runtime, and size
 - `b` - Import a batch file
 - `y` or `r` - Start or retry selected download
 - `p` - Cancel selected download
@@ -134,6 +136,25 @@ help overlay.
 - `E` - Export selected models to `library-selected-catalog.json`
 - `D` - Delete selected staged download data after confirmation
 - `S` - Scan configured directories for new models
+
+## Guided recommendations
+
+Press `G` from any tab to open a guided model picker. The flow asks for:
+
+- Task: chat, coding, embeddings, or image generation
+- Hardware budget: detected local hardware or a RAM override
+- Provider: all providers, Hugging Face, CivitAI, or ModelScope
+- Runtime or placement target: llama.cpp, Ollama, LM Studio, MLX, ComfyUI, or
+  AUTOMATIC1111/Forge
+- Maximum file size
+- Optional search terms
+
+The results reuse the same ranking engine as `modfetch recommend`, including
+hardware fit, runtime hints, and local recommendation history. Press `Enter` on
+a result to create a normal pending download row and start the existing
+resumable downloader. When a runtime has a placement preset and your config has
+matching placement rules, the TUI saves the file directly under that configured
+target; otherwise it saves under `download_root`.
 
 ### Settings Tab Keys
 

--- a/docs/TUI_WIREFRAMES.md
+++ b/docs/TUI_WIREFRAMES.md
@@ -49,7 +49,7 @@ The modfetch TUI has **7 tabs** organized into three functional groups:
 ║  │  Planning   │ ...         │ -          │ -      │ 2.2GB │ flux...    │║
 ║  └──────────────────────────────────────────────────────────────────────┘║
 ╠══════════════════════════════════════════════════════════════════════════╣
-║  ↑↓:Select  n:New  y:Retry  p:Pause  D:Delete  O:Open  /:Filter  ?:Help  ║
+║  ↑↓:Select  G:Recommend  n:New  y:Retry  p:Pause  D:Delete  /:Filter  ?:Help ║
 ╚══════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -286,6 +286,7 @@ The modfetch TUI has **7 tabs** organized into three functional groups:
 ║  │ 0-4      Switch to download tabs (All/Pending/Active/Done/Fail) │ ║
 ║  │ 5 or L   Library tab                                            │ ║
 ║  │ 6 or M   Settings tab                                           │ ║
+║  │ G        Guided model recommendations                           │ ║
 ║  │ ?        Help overlay                                           │ ║
 ║  │ q or Q   Quit                                                   │ ║
 ║  │ j/k      Navigate down/up (Vim-style)                           │ ║
@@ -294,6 +295,7 @@ The modfetch TUI has **7 tabs** organized into three functional groups:
 ╠══════════════════════════════════════════════════════════════════════╣
 ║  DOWNLOAD TABS (0-4)                                                 ║
 ║  ┌─────────────────────────────────────────────────────────────────┐ ║
+║  │ G        Guided model recommendations                           │ ║
 ║  │ n        New download                                           │ ║
 ║  │ b        Import batch file                                      │ ║
 ║  │ y or r   Start/retry download                                   │ ║
@@ -339,7 +341,8 @@ The modfetch TUI has **7 tabs** organized into three functional groups:
 ┌─────────────────────────────────────────────────────────┐
 │  NAVIGATION           DOWNLOADS        LIBRARY          │
 │  ───────────          ─────────        ───────          │
-│  0-6  Tabs            n  New           5/L  Open        │
+│  0-6  Tabs            G  Recommend     5/L  Open        │
+│                       n  New                          │
 │  j/k  Up/Down         y  Start         /    Search      │
 │  ?    Help            p  Pause         f    Favorite    │
 │  q    Quit            D  Delete        S    Scan        │
@@ -406,8 +409,8 @@ The modfetch TUI has **7 tabs** organized into three functional groups:
 
 4. Download a model
    └─► Press '0' (All tab)
-       └─► Press 'n' (New download)
-       └─► Paste URL
+       └─► Press 'G' (guided recommendation) or 'n' (known URL)
+       └─► Choose model filters or paste URL
        └─► Watch in Active tab (Press '2')
 
 5. Organize your library

--- a/docs/TUI_WIREFRAMES.md
+++ b/docs/TUI_WIREFRAMES.md
@@ -342,7 +342,7 @@ The modfetch TUI has **7 tabs** organized into three functional groups:
 │  NAVIGATION           DOWNLOADS        LIBRARY          │
 │  ───────────          ─────────        ───────          │
 │  0-6  Tabs            G  Recommend     5/L  Open        │
-│                       n  New                          │
+│  T    Theme           n  New           Space Select     │
 │  j/k  Up/Down         y  Start         /    Search      │
 │  ?    Help            p  Pause         f    Favorite    │
 │  q    Quit            D  Delete        S    Scan        │

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -103,6 +103,11 @@ modfetch recommend --history
 modfetch recommend --task coding --no-learn
 ```
 
+The same selection path is available in the TUI. Launch `modfetch tui`, press
+`G`, choose the task, hardware budget, provider, runtime or placement target,
+maximum file size, and optional query, then press `Enter` on a recommendation
+to start the normal resumable download.
+
 #### Dry-run planning
 
 Use `--dry-run` to plan without downloading. It resolves resolver URIs and direct URLs, computes the default destination (respecting resolver SuggestedFilename and `--naming-pattern`), and probes remote metadata (filename, size, Accept-Range). It performs no database or file writes.

--- a/internal/recommend/history.go
+++ b/internal/recommend/history.go
@@ -57,6 +57,12 @@ func RecordHistory(st *state.DB, task, query, hardwareKey string, recs []Recomme
 	if st == nil {
 		return errors.New("nil state db")
 	}
+	action = strings.ToLower(strings.TrimSpace(action))
+	switch action {
+	case "selected", "skipped", "shown":
+	default:
+		return fmt.Errorf("unsupported recommendation history action %q", action)
+	}
 	rows := make([]state.RecommendationHistoryRow, 0, len(recs))
 	for _, rec := range recs {
 		switch action {

--- a/internal/recommend/history.go
+++ b/internal/recommend/history.go
@@ -1,0 +1,85 @@
+package recommend
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+func HardwareKey(hw HardwareProfile) string {
+	ramGB := RoundedGiB(hw.RAMBytes)
+	vramGB := RoundedGiB(hw.VRAMBytes)
+	switch {
+	case hw.UnifiedMemory:
+		return fmt.Sprintf("%s/%s/ram%dg/unified", strings.ToLower(hw.OS), strings.ToLower(hw.Arch), ramGB)
+	case hw.VRAMBytes > 0:
+		return fmt.Sprintf("%s/%s/vram%dg-ram%dg/discrete", strings.ToLower(hw.OS), strings.ToLower(hw.Arch), vramGB, ramGB)
+	default:
+		return fmt.Sprintf("%s/%s/ram%dg/system", strings.ToLower(hw.OS), strings.ToLower(hw.Arch), ramGB)
+	}
+}
+
+func RoundedGiB(bytes int64) int64 {
+	if bytes <= 0 {
+		return 0
+	}
+	return (bytes + (1<<30 - 1)) >> 30
+}
+
+func FeedbackFromHistory(st *state.DB, task, query, hardwareKey string) (map[string]Feedback, error) {
+	if st == nil {
+		return nil, errors.New("nil state db")
+	}
+	rows, err := st.RecommendationHistoryFor(task, query, hardwareKey)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]Feedback)
+	for _, row := range rows {
+		key := FeedbackKey(row.URI)
+		fb := out[key]
+		switch row.Action {
+		case "selected":
+			fb.Selected += row.Count
+		case "skipped":
+			fb.Skipped += row.Count
+		case "shown":
+			fb.Shown += row.Count
+		}
+		out[key] = fb
+	}
+	return out, nil
+}
+
+func RecordHistory(st *state.DB, task, query, hardwareKey string, recs []Recommendation, action string, selectedIndex int) error {
+	if st == nil {
+		return errors.New("nil state db")
+	}
+	rows := make([]state.RecommendationHistoryRow, 0, len(recs))
+	for _, rec := range recs {
+		switch action {
+		case "selected":
+			if rec.Index != selectedIndex {
+				continue
+			}
+		case "skipped":
+			if rec.Index == selectedIndex {
+				continue
+			}
+		}
+		rows = append(rows, state.RecommendationHistoryRow{
+			Task:        task,
+			Query:       query,
+			Provider:    rec.Provider,
+			ModelID:     rec.ModelID,
+			URI:         rec.URI,
+			Action:      action,
+			Score:       rec.Score,
+			Fit:         rec.Fit,
+			HardwareKey: hardwareKey,
+		})
+	}
+	return st.BatchUpsertRecommendationHistory(rows)
+}

--- a/internal/recommend/recommend_test.go
+++ b/internal/recommend/recommend_test.go
@@ -1,10 +1,12 @@
 package recommend
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/jxwalker/modfetch/internal/discovery"
+	"github.com/jxwalker/modfetch/internal/state"
 )
 
 func TestRankPrefersHardwareFitAndTask(t *testing.T) {
@@ -145,6 +147,22 @@ func TestApplyFeedbackBoostsPriorSelections(t *testing.T) {
 	}
 	if !strings.Contains(strings.Join(ranked[0].Reasons, " "), "prior selection") {
 		t.Fatalf("missing feedback reason: %#v", ranked[0].Reasons)
+	}
+}
+
+func TestRecordHistoryRejectsUnsupportedAction(t *testing.T) {
+	db, err := state.NewDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	err = RecordHistory(db, "chat", "llama", "darwin/arm64/ram128g/unified", []Recommendation{{
+		Index: 1,
+		URI:   "hf://owner/model/model.gguf?rev=main",
+	}}, "accepted", 1)
+	if err == nil || !strings.Contains(err.Error(), "unsupported recommendation history action") {
+		t.Fatalf("RecordHistory unsupported action err = %v", err)
 	}
 }
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -85,17 +85,17 @@ func (m *Model) renderToasts() string {
 
 func (m *Model) renderCommandsBar() string {
 	// concise single-line commands reference
-	return m.th.footer.Render("n new • b batch • y/r start • p cancel • D delete • O open • / filter • s/e/R sort • o clear • g group host • t col • v compact • i inspector • H toasts • ? help • q quit")
+	return m.th.footer.Render("G recommend • n new • b batch • y/r start • p cancel • D delete • O open • / filter • s/e/R sort • o clear • g group host • t col • v compact • i inspector • ? help • q quit")
 }
 
 func (m *Model) renderLibraryCommandsBar() string {
 	// Library tab commands reference
-	return m.th.footer.Render("j/k navigate • Space select • A all • X clear • F filters • f favorite • r retry • V verify • p place • E export • D delete staged • ? help • q quit")
+	return m.th.footer.Render("G recommend • j/k navigate • Space select • A all • X clear • F filters • f favorite • r retry • V verify • p place • E export • D delete staged • ? help • q quit")
 }
 
 func (m *Model) renderSettingsCommandsBar() string {
 	// Settings tab commands reference
-	return m.th.footer.Render("View current configuration • H toasts • ? help • q quit")
+	return m.th.footer.Render("G recommend • View current configuration • H toasts • ? help • q quit")
 }
 
 // Help screen
@@ -106,6 +106,7 @@ func (m *Model) renderHelp() string {
 	sb.WriteString("Tabs: 1 Pending • 2 Active • 3 Completed • 4 Failed • 5/L Library • 6/M Settings\n")
 	sb.WriteString("\n")
 	sb.WriteString(m.th.head.Render("Download Tabs (1-4)") + "\n")
+	sb.WriteString("Recommend: G opens guided model selection by task, hardware, provider, runtime, and size\n")
 	sb.WriteString("Nav: j/k up/down\n")
 	sb.WriteString("Filter: / to enter; Enter to apply; Esc to clear\n")
 	sb.WriteString("Sort: s speed • e ETA • R remaining • o clear\n")
@@ -118,6 +119,7 @@ func (m *Model) renderHelp() string {
 	sb.WriteString("Actions: y/r start • p cancel • D delete • O open • C copy path • U copy URL\n")
 	sb.WriteString("\n")
 	sb.WriteString(m.th.head.Render("Library Tab (5/L)") + "\n")
+	sb.WriteString("Recommend: G opens guided model selection and starts a resumable download\n")
 	sb.WriteString("Nav: j/k up/down • Enter view details • Esc back to list\n")
 	sb.WriteString("Search/filter: / search • F filter menu for search, type, source, favorites\n")
 	sb.WriteString("Select: Space toggle • A select visible • X clear selection\n")

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -85,7 +85,7 @@ func (m *Model) renderToasts() string {
 
 func (m *Model) renderCommandsBar() string {
 	// concise single-line commands reference
-	return m.th.footer.Render("G recommend • n new • b batch • y/r start • p cancel • D delete • O open • / filter • s/e/R sort • o clear • g group host • t col • v compact • i inspector • ? help • q quit")
+	return m.th.footer.Render("G recommend • n new • b batch • y/r start • p cancel • D delete • O open • / filter • s/e/R sort • o clear • g group host • t col • v compact • i inspector • H toasts • ? help • q quit")
 }
 
 func (m *Model) renderLibraryCommandsBar() string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -136,6 +136,8 @@ type Model struct {
 	// Batch import modal state
 	batchMode  bool
 	batchInput textinput.Model
+	// Guided recommendation modal state
+	recommendFlow recommendFlow
 	// Overrides for auto-place by key url|dest
 	placeType map[string]string
 	autoPlace map[string]bool
@@ -271,6 +273,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.w, m.h = msg.Width, msg.Height
 		return m, nil
 	case tea.KeyMsg:
+		if m.recommendFlow.active {
+			return m.updateRecommendFlow(msg)
+		}
 		if m.newJob {
 			return m.updateNewJob(msg)
 		}
@@ -443,6 +448,30 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.libraryNeedsRefresh = true
 		m.refreshLibraryData()
 		return m, m.refresh()
+	case recommendResultsMsg:
+		if !m.recommendFlow.active {
+			return m, nil
+		}
+		m.recommendFlow.loading = false
+		m.recommendFlow.err = ""
+		if msg.err != nil {
+			m.recommendFlow.err = msg.err.Error()
+			m.recommendFlow.results = nil
+			m.addToast("recommend failed: " + msg.err.Error())
+			return m, nil
+		}
+		m.recommendFlow.results = msg.recommendations
+		m.recommendFlow.hardware = msg.hardware
+		m.recommendFlow.hardwareKey = msg.hardwareKey
+		m.recommendFlow.query = msg.query
+		m.recommendFlow.task = msg.task
+		m.recommendFlow.selected = 0
+		if len(msg.recommendations) == 0 {
+			m.addToast("no recommendations matched those filters")
+		} else {
+			m.addToast(fmt.Sprintf("recommend: %d option(s)", len(msg.recommendations)))
+		}
+		return m, nil
 	case dlDoneMsg:
 		// Apply placement metadata if needed (safe concurrent map access from Update thread)
 		if msg.needsPlaceMap && msg.origKey != msg.resKey {
@@ -560,6 +589,9 @@ func (m *Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.batchInput = textinput.New()
 		m.batchInput.Placeholder = "Path to text file with URLs"
 		m.batchInput.Focus()
+		return m, nil
+	case "G":
+		m.startRecommendFlow()
 		return m, nil
 	case "S":
 		// Scan directories for existing models
@@ -961,6 +993,9 @@ func (m *Model) View() string {
 	}
 	if m.batchMode {
 		modal = m.th.border.Width(m.w - 4).Render(m.renderBatchModal())
+	}
+	if m.recommendFlow.active {
+		modal = m.th.border.Width(m.w - 4).Render(m.renderRecommendFlow())
 	}
 	if m.libraryFilterMenu {
 		modal = m.th.border.Width(m.w - 4).Render(m.renderLibraryFilterMenu())

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -452,6 +452,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !m.recommendFlow.active {
 			return m, nil
 		}
+		m.recommendFlow.cancel = nil
 		m.recommendFlow.loading = false
 		m.recommendFlow.err = ""
 		if msg.err != nil {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -449,7 +449,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.refreshLibraryData()
 		return m, m.refresh()
 	case recommendResultsMsg:
-		if !m.recommendFlow.active {
+		if !m.recommendFlow.active || msg.flowID != m.recommendFlow.flowID {
 			return m, nil
 		}
 		m.recommendFlow.cancel = nil
@@ -471,6 +471,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.addToast("no recommendations matched those filters")
 		} else {
 			m.addToast(fmt.Sprintf("recommend: %d option(s)", len(msg.recommendations)))
+		}
+		if strings.TrimSpace(msg.warning) != "" {
+			m.addToast("warning: " + msg.warning)
 		}
 		return m, nil
 	case dlDoneMsg:

--- a/internal/tui/recommend_flow.go
+++ b/internal/tui/recommend_flow.go
@@ -1,0 +1,712 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/dustin/go-humanize"
+	"github.com/jxwalker/modfetch/internal/discovery"
+	"github.com/jxwalker/modfetch/internal/recommend"
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+type recommendStep int
+
+const (
+	recommendStepTask recommendStep = iota
+	recommendStepHardware
+	recommendStepProvider
+	recommendStepRuntime
+	recommendStepSize
+	recommendStepQuery
+	recommendStepResults
+)
+
+type recommendChoice struct {
+	label       string
+	value       string
+	description string
+	bytes       int64
+}
+
+type recommendFlow struct {
+	active        bool
+	step          recommendStep
+	input         textinput.Model
+	taskIndex     int
+	hardwareIndex int
+	providerIndex int
+	runtimeIndex  int
+	sizeIndex     int
+	selected      int
+	query         string
+	task          string
+	hardware      recommend.HardwareProfile
+	hardwareKey   string
+	results       []recommend.Recommendation
+	loading       bool
+	err           string
+}
+
+type recommendResultsMsg struct {
+	recommendations []recommend.Recommendation
+	hardware        recommend.HardwareProfile
+	query           string
+	task            string
+	hardwareKey     string
+	err             error
+}
+
+func (m *Model) startRecommendFlow() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	input := textinput.New()
+	input.Placeholder = "Optional search, e.g. llama 8b gguf"
+	input.CharLimit = 256
+	m.recommendFlow = recommendFlow{
+		active:   true,
+		step:     recommendStepTask,
+		input:    input,
+		hardware: recommend.DetectHardware(ctx),
+	}
+}
+
+func (m *Model) updateRecommendFlow(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	s := msg.String()
+	if s == "esc" {
+		m.recommendFlow.active = false
+		m.recommendFlow.input.Blur()
+		return m, nil
+	}
+	if m.recommendFlow.loading {
+		return m, nil
+	}
+	if m.recommendFlow.step == recommendStepQuery {
+		switch s {
+		case "enter", "ctrl+j":
+			m.recommendFlow.query = strings.TrimSpace(m.recommendFlow.input.Value())
+			m.recommendFlow.input.Blur()
+			m.recommendFlow.step = recommendStepResults
+			m.recommendFlow.loading = true
+			m.recommendFlow.err = ""
+			m.recommendFlow.results = nil
+			return m, m.recommendSearchCmd()
+		case "left", "ctrl+h":
+			m.recommendFlow.step = recommendStepSize
+			m.recommendFlow.input.Blur()
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.recommendFlow.input, cmd = m.recommendFlow.input.Update(msg)
+		return m, cmd
+	}
+	if m.recommendFlow.step == recommendStepResults {
+		switch s {
+		case "j", "down":
+			if m.recommendFlow.selected < len(m.recommendFlow.results)-1 {
+				m.recommendFlow.selected++
+			}
+			return m, nil
+		case "k", "up":
+			if m.recommendFlow.selected > 0 {
+				m.recommendFlow.selected--
+			}
+			return m, nil
+		case "left", "ctrl+h":
+			m.recommendFlow.step = recommendStepQuery
+			m.recommendFlow.input.Focus()
+			return m, nil
+		case "enter", "ctrl+j":
+			return m, m.startRecommendedDownload()
+		}
+		return m, nil
+	}
+	switch s {
+	case "j", "down":
+		m.adjustRecommendChoice(1)
+		return m, nil
+	case "k", "up":
+		m.adjustRecommendChoice(-1)
+		return m, nil
+	case "left", "ctrl+h":
+		m.previousRecommendStep()
+		return m, nil
+	case "enter", "ctrl+j":
+		m.nextRecommendStep()
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m *Model) nextRecommendStep() {
+	switch m.recommendFlow.step {
+	case recommendStepTask:
+		m.recommendFlow.step = recommendStepHardware
+	case recommendStepHardware:
+		m.recommendFlow.step = recommendStepProvider
+	case recommendStepProvider:
+		m.recommendFlow.step = recommendStepRuntime
+	case recommendStepRuntime:
+		m.recommendFlow.step = recommendStepSize
+	case recommendStepSize:
+		m.recommendFlow.step = recommendStepQuery
+		m.recommendFlow.input.Focus()
+	}
+}
+
+func (m *Model) previousRecommendStep() {
+	switch m.recommendFlow.step {
+	case recommendStepHardware:
+		m.recommendFlow.step = recommendStepTask
+	case recommendStepProvider:
+		m.recommendFlow.step = recommendStepHardware
+	case recommendStepRuntime:
+		m.recommendFlow.step = recommendStepProvider
+	case recommendStepSize:
+		m.recommendFlow.step = recommendStepRuntime
+	case recommendStepResults:
+		m.recommendFlow.step = recommendStepQuery
+		m.recommendFlow.input.Focus()
+	}
+}
+
+func (m *Model) adjustRecommendChoice(delta int) {
+	var idx *int
+	var count int
+	switch m.recommendFlow.step {
+	case recommendStepTask:
+		idx = &m.recommendFlow.taskIndex
+		count = len(recommendTaskChoices())
+	case recommendStepHardware:
+		idx = &m.recommendFlow.hardwareIndex
+		count = len(m.recommendHardwareChoices())
+	case recommendStepProvider:
+		idx = &m.recommendFlow.providerIndex
+		count = len(recommendProviderChoices())
+	case recommendStepRuntime:
+		idx = &m.recommendFlow.runtimeIndex
+		count = len(recommendRuntimeChoices())
+	case recommendStepSize:
+		idx = &m.recommendFlow.sizeIndex
+		count = len(recommendSizeChoices())
+	}
+	if idx == nil || count == 0 {
+		return
+	}
+	*idx += delta
+	if *idx < 0 {
+		*idx = count - 1
+	}
+	if *idx >= count {
+		*idx = 0
+	}
+}
+
+func (m *Model) recommendSearchCmd() tea.Cmd {
+	task := m.selectedRecommendTask()
+	provider := m.selectedRecommendProvider()
+	runtimeTarget := m.selectedRecommendRuntime()
+	sizeLimit := m.selectedRecommendSizeLimit()
+	query := strings.TrimSpace(m.recommendFlow.query)
+	hardware := m.selectedRecommendHardware()
+	st := m.st
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+		effectiveTask := recommend.NormalizeTask(task)
+		effectiveQuery := query
+		if effectiveQuery == "" {
+			effectiveQuery = recommend.DefaultQuery(effectiveTask)
+		}
+		hardwareKey := recommend.HardwareKey(hardware)
+		var feedback map[string]recommend.Feedback
+		if st != nil {
+			var err error
+			feedback, err = recommend.FeedbackFromHistory(st, effectiveTask, effectiveQuery, hardwareKey)
+			if err != nil {
+				return recommendResultsMsg{err: fmt.Errorf("load recommendation history: %w", err)}
+			}
+		}
+		recs, hw, err := recommend.Recommend(ctx, recommend.Options{
+			Query:    query,
+			Task:     task,
+			Provider: provider,
+			Limit:    20,
+			Hardware: hardware,
+			Feedback: feedback,
+		})
+		if err != nil {
+			return recommendResultsMsg{err: err}
+		}
+		recs = filterRecommendResults(recs, runtimeTarget, sizeLimit)
+		if len(recs) > 8 {
+			recs = recs[:8]
+		}
+		for i := range recs {
+			recs[i].Index = i + 1
+		}
+		if st != nil && len(recs) > 0 {
+			if err := recommend.RecordHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "shown", 0); err != nil {
+				return recommendResultsMsg{err: fmt.Errorf("record shown recommendations: %w", err)}
+			}
+		}
+		return recommendResultsMsg{
+			recommendations: recs,
+			hardware:        hw,
+			query:           effectiveQuery,
+			task:            effectiveTask,
+			hardwareKey:     hardwareKey,
+		}
+	}
+}
+
+func filterRecommendResults(recs []recommend.Recommendation, runtimeTarget string, sizeLimit int64) []recommend.Recommendation {
+	runtimeTarget = strings.ToLower(strings.TrimSpace(runtimeTarget))
+	out := make([]recommend.Recommendation, 0, len(recs))
+	for _, rec := range recs {
+		if sizeLimit > 0 && (rec.Size <= 0 || rec.Size > sizeLimit) {
+			continue
+		}
+		if runtimeTarget != "" && runtimeTarget != "any" && !recommendationMatchesRuntime(rec, runtimeTarget) {
+			continue
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+func recommendationMatchesRuntime(rec recommend.Recommendation, target string) bool {
+	target = strings.ToLower(strings.TrimSpace(target))
+	for _, hint := range rec.RuntimeHints {
+		runtimeName := strings.ToLower(strings.TrimSpace(hint.Runtime))
+		preset := strings.ToLower(strings.TrimSpace(hint.PlacementPreset))
+		if runtimeName == target || preset == target {
+			return true
+		}
+		if target == "automatic1111" && strings.Contains(runtimeName, "automatic1111") {
+			return true
+		}
+		if target == "lm studio" && runtimeName == "lm studio" {
+			return true
+		}
+	}
+	return false
+}
+
+func recommendPlacementPreset(rec recommend.Recommendation, target string) string {
+	target = strings.ToLower(strings.TrimSpace(target))
+	if target == "" || target == "any" {
+		return ""
+	}
+	for _, hint := range rec.RuntimeHints {
+		runtimeName := strings.ToLower(strings.TrimSpace(hint.Runtime))
+		preset := strings.ToLower(strings.TrimSpace(hint.PlacementPreset))
+		if preset == "" {
+			continue
+		}
+		if runtimeName == target || preset == target {
+			return preset
+		}
+		if target == "automatic1111" && strings.Contains(runtimeName, "automatic1111") {
+			return preset
+		}
+	}
+	return ""
+}
+
+func (m *Model) startRecommendedDownload() tea.Cmd {
+	if m.st == nil {
+		m.addToast("recommend: state database unavailable")
+		return nil
+	}
+	if len(m.recommendFlow.results) == 0 {
+		return nil
+	}
+	if m.recommendFlow.selected < 0 || m.recommendFlow.selected >= len(m.recommendFlow.results) {
+		m.recommendFlow.selected = 0
+	}
+	rec := m.recommendFlow.results[m.recommendFlow.selected]
+	task := recommend.NormalizeTask(m.recommendFlow.task)
+	runtimeTarget := m.selectedRecommendRuntime()
+	query := strings.TrimSpace(m.recommendFlow.query)
+	if query == "" {
+		query = recommend.DefaultQuery(task)
+	}
+	hardwareKey := strings.TrimSpace(m.recommendFlow.hardwareKey)
+	if hardwareKey == "" {
+		hardwareKey = recommend.HardwareKey(m.recommendFlow.hardware)
+	}
+	if err := recommend.RecordHistory(m.st, task, query, hardwareKey, m.recommendFlow.results, "selected", rec.Index); err != nil {
+		m.addToast("recommend history failed: " + err.Error())
+		return nil
+	}
+	if err := recommend.RecordHistory(m.st, task, query, hardwareKey, m.recommendFlow.results, "skipped", rec.Index); err != nil {
+		m.addToast("recommend history failed: " + err.Error())
+		return nil
+	}
+	artifactType := recommendArtifactType(rec, task, runtimeTarget)
+	dest := m.computeDefaultDest(rec.URI)
+	if preset := recommendPlacementPreset(rec, runtimeTarget); preset != "" && artifactType != "" {
+		if targetDest, ok := m.recommendPlacementDestination(rec.URI, artifactType, preset); ok {
+			dest = targetDest
+		} else {
+			m.addToast("placement target not configured; saving to download root")
+		}
+	}
+	if err := m.preflightDest(dest); err != nil {
+		m.addToast("dest not writable: " + err.Error())
+		return nil
+	}
+	if err := m.st.UpsertDownload(state.DownloadRow{URL: rec.URI, Dest: dest, Status: "pending"}); err != nil {
+		m.addToast("recommend start failed: " + err.Error())
+		return nil
+	}
+	m.ensureDownloadMaps()
+	key := rec.URI + "|" + dest
+	if artifactType != "" {
+		m.placeType[key] = artifactType
+	}
+	cmd := m.startDownloadCmd(rec.URI, dest, false, artifactType)
+	m.addToast("started recommendation: " + truncateMiddle(filepath.Base(dest), 40))
+	m.recommendFlow.active = false
+	m.recommendFlow.input.Blur()
+	return cmd
+}
+
+func (m *Model) recommendPlacementDestination(urlStr, artifactType, preset string) (string, bool) {
+	if m.cfg == nil {
+		return "", false
+	}
+	preset = strings.ToLower(strings.TrimSpace(preset))
+	artifactType = strings.TrimSpace(artifactType)
+	if preset == "" || artifactType == "" {
+		return "", false
+	}
+	base := filepath.Base(m.computeDefaultDest(urlStr))
+	if strings.TrimSpace(base) == "" || base == "." || base == string(filepath.Separator) {
+		base = filepath.Base(m.immediateDestCandidate(urlStr))
+	}
+	if strings.TrimSpace(base) == "" || base == "." || base == string(filepath.Separator) {
+		base = "download"
+	}
+	for _, rule := range m.cfg.Placement.Mapping {
+		if strings.TrimSpace(rule.Match) != artifactType {
+			continue
+		}
+		for _, target := range rule.Targets {
+			appName := strings.ToLower(strings.TrimSpace(target.App))
+			if appName != preset {
+				continue
+			}
+			app, ok := m.cfg.Placement.Apps[target.App]
+			if !ok {
+				return "", false
+			}
+			rel, ok := app.Paths[target.PathKey]
+			if !ok {
+				return "", false
+			}
+			return filepath.Join(app.Base, rel, base), true
+		}
+	}
+	return "", false
+}
+
+func (m *Model) ensureDownloadMaps() {
+	if m.running == nil {
+		m.running = map[string]context.CancelFunc{}
+	}
+	if m.placeType == nil {
+		m.placeType = map[string]string{}
+	}
+	if m.autoPlace == nil {
+		m.autoPlace = map[string]bool{}
+	}
+}
+
+func recommendArtifactType(rec recommend.Recommendation, task, target string) string {
+	ext := strings.ToLower(strings.TrimPrefix(rec.FileType, "."))
+	if ext == "" {
+		name := strings.ToLower(firstNonEmptyString(rec.FileName, rec.Raw.FileName, rec.Raw.FilePath))
+		if dot := strings.LastIndexByte(name, '.'); dot >= 0 {
+			ext = strings.TrimPrefix(name[dot:], ".")
+		}
+	}
+	switch ext {
+	case "gguf":
+		return "llm.gguf"
+	case "safetensors":
+		if recommend.NormalizeTask(task) == "image" || target == "comfyui" || target == "automatic1111" {
+			return "sd.checkpoint"
+		}
+		return "llm.safetensors"
+	case "bin", "pt", "pth":
+		return "generic"
+	default:
+		return "generic"
+	}
+}
+
+func (m *Model) selectedRecommendTask() string {
+	return selectedRecommendChoiceValue(recommendTaskChoices(), m.recommendFlow.taskIndex, "chat")
+}
+
+func (m *Model) selectedRecommendProvider() string {
+	return selectedRecommendChoiceValue(recommendProviderChoices(), m.recommendFlow.providerIndex, discovery.ProviderAll)
+}
+
+func (m *Model) selectedRecommendRuntime() string {
+	return selectedRecommendChoiceValue(recommendRuntimeChoices(), m.recommendFlow.runtimeIndex, "any")
+}
+
+func (m *Model) selectedRecommendSizeLimit() int64 {
+	choices := recommendSizeChoices()
+	if m.recommendFlow.sizeIndex < 0 || m.recommendFlow.sizeIndex >= len(choices) {
+		return 0
+	}
+	return choices[m.recommendFlow.sizeIndex].bytes
+}
+
+func (m *Model) selectedRecommendHardware() recommend.HardwareProfile {
+	choices := m.recommendHardwareChoices()
+	if m.recommendFlow.hardwareIndex <= 0 || m.recommendFlow.hardwareIndex >= len(choices) {
+		return m.recommendFlow.hardware
+	}
+	selected := choices[m.recommendFlow.hardwareIndex]
+	hw := m.recommendFlow.hardware
+	hw.RAMBytes = selected.bytes
+	hw.VRAMBytes = 0
+	hw.UnifiedMemory = hw.OS == "darwin" && hw.Arch == "arm64"
+	hw.Source = "tui-override"
+	return hw
+}
+
+func selectedRecommendChoiceValue(choices []recommendChoice, index int, fallback string) string {
+	if index < 0 || index >= len(choices) {
+		return fallback
+	}
+	return choices[index].value
+}
+
+func recommendTaskChoices() []recommendChoice {
+	return []recommendChoice{
+		{label: "Chat / assistant", value: "chat", description: "general local assistant and writing"},
+		{label: "Coding", value: "coding", description: "code generation, refactoring, and agent work"},
+		{label: "Embeddings", value: "embedding", description: "search, RAG, and semantic indexes"},
+		{label: "Image generation", value: "image", description: "Stable Diffusion, SDXL, Flux-style checkpoints"},
+	}
+}
+
+func recommendProviderChoices() []recommendChoice {
+	return []recommendChoice{
+		{label: "All providers", value: discovery.ProviderAll, description: "search Hugging Face, CivitAI, and ModelScope"},
+		{label: "Hugging Face", value: discovery.ProviderHuggingFace, description: "best for GGUF and general ML artifacts"},
+		{label: "CivitAI", value: discovery.ProviderCivitAI, description: "best for Stable Diffusion artifacts"},
+		{label: "ModelScope", value: discovery.ProviderModelScope, description: "alternate model catalog"},
+	}
+}
+
+func recommendRuntimeChoices() []recommendChoice {
+	return []recommendChoice{
+		{label: "Any runtime", value: "any", description: "show every compatible result"},
+		{label: "llama.cpp", value: "llama.cpp", description: "local GGUF runtimes and servers"},
+		{label: "Ollama", value: "ollama", description: "GGUF import into Ollama models"},
+		{label: "LM Studio", value: "lm studio", description: "desktop GGUF model loading"},
+		{label: "MLX", value: "mlx", description: "Apple Silicon safetensors workflows"},
+		{label: "ComfyUI", value: "comfyui", description: "image checkpoints and LoRAs"},
+		{label: "AUTOMATIC1111/Forge", value: "automatic1111", description: "Stable Diffusion WebUI layouts"},
+	}
+}
+
+func recommendSizeChoices() []recommendChoice {
+	return []recommendChoice{
+		{label: "Any size", value: "any", description: "rank by hardware fit only"},
+		{label: "Up to 4 GiB", value: "4", description: "small first download", bytes: 4 << 30},
+		{label: "Up to 8 GiB", value: "8", description: "typical 7B Q4/Q5 models", bytes: 8 << 30},
+		{label: "Up to 16 GiB", value: "16", description: "larger 14B-ish local models", bytes: 16 << 30},
+		{label: "Up to 32 GiB", value: "32", description: "larger local models and image checkpoints", bytes: 32 << 30},
+		{label: "Up to 64 GiB", value: "64", description: "large unified-memory systems", bytes: 64 << 30},
+	}
+}
+
+func (m *Model) recommendHardwareChoices() []recommendChoice {
+	hw := m.recommendFlow.hardware
+	detected := "Detected"
+	var parts []string
+	if hw.OS != "" || hw.Arch != "" {
+		parts = append(parts, strings.Trim(strings.ToLower(hw.OS+"/"+hw.Arch), "/"))
+	}
+	if hw.RAMBytes > 0 {
+		parts = append(parts, "RAM "+humanize.Bytes(uint64(hw.RAMBytes)))
+	}
+	if hw.VRAMBytes > 0 {
+		parts = append(parts, "VRAM "+humanize.Bytes(uint64(hw.VRAMBytes)))
+	}
+	if hw.UnifiedMemory {
+		parts = append(parts, "unified")
+	}
+	if len(parts) > 0 {
+		detected += ": " + strings.Join(parts, ", ")
+	}
+	return []recommendChoice{
+		{label: detected, value: "detected", description: "use this machine's detected hardware"},
+		{label: "16 GiB RAM", value: "16", description: "override for smaller machines", bytes: 16 << 30},
+		{label: "32 GiB RAM", value: "32", description: "mainstream local model box", bytes: 32 << 30},
+		{label: "64 GiB RAM", value: "64", description: "larger model workstation", bytes: 64 << 30},
+		{label: "128 GiB RAM", value: "128", description: "large unified-memory Mac or server", bytes: 128 << 30},
+	}
+}
+
+func (m *Model) renderRecommendFlow() string {
+	var sb strings.Builder
+	sb.WriteString(m.th.head.Render("Recommend Models") + "\n")
+	sb.WriteString(m.th.label.Render(m.renderRecommendSummary()) + "\n\n")
+	if m.recommendFlow.loading {
+		sb.WriteString(m.th.label.Render("Searching providers and applying local history...") + "\n")
+		sb.WriteString(m.th.label.Render("Esc cancels the panel; the search will finish in the background."))
+		return sb.String()
+	}
+	if m.recommendFlow.err != "" {
+		sb.WriteString(m.th.bad.Render("Error: "+m.recommendFlow.err) + "\n\n")
+	}
+	switch m.recommendFlow.step {
+	case recommendStepTask:
+		sb.WriteString(m.th.label.Render("Choose the job this model should do.") + "\n\n")
+		sb.WriteString(m.renderRecommendChoices(recommendTaskChoices(), m.recommendFlow.taskIndex))
+	case recommendStepHardware:
+		sb.WriteString(m.th.label.Render("Choose the hardware budget to rank against.") + "\n\n")
+		sb.WriteString(m.renderRecommendChoices(m.recommendHardwareChoices(), m.recommendFlow.hardwareIndex))
+	case recommendStepProvider:
+		sb.WriteString(m.th.label.Render("Choose where to search.") + "\n\n")
+		sb.WriteString(m.renderRecommendChoices(recommendProviderChoices(), m.recommendFlow.providerIndex))
+	case recommendStepRuntime:
+		sb.WriteString(m.th.label.Render("Choose a runtime or placement target.") + "\n\n")
+		sb.WriteString(m.renderRecommendChoices(recommendRuntimeChoices(), m.recommendFlow.runtimeIndex))
+	case recommendStepSize:
+		sb.WriteString(m.th.label.Render("Choose the maximum file size.") + "\n\n")
+		sb.WriteString(m.renderRecommendChoices(recommendSizeChoices(), m.recommendFlow.sizeIndex))
+	case recommendStepQuery:
+		sb.WriteString(m.th.label.Render("Search terms are optional; empty uses the task default.") + "\n")
+		sb.WriteString(m.th.label.Render("Default: "+recommend.DefaultQuery(m.selectedRecommendTask())) + "\n\n")
+		sb.WriteString(m.recommendFlow.input.View())
+	case recommendStepResults:
+		sb.WriteString(m.renderRecommendResults())
+	}
+	sb.WriteString("\n")
+	sb.WriteString(m.th.label.Render("j/k: choose  •  Enter: continue/start  •  Left: back  •  Esc: close") + "\n")
+	return sb.String()
+}
+
+func (m *Model) renderRecommendChoices(choices []recommendChoice, selected int) string {
+	var sb strings.Builder
+	for i, choice := range choices {
+		prefix := "  "
+		if i == selected {
+			prefix = "▸ "
+		}
+		line := fmt.Sprintf("%s%-24s %s", prefix, choice.label, choice.description)
+		if i == selected {
+			sb.WriteString(m.th.ok.Render(line) + "\n")
+		} else {
+			sb.WriteString(m.th.label.Render(line) + "\n")
+		}
+	}
+	return sb.String()
+}
+
+func (m *Model) renderRecommendResults() string {
+	var sb strings.Builder
+	if len(m.recommendFlow.results) == 0 {
+		sb.WriteString(m.th.label.Render("No recommendations matched the selected filters.") + "\n")
+		sb.WriteString(m.th.label.Render("Go back and loosen the runtime, size, or provider filter.") + "\n")
+		return sb.String()
+	}
+	sb.WriteString(m.th.label.Render("Select a model to start the normal resumable download path.") + "\n\n")
+	for i, rec := range m.recommendFlow.results {
+		prefix := "  "
+		if i == m.recommendFlow.selected {
+			prefix = "▸ "
+		}
+		size := "-"
+		if rec.Size > 0 {
+			size = humanize.Bytes(uint64(rec.Size))
+		}
+		meta := []string{rec.Provider, "fit=" + rec.Fit, "score=" + fmt.Sprint(rec.Score), "size=" + size}
+		if rec.ParameterCount != "" {
+			meta = append(meta, rec.ParameterCount)
+		}
+		if rec.Quantization != "" {
+			meta = append(meta, rec.Quantization)
+		}
+		line := fmt.Sprintf("%s%d. %s", prefix, rec.Index, truncateMiddle(rec.Name, 44))
+		detail := "    " + strings.Join(meta, " • ")
+		if i == m.recommendFlow.selected {
+			sb.WriteString(m.th.ok.Render(line) + "\n")
+			sb.WriteString(m.th.label.Render(detail) + "\n")
+			if len(rec.RuntimeHints) > 0 {
+				sb.WriteString(m.th.label.Render("    runtimes: "+renderRuntimeHints(rec.RuntimeHints)) + "\n")
+			}
+			if len(rec.Reasons) > 0 {
+				sb.WriteString(m.th.label.Render("    why: "+truncateMiddle(strings.Join(rec.Reasons, "; "), 96)) + "\n")
+			}
+			sb.WriteString(m.th.label.Render("    uri: "+truncateMiddle(rec.URI, 96)) + "\n")
+		} else {
+			sb.WriteString(m.th.label.Render(line+"  "+strings.Join(meta, " • ")) + "\n")
+		}
+	}
+	return sb.String()
+}
+
+func renderRuntimeHints(hints []recommend.RuntimeHint) string {
+	parts := make([]string, 0, len(hints))
+	for _, hint := range hints {
+		value := hint.Runtime
+		if hint.PlacementPreset != "" {
+			value += " -> " + hint.PlacementPreset
+		}
+		parts = append(parts, value)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func (m *Model) renderRecommendSummary() string {
+	step := "task"
+	switch m.recommendFlow.step {
+	case recommendStepHardware:
+		step = "hardware"
+	case recommendStepProvider:
+		step = "provider"
+	case recommendStepRuntime:
+		step = "runtime"
+	case recommendStepSize:
+		step = "size"
+	case recommendStepQuery:
+		step = "query"
+	case recommendStepResults:
+		step = "results"
+	}
+	query := strings.TrimSpace(m.recommendFlow.query)
+	if query == "" {
+		query = recommend.DefaultQuery(m.selectedRecommendTask())
+	}
+	size := "any"
+	if b := m.selectedRecommendSizeLimit(); b > 0 {
+		size = humanize.Bytes(uint64(b))
+	}
+	return fmt.Sprintf("Step: %s • task=%s • source=%s • runtime=%s • max-size=%s • query=%s",
+		step, m.selectedRecommendTask(), m.selectedRecommendProvider(), m.selectedRecommendRuntime(), size, query)
+}

--- a/internal/tui/recommend_flow.go
+++ b/internal/tui/recommend_flow.go
@@ -38,6 +38,7 @@ type recommendFlow struct {
 	active        bool
 	step          recommendStep
 	input         textinput.Model
+	cancel        context.CancelFunc
 	taskIndex     int
 	hardwareIndex int
 	providerIndex int
@@ -63,7 +64,7 @@ type recommendResultsMsg struct {
 }
 
 func (m *Model) startRecommendFlow() {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	input := textinput.New()
 	input.Placeholder = "Optional search, e.g. llama 8b gguf"
@@ -79,6 +80,10 @@ func (m *Model) startRecommendFlow() {
 func (m *Model) updateRecommendFlow(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	s := msg.String()
 	if s == "esc" {
+		if m.recommendFlow.cancel != nil {
+			m.recommendFlow.cancel()
+			m.recommendFlow.cancel = nil
+		}
 		m.recommendFlow.active = false
 		m.recommendFlow.input.Blur()
 		return m, nil
@@ -96,7 +101,7 @@ func (m *Model) updateRecommendFlow(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.recommendFlow.err = ""
 			m.recommendFlow.results = nil
 			return m, m.recommendSearchCmd()
-		case "left", "ctrl+h":
+		case "shift+tab":
 			m.recommendFlow.step = recommendStepSize
 			m.recommendFlow.input.Blur()
 			return m, nil
@@ -117,7 +122,7 @@ func (m *Model) updateRecommendFlow(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.recommendFlow.selected--
 			}
 			return m, nil
-		case "left", "ctrl+h":
+		case "left", "shift+tab":
 			m.recommendFlow.step = recommendStepQuery
 			m.recommendFlow.input.Focus()
 			return m, nil
@@ -215,8 +220,9 @@ func (m *Model) recommendSearchCmd() tea.Cmd {
 	query := strings.TrimSpace(m.recommendFlow.query)
 	hardware := m.selectedRecommendHardware()
 	st := m.st
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	m.recommendFlow.cancel = cancel
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 		defer cancel()
 		effectiveTask := recommend.NormalizeTask(task)
 		effectiveQuery := query
@@ -233,7 +239,7 @@ func (m *Model) recommendSearchCmd() tea.Cmd {
 			}
 		}
 		recs, hw, err := recommend.Recommend(ctx, recommend.Options{
-			Query:    query,
+			Query:    effectiveQuery,
 			Task:     task,
 			Provider: provider,
 			Limit:    20,
@@ -342,12 +348,10 @@ func (m *Model) startRecommendedDownload() tea.Cmd {
 		hardwareKey = recommend.HardwareKey(m.recommendFlow.hardware)
 	}
 	if err := recommend.RecordHistory(m.st, task, query, hardwareKey, m.recommendFlow.results, "selected", rec.Index); err != nil {
-		m.addToast("recommend history failed: " + err.Error())
-		return nil
+		m.addToast("warning: selection history failed: " + err.Error())
 	}
 	if err := recommend.RecordHistory(m.st, task, query, hardwareKey, m.recommendFlow.results, "skipped", rec.Index); err != nil {
-		m.addToast("recommend history failed: " + err.Error())
-		return nil
+		m.addToast("warning: skipped history failed: " + err.Error())
 	}
 	artifactType := recommendArtifactType(rec, task, runtimeTarget)
 	dest := m.computeDefaultDest(rec.URI)
@@ -387,13 +391,7 @@ func (m *Model) recommendPlacementDestination(urlStr, artifactType, preset strin
 	if preset == "" || artifactType == "" {
 		return "", false
 	}
-	base := filepath.Base(m.computeDefaultDest(urlStr))
-	if strings.TrimSpace(base) == "" || base == "." || base == string(filepath.Separator) {
-		base = filepath.Base(m.immediateDestCandidate(urlStr))
-	}
-	if strings.TrimSpace(base) == "" || base == "." || base == string(filepath.Separator) {
-		base = "download"
-	}
+	base := m.recommendDestinationBase(urlStr)
 	for _, rule := range m.cfg.Placement.Mapping {
 		if strings.TrimSpace(rule.Match) != artifactType {
 			continue
@@ -415,6 +413,17 @@ func (m *Model) recommendPlacementDestination(urlStr, artifactType, preset strin
 		}
 	}
 	return "", false
+}
+
+func (m *Model) recommendDestinationBase(urlStr string) string {
+	base := filepath.Base(m.computeDefaultDest(urlStr))
+	if strings.TrimSpace(base) == "" || base == "." || base == string(filepath.Separator) {
+		base = filepath.Base(m.immediateDestCandidate(urlStr))
+	}
+	if strings.TrimSpace(base) == "" || base == "." || base == string(filepath.Separator) {
+		return "download"
+	}
+	return base
 }
 
 func (m *Model) ensureDownloadMaps() {
@@ -597,8 +606,12 @@ func (m *Model) renderRecommendFlow() string {
 	case recommendStepResults:
 		sb.WriteString(m.renderRecommendResults())
 	}
+	backHint := "Shift+Tab/Left"
+	if m.recommendFlow.step == recommendStepQuery {
+		backHint = "Shift+Tab"
+	}
 	sb.WriteString("\n")
-	sb.WriteString(m.th.label.Render("j/k: choose  •  Enter: continue/start  •  Left: back  •  Esc: close") + "\n")
+	sb.WriteString(m.th.label.Render("j/k: choose  •  Enter: continue/start  •  "+backHint+": back  •  Esc: close") + "\n")
 	return sb.String()
 }
 

--- a/internal/tui/recommend_flow.go
+++ b/internal/tui/recommend_flow.go
@@ -37,6 +37,7 @@ type recommendChoice struct {
 type recommendFlow struct {
 	active        bool
 	step          recommendStep
+	flowID        int64
 	input         textinput.Model
 	cancel        context.CancelFunc
 	taskIndex     int
@@ -55,11 +56,13 @@ type recommendFlow struct {
 }
 
 type recommendResultsMsg struct {
+	flowID          int64
 	recommendations []recommend.Recommendation
 	hardware        recommend.HardwareProfile
 	query           string
 	task            string
 	hardwareKey     string
+	warning         string
 	err             error
 }
 
@@ -72,6 +75,7 @@ func (m *Model) startRecommendFlow() {
 	m.recommendFlow = recommendFlow{
 		active:   true,
 		step:     recommendStepTask,
+		flowID:   time.Now().UnixNano(),
 		input:    input,
 		hardware: recommend.DetectHardware(ctx),
 	}
@@ -219,6 +223,7 @@ func (m *Model) recommendSearchCmd() tea.Cmd {
 	sizeLimit := m.selectedRecommendSizeLimit()
 	query := strings.TrimSpace(m.recommendFlow.query)
 	hardware := m.selectedRecommendHardware()
+	flowID := m.recommendFlow.flowID
 	st := m.st
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	m.recommendFlow.cancel = cancel
@@ -235,19 +240,19 @@ func (m *Model) recommendSearchCmd() tea.Cmd {
 			var err error
 			feedback, err = recommend.FeedbackFromHistory(st, effectiveTask, effectiveQuery, hardwareKey)
 			if err != nil {
-				return recommendResultsMsg{err: fmt.Errorf("load recommendation history: %w", err)}
+				return recommendResultsMsg{flowID: flowID, err: fmt.Errorf("load recommendation history: %w", err)}
 			}
 		}
 		recs, hw, err := recommend.Recommend(ctx, recommend.Options{
 			Query:    effectiveQuery,
-			Task:     task,
+			Task:     effectiveTask,
 			Provider: provider,
 			Limit:    20,
 			Hardware: hardware,
 			Feedback: feedback,
 		})
 		if err != nil {
-			return recommendResultsMsg{err: err}
+			return recommendResultsMsg{flowID: flowID, err: err}
 		}
 		recs = filterRecommendResults(recs, runtimeTarget, sizeLimit)
 		if len(recs) > 8 {
@@ -256,17 +261,20 @@ func (m *Model) recommendSearchCmd() tea.Cmd {
 		for i := range recs {
 			recs[i].Index = i + 1
 		}
+		warning := ""
 		if st != nil && len(recs) > 0 {
 			if err := recommend.RecordHistory(st, effectiveTask, effectiveQuery, hardwareKey, recs, "shown", 0); err != nil {
-				return recommendResultsMsg{err: fmt.Errorf("record shown recommendations: %w", err)}
+				warning = "record shown recommendations: " + err.Error()
 			}
 		}
 		return recommendResultsMsg{
+			flowID:          flowID,
 			recommendations: recs,
 			hardware:        hw,
 			query:           effectiveQuery,
 			task:            effectiveTask,
 			hardwareKey:     hardwareKey,
+			warning:         warning,
 		}
 	}
 }

--- a/internal/tui/recommend_flow.go
+++ b/internal/tui/recommend_flow.go
@@ -283,7 +283,7 @@ func filterRecommendResults(recs []recommend.Recommendation, runtimeTarget strin
 	runtimeTarget = strings.ToLower(strings.TrimSpace(runtimeTarget))
 	out := make([]recommend.Recommendation, 0, len(recs))
 	for _, rec := range recs {
-		if sizeLimit > 0 && (rec.Size <= 0 || rec.Size > sizeLimit) {
+		if sizeLimit > 0 && rec.Size > 0 && rec.Size > sizeLimit {
 			continue
 		}
 		if runtimeTarget != "" && runtimeTarget != "any" && !recommendationMatchesRuntime(rec, runtimeTarget) {
@@ -356,10 +356,9 @@ func (m *Model) startRecommendedDownload() tea.Cmd {
 		hardwareKey = recommend.HardwareKey(m.recommendFlow.hardware)
 	}
 	if err := recommend.RecordHistory(m.st, task, query, hardwareKey, m.recommendFlow.results, "selected", rec.Index); err != nil {
-		m.addToast("warning: selection history failed: " + err.Error())
-	}
-	if err := recommend.RecordHistory(m.st, task, query, hardwareKey, m.recommendFlow.results, "skipped", rec.Index); err != nil {
-		m.addToast("warning: skipped history failed: " + err.Error())
+		m.addToast("warning: recommendation history failed: " + err.Error())
+	} else if err := recommend.RecordHistory(m.st, task, query, hardwareKey, m.recommendFlow.results, "skipped", rec.Index); err != nil {
+		m.addToast("warning: recommendation history failed: " + err.Error())
 	}
 	artifactType := recommendArtifactType(rec, task, runtimeTarget)
 	dest := m.computeDefaultDest(rec.URI)

--- a/internal/tui/recommend_flow_test.go
+++ b/internal/tui/recommend_flow_test.go
@@ -1,0 +1,201 @@
+package tui
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jxwalker/modfetch/internal/config"
+	"github.com/jxwalker/modfetch/internal/discovery"
+	"github.com/jxwalker/modfetch/internal/recommend"
+	"github.com/jxwalker/modfetch/internal/state"
+)
+
+func TestRecommendFlowFiltersByRuntimeAndSize(t *testing.T) {
+	recs := []recommend.Recommendation{
+		{
+			Name:  "small ollama",
+			URI:   "hf://owner/small/model.gguf?rev=main",
+			Size:  5 << 30,
+			Index: 1,
+			RuntimeHints: []recommend.RuntimeHint{
+				{Runtime: "Ollama", PlacementPreset: "ollama"},
+			},
+		},
+		{
+			Name:  "large ollama",
+			URI:   "hf://owner/large/model.gguf?rev=main",
+			Size:  20 << 30,
+			Index: 2,
+			RuntimeHints: []recommend.RuntimeHint{
+				{Runtime: "Ollama", PlacementPreset: "ollama"},
+			},
+		},
+		{
+			Name:  "image checkpoint",
+			URI:   "hf://owner/image/model.safetensors?rev=main",
+			Size:  5 << 30,
+			Index: 3,
+			RuntimeHints: []recommend.RuntimeHint{
+				{Runtime: "ComfyUI", PlacementPreset: "comfyui"},
+			},
+		},
+	}
+
+	got := filterRecommendResults(recs, "ollama", 8<<30)
+	if len(got) != 1 || got[0].Name != "small ollama" {
+		t.Fatalf("filtered recommendations = %+v, want only small ollama", got)
+	}
+}
+
+func TestRecommendFlowStartsSelectedRecommendationDownload(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := state.NewDB(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	cfg := &config.Config{
+		General: config.General{
+			DataRoot:      tmpDir,
+			DownloadRoot:  tmpDir,
+			PlacementMode: "symlink",
+		},
+	}
+	m := New(cfg, db, "test").(*Model)
+	m.recommendFlow = recommendFlow{
+		active:      true,
+		step:        recommendStepResults,
+		task:        "chat",
+		query:       "llama instruct gguf",
+		hardwareKey: "darwin/arm64/ram128g/unified",
+		hardware:    recommend.HardwareProfile{OS: "darwin", Arch: "arm64", RAMBytes: 128 << 30, UnifiedMemory: true},
+		results: []recommend.Recommendation{
+			{
+				Index:    1,
+				Provider: discovery.ProviderHuggingFace,
+				ModelID:  "owner/model",
+				Name:     "Owner Model",
+				URI:      "https://example.com/model.gguf",
+				FileName: "model.gguf",
+				FileType: "gguf",
+				Score:    120,
+				Fit:      "excellent",
+			},
+		},
+	}
+
+	_, cmd := m.updateRecommendFlow(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected selected recommendation to return a download command")
+	}
+	if m.recommendFlow.active {
+		t.Fatal("recommend flow should close after starting a download")
+	}
+
+	rows, err := db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("download rows = %+v, want one pending row", rows)
+	}
+	if rows[0].URL != "https://example.com/model.gguf" || rows[0].Status != "pending" {
+		t.Fatalf("download row = %+v, want pending recommendation URL", rows[0])
+	}
+	if _, ok := m.running["https://example.com/model.gguf|"+rows[0].Dest]; !ok {
+		t.Fatalf("expected running cancellation handle for %q", rows[0].Dest)
+	}
+
+	history, err := db.RecommendationHistoryFor("chat", "llama instruct gguf", "darwin/arm64/ram128g/unified")
+	if err != nil {
+		t.Fatalf("recommendation history: %v", err)
+	}
+	if len(history) != 1 || history[0].Action != "selected" {
+		t.Fatalf("history = %+v, want selected row", history)
+	}
+}
+
+func TestRecommendFlowUsesConfiguredPlacementTargetAsDestination(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := state.NewDB(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	cfg := &config.Config{
+		General: config.General{
+			DataRoot:      tmpDir,
+			DownloadRoot:  filepath.Join(tmpDir, "downloads"),
+			PlacementMode: "symlink",
+		},
+		Placement: config.Placement{
+			Apps: map[string]config.AppPlacement{
+				"ollama": {
+					Base: filepath.Join(tmpDir, "ollama"),
+					Paths: map[string]string{
+						"models": "models",
+					},
+				},
+			},
+			Mapping: []config.MappingRule{
+				{Match: "llm.gguf", Targets: []config.MappingTarget{{App: "ollama", PathKey: "models"}}},
+			},
+		},
+	}
+	m := New(cfg, db, "test").(*Model)
+	m.recommendFlow = recommendFlow{
+		active:       true,
+		step:         recommendStepResults,
+		task:         "chat",
+		query:        "llama instruct gguf",
+		hardwareKey:  "darwin/arm64/ram128g/unified",
+		hardware:     recommend.HardwareProfile{OS: "darwin", Arch: "arm64", RAMBytes: 128 << 30, UnifiedMemory: true},
+		runtimeIndex: 2, // Ollama
+		results: []recommend.Recommendation{
+			{
+				Index:    1,
+				Provider: discovery.ProviderHuggingFace,
+				ModelID:  "owner/model",
+				Name:     "Owner Model",
+				URI:      "https://example.com/model.gguf",
+				FileName: "model.gguf",
+				FileType: "gguf",
+				Score:    120,
+				Fit:      "excellent",
+				RuntimeHints: []recommend.RuntimeHint{
+					{Runtime: "Ollama", PlacementPreset: "ollama"},
+				},
+			},
+		},
+	}
+
+	_, cmd := m.updateRecommendFlow(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected selected recommendation to return a download command")
+	}
+	rows, err := db.ListDownloads()
+	if err != nil {
+		t.Fatalf("list downloads: %v", err)
+	}
+	wantDest := filepath.Join(tmpDir, "ollama", "models", "model.gguf")
+	if len(rows) != 1 || rows[0].Dest != wantDest {
+		t.Fatalf("download rows = %+v, want dest %q", rows, wantDest)
+	}
+	if m.autoPlace["https://example.com/model.gguf|"+wantDest] {
+		t.Fatal("recommend placement target should use the target destination without a second place pass")
+	}
+}
+
+func TestRecommendFlowRenderTaskStep(t *testing.T) {
+	m := &Model{th: defaultTheme()}
+	m.startRecommendFlow()
+
+	view := m.renderRecommendFlow()
+	if !strings.Contains(view, "Recommend Models") || !strings.Contains(view, "Chat / assistant") {
+		t.Fatalf("recommend flow view missing expected labels:\n%s", view)
+	}
+}

--- a/internal/tui/recommend_flow_test.go
+++ b/internal/tui/recommend_flow_test.go
@@ -50,6 +50,31 @@ func TestRecommendFlowFiltersByRuntimeAndSize(t *testing.T) {
 	}
 }
 
+func TestRecommendFlowSizeFilterKeepsUnknownSizeResults(t *testing.T) {
+	recs := []recommend.Recommendation{
+		{
+			Name: "unknown ollama",
+			URI:  "hf://owner/unknown/model.gguf?rev=main",
+			RuntimeHints: []recommend.RuntimeHint{
+				{Runtime: "Ollama", PlacementPreset: "ollama"},
+			},
+		},
+		{
+			Name: "known too large",
+			URI:  "hf://owner/large/model.gguf?rev=main",
+			Size: 20 << 30,
+			RuntimeHints: []recommend.RuntimeHint{
+				{Runtime: "Ollama", PlacementPreset: "ollama"},
+			},
+		},
+	}
+
+	got := filterRecommendResults(recs, "ollama", 8<<30)
+	if len(got) != 1 || got[0].Name != "unknown ollama" {
+		t.Fatalf("filtered recommendations = %+v, want unknown-size result kept", got)
+	}
+}
+
 func TestRecommendFlowStartsSelectedRecommendationDownload(t *testing.T) {
 	tmpDir := t.TempDir()
 	db, err := state.NewDB(filepath.Join(tmpDir, "state.db"))

--- a/internal/tui/recommend_flow_test.go
+++ b/internal/tui/recommend_flow_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jxwalker/modfetch/internal/config"
 	"github.com/jxwalker/modfetch/internal/discovery"
@@ -187,6 +188,41 @@ func TestRecommendFlowUsesConfiguredPlacementTargetAsDestination(t *testing.T) {
 	}
 	if m.autoPlace["https://example.com/model.gguf|"+wantDest] {
 		t.Fatal("recommend placement target should use the target destination without a second place pass")
+	}
+}
+
+func TestRecommendFlowQueryStepKeepsTextEditingKeys(t *testing.T) {
+	input := textinput.New()
+	input.SetValue("llama")
+	m := &Model{recommendFlow: recommendFlow{active: true, step: recommendStepQuery, input: input}}
+	m.recommendFlow.input.Focus()
+
+	m.updateRecommendFlow(tea.KeyMsg{Type: tea.KeyLeft})
+	if m.recommendFlow.step != recommendStepQuery {
+		t.Fatalf("left should stay in query input, got step %v", m.recommendFlow.step)
+	}
+
+	m.updateRecommendFlow(tea.KeyMsg{Type: tea.KeyShiftTab})
+	if m.recommendFlow.step != recommendStepSize {
+		t.Fatalf("shift+tab should navigate back to size step, got %v", m.recommendFlow.step)
+	}
+}
+
+func TestRecommendFlowEscCancelsInFlightSearch(t *testing.T) {
+	cancelled := false
+	m := &Model{recommendFlow: recommendFlow{
+		active:  true,
+		loading: true,
+		cancel:  func() { cancelled = true },
+	}}
+
+	m.updateRecommendFlow(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if !cancelled {
+		t.Fatal("expected esc to cancel in-flight recommendation search")
+	}
+	if m.recommendFlow.active {
+		t.Fatal("expected esc to close recommendation flow")
 	}
 }
 

--- a/internal/tui/recommend_flow_test.go
+++ b/internal/tui/recommend_flow_test.go
@@ -226,6 +226,30 @@ func TestRecommendFlowEscCancelsInFlightSearch(t *testing.T) {
 	}
 }
 
+func TestRecommendResultsIgnoreStaleFlow(t *testing.T) {
+	m := &Model{recommendFlow: recommendFlow{
+		active:  true,
+		loading: true,
+		flowID:  2,
+	}}
+
+	m.Update(recommendResultsMsg{
+		flowID: 1,
+		recommendations: []recommend.Recommendation{{
+			Index: 1,
+			Name:  "stale",
+			URI:   "https://example.com/stale.gguf",
+		}},
+	})
+
+	if !m.recommendFlow.loading {
+		t.Fatal("stale result should not mutate the active flow")
+	}
+	if len(m.recommendFlow.results) != 0 {
+		t.Fatalf("stale result populated results: %+v", m.recommendFlow.results)
+	}
+}
+
 func TestRecommendFlowRenderTaskStep(t *testing.T) {
 	m := &Model{th: defaultTheme()}
 	m.startRecommendFlow()


### PR DESCRIPTION
## Summary
- add a guided `G` recommendation flow in the TUI for task, hardware, provider, runtime/placement target, size, and query selection
- reuse shared recommendation history helpers across CLI and TUI, then hand selected results into the existing resumable TUI download path
- update README, changelog, quickstart, user guide, TUI guide, wireframes, roadmap, and TUI analysis docs

## Validation
- go test -count=1 ./...
- make lint
- scripts/check-docs-drift.sh && git diff --check
- go run ./cmd/modfetch recommend "tiny gpt2" --provider huggingface --limit 2 --no-learn --json
- bin/modfetch recommend "tiny gpt2" --provider huggingface --limit 1 --no-learn --download --select 1 --dry-run --dest /tmp/modfetch-recommend-dryrun-model.safetensors --summary-json
- go run ./cmd/modfetch tui --snapshot --json
- make build