### PR TITLE
feat: add recommendation result inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Added
   model by task, detected or overridden hardware budget, provider, runtime or
   placement target, and maximum file size before starting a normal resumable
   download.
+- Added TUI recommendation inspection: result rows now expose rationale,
+  runtime setup guidance, placement readiness, dry-run destination and transfer
+  settings, plus a live metadata probe for size, range support, and prior host
+  transfer history before starting a large download.
 
 ## v0.8.0 — 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -129,9 +129,11 @@ The modfetch TUI provides a beautiful, full-featured interface for managing your
 - **Guided TUI recommendations**: press `G` in the TUI to choose a model by
   task, detected or overridden hardware budget, provider, runtime or placement
   target, and maximum file size, then start the same resumable download path
-  used by `modfetch download`.
-- **Recommendation refinements**: richer result inspection and runtime-specific
-  setup guidance after the guided TUI recommendation flow starts a download.
+  used by `modfetch download`. In the result list, press `i` for rationale,
+  runtime setup, placement, and dry-run transfer details, or `p` to probe live
+  size/range metadata before starting a large download.
+- **Recommendation refinements**: end-to-end release hardening around the guided
+  recommendation path and real-provider UAT before the next patch tag.
 
 ## What's new in v0.8.0
 - **Hardware-aware recommendations**: `modfetch recommend --task coding` detects

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -234,7 +234,10 @@ Inside the TUI, press `G` to choose a model without copying a URL. The guided
 flow filters live provider results by task, detected or overridden hardware,
 provider, runtime or placement target, and maximum file size. Press `Enter` on
 the selected recommendation to start the same resumable download pipeline used
-by the CLI.
+by the CLI. Before starting a large result, press `i` to inspect why it was
+ranked, where it will be placed, and what runtime setup it expects; press `p`
+to run a live metadata probe for remote size, range support, and prior host
+transfer history without writing files.
 
 If you want modfetch to choose a model that fits your hardware, use
 `recommend`:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -186,10 +186,13 @@ These are useful, but not required for the first v0.7.0 release:
 - [DONE] Interactive recommendation flow in the TUI:
   add a guided "choose a model" workflow that filters by task, hardware, file
   size, source, and placement target before starting a download.
-- [NEXT] Recommendation result inspection:
+- [DONE] Recommendation result inspection:
   add richer TUI detail views for recommendation rationale, runtime setup
   commands, placement prerequisites, and dry-run transfer metadata before the
   user starts a large download.
+- [NEXT] Recommendation release hardening:
+  run end-to-end UAT on the CLI and TUI recommendation flows, refresh release
+  notes, and prepare a patch tag once the guided recommendation work is merged.
 
 ## Completed Release History
 

--- a/docs/TUI_ANALYSIS_SUMMARY.txt
+++ b/docs/TUI_ANALYSIS_SUMMARY.txt
@@ -67,6 +67,11 @@ Recommendation workflow:
     target, maximum file size, and optional query
   - Results reuse the same recommendation ranking and history helpers as the
     CLI
+  - Result inspection (`i`) shows ranking rationale, memory fit, runtime setup,
+    placement readiness, destination, and transfer settings
+  - Live recommendation probing (`p`) resolves the selected URI and checks remote
+    size, range support, server filename, validators, and learned transfer
+    history without starting a download
   - Selecting a result creates a normal pending row and starts the existing
     resumable download path
 

--- a/docs/TUI_GUIDE.md
+++ b/docs/TUI_GUIDE.md
@@ -156,6 +156,14 @@ resumable downloader. When a runtime has a placement preset and your config has
 matching placement rules, the TUI saves the file directly under that configured
 target; otherwise it saves under `download_root`.
 
+On the result list, press `i` to inspect the selected recommendation before
+starting it. The detail view shows the ranking rationale, estimated memory
+budget, runtime setup guidance, placement preset readiness, planned destination,
+and current transfer settings. Press `p` to run a live metadata probe for the
+selected URL; the probe resolves resolver URIs, checks remote size and range
+support, and shows any prior per-host transfer history that will influence
+adaptive downloads. The probe does not create a download row or write files.
+
 ### Settings Tab Keys
 
 - `j`/`k` or arrow keys - Scroll settings view

--- a/docs/TUI_WIREFRAMES.md
+++ b/docs/TUI_WIREFRAMES.md
@@ -411,6 +411,7 @@ The modfetch TUI has **7 tabs** organized into three functional groups:
    └─► Press '0' (All tab)
        └─► Press 'G' (guided recommendation) or 'n' (known URL)
        └─► Choose model filters or paste URL
+       └─► On recommendation results, press 'i' for details or 'p' to probe
        └─► Watch in Active tab (Press '2')
 
 5. Organize your library

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -106,7 +106,11 @@ modfetch recommend --task coding --no-learn
 The same selection path is available in the TUI. Launch `modfetch tui`, press
 `G`, choose the task, hardware budget, provider, runtime or placement target,
 maximum file size, and optional query, then press `Enter` on a recommendation
-to start the normal resumable download.
+to start the normal resumable download. On the recommendation result list,
+press `i` to inspect ranking rationale, runtime setup, placement prerequisites,
+and the dry-run destination/transfer plan. Press `p` to run a live metadata
+probe that checks the resolved URL, remote size, range support, and any learned
+per-host transfer history before you commit to a large download.
 
 #### Dry-run planning
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -107,6 +107,7 @@ func (m *Model) renderHelp() string {
 	sb.WriteString("\n")
 	sb.WriteString(m.th.head.Render("Download Tabs (1-4)") + "\n")
 	sb.WriteString("Recommend: G opens guided model selection by task, hardware, provider, runtime, and size\n")
+	sb.WriteString("Recommend results: i inspect rationale/placement/transfer plan • p probe live metadata\n")
 	sb.WriteString("Nav: j/k up/down\n")
 	sb.WriteString("Filter: / to enter; Enter to apply; Esc to clear\n")
 	sb.WriteString("Sort: s speed • e ETA • R remaining • o clear\n")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/dustin/go-humanize"
 	"github.com/jxwalker/modfetch/internal/config"
 	"github.com/jxwalker/modfetch/internal/logging"
 	"github.com/jxwalker/modfetch/internal/placer"
@@ -475,6 +476,36 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if strings.TrimSpace(msg.warning) != "" {
 			m.addToast("warning: " + msg.warning)
 		}
+		return m, nil
+	case recommendInspectProbeMsg:
+		if !m.recommendFlow.active || msg.flowID != m.recommendFlow.flowID {
+			return m, nil
+		}
+		if msg.selected != m.recommendFlow.selected {
+			return m, nil
+		}
+		if msg.selected < 0 || msg.selected >= len(m.recommendFlow.results) {
+			return m, nil
+		}
+		if m.recommendFlow.results[msg.selected].URI != msg.uri {
+			return m, nil
+		}
+		m.recommendFlow.cancel = nil
+		m.recommendFlow.inspect = true
+		m.recommendFlow.probeLoading = false
+		m.recommendFlow.probeErr = ""
+		if msg.err != nil {
+			m.recommendFlow.probeErr = msg.err.Error()
+			m.recommendFlow.probeDetails = recommendProbeDetails{}
+			m.addToast("recommend probe failed: " + msg.err.Error())
+			return m, nil
+		}
+		m.recommendFlow.probeDetails = msg.details
+		size := "unknown"
+		if msg.details.Size > 0 {
+			size = humanize.Bytes(uint64(msg.details.Size))
+		}
+		m.addToast("recommend probe: size=" + size + " ranges=" + fmt.Sprint(msg.details.AcceptRange))
 		return m, nil
 	case dlDoneMsg:
 		// Apply placement metadata if needed (safe concurrent map access from Update thread)

--- a/internal/tui/recommend_flow.go
+++ b/internal/tui/recommend_flow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -11,7 +12,9 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/dustin/go-humanize"
 	"github.com/jxwalker/modfetch/internal/discovery"
+	"github.com/jxwalker/modfetch/internal/downloader"
 	"github.com/jxwalker/modfetch/internal/recommend"
+	"github.com/jxwalker/modfetch/internal/resolver"
 	"github.com/jxwalker/modfetch/internal/state"
 )
 
@@ -51,6 +54,10 @@ type recommendFlow struct {
 	hardware      recommend.HardwareProfile
 	hardwareKey   string
 	results       []recommend.Recommendation
+	inspect       bool
+	probeLoading  bool
+	probeErr      string
+	probeDetails  recommendProbeDetails
 	loading       bool
 	err           string
 }
@@ -64,6 +71,35 @@ type recommendResultsMsg struct {
 	hardwareKey     string
 	warning         string
 	err             error
+}
+
+type recommendProbeDetails struct {
+	URI          string
+	ResolvedURL  string
+	FinalURL     string
+	Filename     string
+	Size         int64
+	ETag         string
+	LastModified string
+	AcceptRange  bool
+	History      state.TransferHistoryRow
+	HasHistory   bool
+}
+
+type recommendInspectProbeMsg struct {
+	flowID   int64
+	selected int
+	uri      string
+	details  recommendProbeDetails
+	err      error
+}
+
+type recommendLocalInspection struct {
+	Destination         string
+	ArtifactType        string
+	PlacementPreset     string
+	PlacementConfigured bool
+	PlacementNote       string
 }
 
 func (m *Model) startRecommendFlow() {
@@ -84,10 +120,7 @@ func (m *Model) startRecommendFlow() {
 func (m *Model) updateRecommendFlow(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	s := msg.String()
 	if s == "esc" {
-		if m.recommendFlow.cancel != nil {
-			m.recommendFlow.cancel()
-			m.recommendFlow.cancel = nil
-		}
+		m.cancelRecommendBackground()
 		m.recommendFlow.active = false
 		m.recommendFlow.input.Blur()
 		return m, nil
@@ -117,19 +150,22 @@ func (m *Model) updateRecommendFlow(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.recommendFlow.step == recommendStepResults {
 		switch s {
 		case "j", "down":
-			if m.recommendFlow.selected < len(m.recommendFlow.results)-1 {
-				m.recommendFlow.selected++
-			}
+			m.moveRecommendSelection(1)
 			return m, nil
 		case "k", "up":
-			if m.recommendFlow.selected > 0 {
-				m.recommendFlow.selected--
-			}
+			m.moveRecommendSelection(-1)
 			return m, nil
 		case "left", "shift+tab":
+			m.cancelRecommendBackground()
+			m.clearRecommendProbe()
 			m.recommendFlow.step = recommendStepQuery
 			m.recommendFlow.input.Focus()
 			return m, nil
+		case "i":
+			m.recommendFlow.inspect = !m.recommendFlow.inspect
+			return m, nil
+		case "p", "P":
+			return m, m.startRecommendProbe()
 		case "enter", "ctrl+j":
 			return m, m.startRecommendedDownload()
 		}
@@ -150,6 +186,37 @@ func (m *Model) updateRecommendFlow(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	return m, nil
+}
+
+func (m *Model) moveRecommendSelection(delta int) {
+	if len(m.recommendFlow.results) == 0 {
+		return
+	}
+	prev := m.recommendFlow.selected
+	m.recommendFlow.selected += delta
+	if m.recommendFlow.selected < 0 {
+		m.recommendFlow.selected = 0
+	}
+	if m.recommendFlow.selected >= len(m.recommendFlow.results) {
+		m.recommendFlow.selected = len(m.recommendFlow.results) - 1
+	}
+	if m.recommendFlow.selected != prev {
+		m.cancelRecommendBackground()
+		m.clearRecommendProbe()
+	}
+}
+
+func (m *Model) cancelRecommendBackground() {
+	if m.recommendFlow.cancel != nil {
+		m.recommendFlow.cancel()
+		m.recommendFlow.cancel = nil
+	}
+}
+
+func (m *Model) clearRecommendProbe() {
+	m.recommendFlow.probeLoading = false
+	m.recommendFlow.probeErr = ""
+	m.recommendFlow.probeDetails = recommendProbeDetails{}
 }
 
 func (m *Model) nextRecommendStep() {
@@ -216,6 +283,21 @@ func (m *Model) adjustRecommendChoice(delta int) {
 	}
 }
 
+func (m *Model) startRecommendProbe() tea.Cmd {
+	if len(m.recommendFlow.results) == 0 {
+		return nil
+	}
+	if m.recommendFlow.selected < 0 || m.recommendFlow.selected >= len(m.recommendFlow.results) {
+		m.recommendFlow.selected = 0
+	}
+	m.cancelRecommendBackground()
+	m.recommendFlow.inspect = true
+	m.recommendFlow.probeLoading = true
+	m.recommendFlow.probeErr = ""
+	m.recommendFlow.probeDetails = recommendProbeDetails{}
+	return m.recommendInspectProbeCmd()
+}
+
 func (m *Model) recommendSearchCmd() tea.Cmd {
 	task := m.selectedRecommendTask()
 	provider := m.selectedRecommendProvider()
@@ -279,6 +361,71 @@ func (m *Model) recommendSearchCmd() tea.Cmd {
 	}
 }
 
+func (m *Model) recommendInspectProbeCmd() tea.Cmd {
+	if m.recommendFlow.selected < 0 || m.recommendFlow.selected >= len(m.recommendFlow.results) {
+		return nil
+	}
+	rec := m.recommendFlow.results[m.recommendFlow.selected]
+	flowID := m.recommendFlow.flowID
+	selected := m.recommendFlow.selected
+	cfg := m.cfg
+	st := m.st
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	m.recommendFlow.cancel = cancel
+	return func() tea.Msg {
+		defer cancel()
+		details := recommendProbeDetails{
+			URI:      rec.URI,
+			Filename: firstNonEmptyString(rec.FileName, rec.Raw.FileName, rec.Raw.FilePath),
+			Size:     rec.Size,
+		}
+		resolvedURL := rec.URI
+		var headers map[string]string
+		if recommendURINeedsResolve(rec.URI) {
+			res, err := resolver.Resolve(ctx, rec.URI, cfg)
+			if err != nil {
+				return recommendInspectProbeMsg{flowID: flowID, selected: selected, uri: rec.URI, err: err}
+			}
+			resolvedURL = res.URL
+			headers = res.Headers
+			details.ResolvedURL = res.URL
+			details.Filename = firstNonEmptyString(details.Filename, res.SuggestedFilename, res.FileName)
+		} else {
+			details.ResolvedURL = rec.URI
+		}
+		meta, err := downloader.ProbeURL(ctx, cfg, resolvedURL, headers)
+		if err != nil {
+			return recommendInspectProbeMsg{flowID: flowID, selected: selected, uri: rec.URI, err: err}
+		}
+		details.FinalURL = meta.FinalURL
+		details.Filename = firstNonEmptyString(meta.Filename, details.Filename)
+		if meta.Size > 0 {
+			details.Size = meta.Size
+		}
+		details.ETag = meta.ETag
+		details.LastModified = meta.LastModified
+		details.AcceptRange = meta.AcceptRange
+		if st != nil {
+			host := downloader.HostFromURLForHistory(firstNonEmptyString(meta.FinalURL, resolvedURL))
+			if host != "" {
+				if row, ok, hErr := st.BestTransferHistory(host, "modfetch"); hErr == nil && ok {
+					details.History = row
+					details.HasHistory = true
+				}
+			}
+		}
+		return recommendInspectProbeMsg{flowID: flowID, selected: selected, uri: rec.URI, details: details}
+	}
+}
+
+func recommendURINeedsResolve(uri string) bool {
+	uri = strings.ToLower(strings.TrimSpace(uri))
+	return strings.HasPrefix(uri, "hf://") ||
+		strings.HasPrefix(uri, "huggingface://") ||
+		strings.HasPrefix(uri, "civitai://") ||
+		strings.HasPrefix(uri, "starter://")
+}
+
 func filterRecommendResults(recs []recommend.Recommendation, runtimeTarget string, sizeLimit int64) []recommend.Recommendation {
 	runtimeTarget = strings.ToLower(strings.TrimSpace(runtimeTarget))
 	out := make([]recommend.Recommendation, 0, len(recs))
@@ -334,6 +481,7 @@ func recommendPlacementPreset(rec recommend.Recommendation, target string) strin
 }
 
 func (m *Model) startRecommendedDownload() tea.Cmd {
+	m.cancelRecommendBackground()
 	if m.st == nil {
 		m.addToast("recommend: state database unavailable")
 		return nil
@@ -346,7 +494,6 @@ func (m *Model) startRecommendedDownload() tea.Cmd {
 	}
 	rec := m.recommendFlow.results[m.recommendFlow.selected]
 	task := recommend.NormalizeTask(m.recommendFlow.task)
-	runtimeTarget := m.selectedRecommendRuntime()
 	query := strings.TrimSpace(m.recommendFlow.query)
 	if query == "" {
 		query = recommend.DefaultQuery(task)
@@ -360,14 +507,11 @@ func (m *Model) startRecommendedDownload() tea.Cmd {
 	} else if err := recommend.RecordHistory(m.st, task, query, hardwareKey, m.recommendFlow.results, "skipped", rec.Index); err != nil {
 		m.addToast("warning: recommendation history failed: " + err.Error())
 	}
-	artifactType := recommendArtifactType(rec, task, runtimeTarget)
-	dest := m.computeDefaultDest(rec.URI)
-	if preset := recommendPlacementPreset(rec, runtimeTarget); preset != "" && artifactType != "" {
-		if targetDest, ok := m.recommendPlacementDestination(rec.URI, artifactType, preset); ok {
-			dest = targetDest
-		} else {
-			m.addToast("placement target not configured; saving to download root")
-		}
+	inspection := m.recommendLocalInspection(rec)
+	artifactType := inspection.ArtifactType
+	dest := inspection.Destination
+	if inspection.PlacementPreset != "" && !inspection.PlacementConfigured {
+		m.addToast("placement target not configured; saving to download root")
 	}
 	if err := m.preflightDest(dest); err != nil {
 		m.addToast("dest not writable: " + err.Error())
@@ -387,6 +531,34 @@ func (m *Model) startRecommendedDownload() tea.Cmd {
 	m.recommendFlow.active = false
 	m.recommendFlow.input.Blur()
 	return cmd
+}
+
+func (m *Model) recommendLocalInspection(rec recommend.Recommendation) recommendLocalInspection {
+	task := recommend.NormalizeTask(m.recommendFlow.task)
+	if task == "" {
+		task = recommend.NormalizeTask(m.selectedRecommendTask())
+	}
+	runtimeTarget := m.selectedRecommendRuntime()
+	artifactType := recommendArtifactType(rec, task, runtimeTarget)
+	dest := m.computeDefaultDest(rec.URI)
+	out := recommendLocalInspection{
+		Destination:  dest,
+		ArtifactType: artifactType,
+	}
+	preset := recommendPlacementPreset(rec, runtimeTarget)
+	if preset == "" || artifactType == "" {
+		out.PlacementNote = "no selected placement target; download root will be used"
+		return out
+	}
+	out.PlacementPreset = preset
+	if targetDest, ok := m.recommendPlacementDestination(rec.URI, artifactType, preset); ok {
+		out.Destination = targetDest
+		out.PlacementConfigured = true
+		out.PlacementNote = "configured placement target"
+		return out
+	}
+	out.PlacementNote = "placement target is not configured; download root will be used"
+	return out
 }
 
 func (m *Model) recommendPlacementDestination(urlStr, artifactType, preset string) (string, bool) {
@@ -584,7 +756,7 @@ func (m *Model) renderRecommendFlow() string {
 	sb.WriteString(m.th.label.Render(m.renderRecommendSummary()) + "\n\n")
 	if m.recommendFlow.loading {
 		sb.WriteString(m.th.label.Render("Searching providers and applying local history...") + "\n")
-		sb.WriteString(m.th.label.Render("Esc cancels the panel; the search will finish in the background."))
+		sb.WriteString(m.th.label.Render("Esc closes the panel and cancels the in-flight request."))
 		return sb.String()
 	}
 	if m.recommendFlow.err != "" {
@@ -618,7 +790,11 @@ func (m *Model) renderRecommendFlow() string {
 		backHint = "Shift+Tab"
 	}
 	sb.WriteString("\n")
-	sb.WriteString(m.th.label.Render("j/k: choose  •  Enter: continue/start  •  "+backHint+": back  •  Esc: close") + "\n")
+	if m.recommendFlow.step == recommendStepResults {
+		sb.WriteString(m.th.label.Render("j/k: choose  •  i: details  •  p: probe  •  Enter: start  •  "+backHint+": back  •  Esc: close") + "\n")
+	} else {
+		sb.WriteString(m.th.label.Render("j/k: choose  •  Enter: continue/start  •  "+backHint+": back  •  Esc: close") + "\n")
+	}
 	return sb.String()
 }
 
@@ -646,7 +822,7 @@ func (m *Model) renderRecommendResults() string {
 		sb.WriteString(m.th.label.Render("Go back and loosen the runtime, size, or provider filter.") + "\n")
 		return sb.String()
 	}
-	sb.WriteString(m.th.label.Render("Select a model to start the normal resumable download path.") + "\n\n")
+	sb.WriteString(m.th.label.Render("Select a model to start the normal resumable download path. Press i for details or p to probe.") + "\n\n")
 	for i, rec := range m.recommendFlow.results {
 		prefix := "  "
 		if i == m.recommendFlow.selected {
@@ -679,7 +855,136 @@ func (m *Model) renderRecommendResults() string {
 			sb.WriteString(m.th.label.Render(line+"  "+strings.Join(meta, " • ")) + "\n")
 		}
 	}
+	if m.recommendFlow.inspect {
+		selected := m.recommendFlow.selected
+		if selected < 0 || selected >= len(m.recommendFlow.results) {
+			selected = 0
+		}
+		sb.WriteString(m.renderRecommendInspection(m.recommendFlow.results[selected]))
+	}
 	return sb.String()
+}
+
+func (m *Model) renderRecommendInspection(rec recommend.Recommendation) string {
+	local := m.recommendLocalInspection(rec)
+	var sb strings.Builder
+	sb.WriteString("\n")
+	sb.WriteString(m.th.head.Render("Details") + "\n")
+	sb.WriteString(m.th.label.Render("  model: "+firstNonEmptyString(rec.Name, rec.ModelID)) + "\n")
+	sb.WriteString(m.th.label.Render("  file: "+firstNonEmptyString(rec.FileName, rec.Raw.FileName, rec.Raw.FilePath, "-")) + "\n")
+	sb.WriteString(m.th.label.Render("  provider: "+rec.Provider+"  model-id: "+firstNonEmptyString(rec.ModelID, "-")) + "\n")
+	sb.WriteString(m.th.label.Render("  score: "+fmt.Sprint(rec.Score)+"  fit: "+rec.Fit+"  size: "+recommendBytes(rec.Size)) + "\n")
+	if rec.EstimatedRequired > 0 || rec.MemoryBudget > 0 {
+		sb.WriteString(m.th.label.Render("  memory: needs "+recommendBytes(rec.EstimatedRequired)+" of "+recommendBytes(rec.MemoryBudget)+" budget") + "\n")
+	}
+	if rec.ParameterCount != "" || rec.Quantization != "" {
+		sb.WriteString(m.th.label.Render("  model shape: params="+firstNonEmptyString(rec.ParameterCount, "-")+" quant="+firstNonEmptyString(rec.Quantization, "-")) + "\n")
+	}
+	if rec.Downloads > 0 || rec.Likes > 0 {
+		sb.WriteString(m.th.label.Render(fmt.Sprintf("  popularity: downloads=%d likes=%d", rec.Downloads, rec.Likes)) + "\n")
+	}
+	if len(rec.Reasons) > 0 {
+		sb.WriteString(m.th.label.Render("  rationale:") + "\n")
+		for _, reason := range rec.Reasons {
+			sb.WriteString(m.th.label.Render("    - "+reason) + "\n")
+		}
+	}
+	if len(rec.RuntimeHints) > 0 {
+		sb.WriteString(m.th.label.Render("  runtime setup:") + "\n")
+		for _, hint := range rec.RuntimeHints {
+			line := "    - " + hint.Runtime
+			if hint.PlacementPreset != "" {
+				line += " -> " + hint.PlacementPreset
+			}
+			if hint.Reason != "" {
+				line += ": " + hint.Reason
+			}
+			sb.WriteString(m.th.label.Render(line) + "\n")
+			if cmd := recommendRuntimeSetupCommand(hint, local.Destination); cmd != "" {
+				sb.WriteString(m.th.label.Render("      setup: "+cmd) + "\n")
+			}
+		}
+	}
+	sb.WriteString(m.th.label.Render("  placement: "+local.PlacementNote) + "\n")
+	if local.PlacementPreset != "" {
+		sb.WriteString(m.th.label.Render("    preset: "+local.PlacementPreset+"  artifact: "+local.ArtifactType) + "\n")
+	}
+	sb.WriteString(m.th.label.Render("  dry-run transfer:") + "\n")
+	sb.WriteString(m.th.label.Render("    dest: "+truncateMiddle(local.Destination, 100)) + "\n")
+	sb.WriteString(m.th.label.Render("    "+m.recommendTransferSettings()) + "\n")
+	if m.recommendFlow.probeLoading {
+		sb.WriteString(m.th.label.Render("    live metadata: probing selected URL...") + "\n")
+	} else if m.recommendFlow.probeErr != "" {
+		sb.WriteString(m.th.bad.Render("    live metadata failed: "+m.recommendFlow.probeErr) + "\n")
+	} else if m.recommendFlow.probeDetails.URI == rec.URI {
+		sb.WriteString(m.renderRecommendProbeDetails(m.recommendFlow.probeDetails))
+	} else {
+		sb.WriteString(m.th.label.Render("    live metadata: press p to resolve URL, check size, range support, and history") + "\n")
+	}
+	return sb.String()
+}
+
+func (m *Model) renderRecommendProbeDetails(details recommendProbeDetails) string {
+	var sb strings.Builder
+	sb.WriteString(m.th.label.Render("    resolved: "+truncateMiddle(firstNonEmptyString(details.ResolvedURL, details.URI), 100)) + "\n")
+	if details.FinalURL != "" && details.FinalURL != details.ResolvedURL {
+		sb.WriteString(m.th.label.Render("    final: "+truncateMiddle(details.FinalURL, 100)) + "\n")
+	}
+	sb.WriteString(m.th.label.Render("    remote size: "+recommendBytes(details.Size)+"  ranges: "+yesNo(details.AcceptRange)) + "\n")
+	if details.Filename != "" {
+		sb.WriteString(m.th.label.Render("    server filename: "+details.Filename) + "\n")
+	}
+	if details.ETag != "" || details.LastModified != "" {
+		sb.WriteString(m.th.label.Render("    validators: etag="+firstNonEmptyString(details.ETag, "-")+" last-modified="+firstNonEmptyString(details.LastModified, "-")) + "\n")
+	}
+	if details.HasHistory {
+		sb.WriteString(m.th.label.Render(fmt.Sprintf("    prior host speed: %s/s over %d sample(s), connections=%d chunk=%dMiB status=%s",
+			humanize.Bytes(uint64(details.History.AvgBPS)), details.History.Samples, details.History.Connections, details.History.ChunkSizeMB, details.History.LastStatus)) + "\n")
+	}
+	return sb.String()
+}
+
+func recommendRuntimeSetupCommand(hint recommend.RuntimeHint, dest string) string {
+	if strings.TrimSpace(hint.SetupCommand) != "" {
+		return hint.SetupCommand
+	}
+	switch strings.ToLower(strings.TrimSpace(hint.Runtime)) {
+	case "llama.cpp":
+		return "llama-cli -m " + strconv.Quote(dest) + " -p \"Hello\""
+	case "lm studio":
+		return "Open LM Studio and add " + dest
+	default:
+		return ""
+	}
+}
+
+func (m *Model) recommendTransferSettings() string {
+	if m.cfg == nil {
+		return "transfer: config unavailable"
+	}
+	connections := "default"
+	if m.cfg.Concurrency.PerFileChunks > 0 {
+		connections = fmt.Sprintf("%d", m.cfg.Concurrency.PerFileChunks)
+	}
+	chunk := "auto"
+	if m.cfg.Concurrency.ChunkSizeMB > 0 {
+		chunk = fmt.Sprintf("%d MiB", m.cfg.Concurrency.ChunkSizeMB)
+	}
+	return "transfer: connections=" + connections + " chunk=" + chunk + " profile=auto/adaptive"
+}
+
+func recommendBytes(size int64) string {
+	if size <= 0 {
+		return "unknown"
+	}
+	return humanize.Bytes(uint64(size))
+}
+
+func yesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
 }
 
 func renderRuntimeHints(hints []recommend.RuntimeHint) string {

--- a/internal/tui/recommend_flow_test.go
+++ b/internal/tui/recommend_flow_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -9,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jxwalker/modfetch/internal/config"
 	"github.com/jxwalker/modfetch/internal/discovery"
+	"github.com/jxwalker/modfetch/internal/downloader"
 	"github.com/jxwalker/modfetch/internal/recommend"
 	"github.com/jxwalker/modfetch/internal/state"
 )
@@ -282,5 +285,165 @@ func TestRecommendFlowRenderTaskStep(t *testing.T) {
 	view := m.renderRecommendFlow()
 	if !strings.Contains(view, "Recommend Models") || !strings.Contains(view, "Chat / assistant") {
 		t.Fatalf("recommend flow view missing expected labels:\n%s", view)
+	}
+}
+
+func TestRecommendFlowInspectionRendersRationalePlacementAndTransferPlan(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := state.NewDB(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	cfg := &config.Config{
+		General: config.General{
+			DataRoot:      tmpDir,
+			DownloadRoot:  filepath.Join(tmpDir, "downloads"),
+			PlacementMode: "symlink",
+		},
+		Concurrency: config.Concurrency{PerFileChunks: 8, ChunkSizeMB: 64},
+		Placement: config.Placement{
+			Apps: map[string]config.AppPlacement{
+				"ollama": {
+					Base: filepath.Join(tmpDir, "ollama"),
+					Paths: map[string]string{
+						"models": "models",
+					},
+				},
+			},
+			Mapping: []config.MappingRule{
+				{Match: "llm.gguf", Targets: []config.MappingTarget{{App: "ollama", PathKey: "models"}}},
+			},
+		},
+	}
+	m := New(cfg, db, "test").(*Model)
+	m.recommendFlow = recommendFlow{
+		active:       true,
+		step:         recommendStepResults,
+		inspect:      true,
+		task:         "chat",
+		query:        "llama instruct gguf",
+		runtimeIndex: 2,
+		results: []recommend.Recommendation{
+			{
+				Index:             1,
+				Provider:          discovery.ProviderHuggingFace,
+				ModelID:           "owner/model",
+				Name:              "Owner Model",
+				URI:               "https://example.com/model.gguf",
+				FileName:          "model.gguf",
+				FileType:          "gguf",
+				Size:              7 << 30,
+				EstimatedRequired: 9 << 30,
+				MemoryBudget:      92 << 30,
+				Score:             120,
+				Fit:               "excellent",
+				Reasons:           []string{"comfortable memory fit", "GGUF is ready for local llama.cpp-style runtimes"},
+				RuntimeHints: []recommend.RuntimeHint{
+					{Runtime: "Ollama", Reason: "GGUF can be imported with a Modelfile", PlacementPreset: "ollama", SetupCommand: "ollama create NAME -f Modelfile"},
+				},
+			},
+		},
+	}
+
+	view := m.renderRecommendResults()
+	for _, want := range []string{
+		"Details",
+		"rationale:",
+		"setup: ollama create NAME -f Modelfile",
+		"placement: configured placement target",
+		"artifact: llm.gguf",
+		"dry-run transfer:",
+		"connections=8 chunk=64 MiB",
+		"live metadata: press p",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("inspection view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestRecommendFlowProbeUsesRealHTTPMetadataAndTransferHistory(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := state.NewDB(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.Header().Set("Content-Length", "4096")
+		w.Header().Set("Content-Disposition", `attachment; filename="server-model.gguf"`)
+		w.Header().Set("ETag", `"abc123"`)
+		w.Header().Set("Last-Modified", "Thu, 14 May 2026 12:00:00 GMT")
+		if r.Method == http.MethodHead {
+			return
+		}
+		if r.Header.Get("Range") == "bytes=0-0" {
+			w.Header().Set("Content-Range", "bytes 0-0/4096")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte{0})
+			return
+		}
+		_, _ = w.Write(make([]byte, 4096))
+	}))
+	defer ts.Close()
+
+	rawURL := ts.URL + "/model.gguf"
+	if err := db.UpsertTransferHistory(state.TransferHistoryRow{
+		Host:        downloader.HostFromURLForHistory(rawURL),
+		Tool:        "modfetch",
+		Connections: 12,
+		ChunkSizeMB: 64,
+		AvgBPS:      2048,
+		LastStatus:  "complete",
+	}); err != nil {
+		t.Fatalf("upsert transfer history: %v", err)
+	}
+
+	cfg := &config.Config{
+		General:     config.General{DataRoot: tmpDir, DownloadRoot: tmpDir},
+		Concurrency: config.Concurrency{PerFileChunks: 4, ChunkSizeMB: 8},
+	}
+	m := New(cfg, db, "test").(*Model)
+	m.recommendFlow = recommendFlow{
+		active:  true,
+		step:    recommendStepResults,
+		flowID:  42,
+		inspect: true,
+		results: []recommend.Recommendation{
+			{Index: 1, Provider: discovery.ProviderHuggingFace, Name: "probe me", URI: rawURL, FileName: "model.gguf", FileType: "gguf"},
+		},
+	}
+
+	cmd := m.startRecommendProbe()
+	if cmd == nil {
+		t.Fatal("expected probe command")
+	}
+	msg, ok := cmd().(recommendInspectProbeMsg)
+	if !ok {
+		t.Fatalf("probe command returned %T", msg)
+	}
+	if msg.err != nil {
+		t.Fatalf("probe command error: %v", msg.err)
+	}
+	m.Update(msg)
+
+	if m.recommendFlow.probeLoading {
+		t.Fatal("probe should not remain loading")
+	}
+	if m.recommendFlow.probeDetails.Size != 4096 || !m.recommendFlow.probeDetails.AcceptRange {
+		t.Fatalf("probe details = %+v, want size and range metadata", m.recommendFlow.probeDetails)
+	}
+	if !m.recommendFlow.probeDetails.HasHistory {
+		t.Fatalf("probe details missing transfer history: %+v", m.recommendFlow.probeDetails)
+	}
+	view := m.renderRecommendResults()
+	for _, want := range []string{"remote size: 4.1 kB", "ranges: yes", "server filename: server-model.gguf", "prior host speed:"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("probe view missing %q:\n%s", want, view)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- adds an `i` inspection view to TUI recommendation results with ranking rationale, memory fit, runtime setup, placement readiness, and dry-run transfer details
- adds a `p` live metadata probe that resolves the selected URI and checks remote size, range support, server filename, validators, and prior transfer history without starting a download
- updates TUI docs, quickstart, user guide, changelog, and roadmap

## Validation
- go test -count=1 ./...
- make lint
- scripts/check-docs-drift.sh
- git diff --check
- go run ./cmd/modfetch recommend "tiny gpt2" --provider huggingface --limit 1 --no-learn --json
- bin/modfetch download --dry-run --summary-json against the selected live Hugging Face recommendation
- go run ./cmd/modfetch tui --snapshot --json