### PR TITLE
chore: update AUR metadata for v0.8.1

### DIFF
--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = modfetch-bin
 	pkgdesc = Robust CLI/TUI downloader for LLM and Stable Diffusion assets
-	pkgver = 0.8.0
+	pkgver = 0.8.1
 	pkgrel = 1
 	url = https://github.com/jxwalker/modfetch
 	arch = x86_64
@@ -8,11 +8,11 @@ pkgbase = modfetch-bin
 	license = MIT
 	provides = modfetch
 	conflicts = modfetch
-	source = LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v0.8.0/LICENSE
+	source = LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v0.8.1/LICENSE
 	sha256sums = 73be8e0a20ff3b0a6991d6405d4d485e5ffc8dfb07a13a1f1b7afb081f57ee54
-	source_x86_64 = modfetch-0.8.0-linux-amd64::https://github.com/jxwalker/modfetch/releases/download/v0.8.0/modfetch_linux_amd64
-	sha256sums_x86_64 = a7bbfb6ce482b91ab1a93eb3b3aa9618b1e61b943e078bf84befc0e3114c5e2a
-	source_aarch64 = modfetch-0.8.0-linux-arm64::https://github.com/jxwalker/modfetch/releases/download/v0.8.0/modfetch_linux_arm64
-	sha256sums_aarch64 = 063f70619266d9a89ebf9178f412a50ae757977f9615d1fb8c3faa2e6771e150
+	source_x86_64 = modfetch-0.8.1-linux-amd64::https://github.com/jxwalker/modfetch/releases/download/v0.8.1/modfetch_linux_amd64
+	sha256sums_x86_64 = 09f8bede51811fa5e4e61a5437b2654058ef96f0ee6db231178d03186e8f9201
+	source_aarch64 = modfetch-0.8.1-linux-arm64::https://github.com/jxwalker/modfetch/releases/download/v0.8.1/modfetch_linux_arm64
+	sha256sums_aarch64 = a8de023093967cc6b5c6c6ac61faddb687bc6d1eb6635bb1163f79fbd5cb83d7
 
 pkgname = modfetch-bin

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: James Walker <james@jameswalker.org.uk>
 pkgname=modfetch-bin
 _pkgname=modfetch
-pkgver=0.8.0
+pkgver=0.8.1
 pkgrel=1
 pkgdesc="Robust CLI/TUI downloader for LLM and Stable Diffusion assets"
 arch=('x86_64' 'aarch64')
@@ -14,10 +14,10 @@ source=("LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v${pkgver}
 sha256sums=('73be8e0a20ff3b0a6991d6405d4d485e5ffc8dfb07a13a1f1b7afb081f57ee54')
 
 source_x86_64=("${_pkgname}-${pkgver}-linux-amd64::https://github.com/jxwalker/modfetch/releases/download/v${pkgver}/${_pkgname}_linux_amd64")
-sha256sums_x86_64=('a7bbfb6ce482b91ab1a93eb3b3aa9618b1e61b943e078bf84befc0e3114c5e2a')
+sha256sums_x86_64=('09f8bede51811fa5e4e61a5437b2654058ef96f0ee6db231178d03186e8f9201')
 
 source_aarch64=("${_pkgname}-${pkgver}-linux-arm64::https://github.com/jxwalker/modfetch/releases/download/v${pkgver}/${_pkgname}_linux_arm64")
-sha256sums_aarch64=('063f70619266d9a89ebf9178f412a50ae757977f9615d1fb8c3faa2e6771e150')
+sha256sums_aarch64=('a8de023093967cc6b5c6c6ac61faddb687bc6d1eb6635bb1163f79fbd5cb83d7')
 
 package() {
   local binary


### PR DESCRIPTION
## Summary
- bumps AUR `modfetch-bin` metadata to pkgver 0.8.1
- updates Linux amd64/arm64 release asset URLs and checksums from the published v0.8.1 release

## Validation
- scripts/check-aur-package.sh v0.8.1
- git diff --check