### PR TITLE
docs: close v0.8.1 package verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ The modfetch TUI provides a beautiful, full-featured interface for managing your
 ---
 
 ## Upcoming
-- **Package channel updates**: validate the v0.8.1 release assets after publish
-  and refresh downstream Homebrew/AUR package metadata as needed.
+- **v0.9 planning**: choose the next product direction from real user feedback
+  after the v0.8.1 recommendation and adaptive-transfer release line has
+  shipped.
 
 ## What's new in v0.8.1
 - **Guided TUI recommendations**: press `G` in the TUI to choose a model by

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -196,9 +196,12 @@ These are useful, but not required for the first v0.7.0 release:
 - [DONE] Recommendation release hardening:
   run end-to-end UAT on the CLI and TUI recommendation flows, refresh release
   notes, and prepare a patch tag once the guided recommendation work is merged.
-- [NEXT] Package channel verification:
+- [DONE] Package channel verification:
   after v0.8.1 assets publish, verify release artifacts and refresh downstream
   Homebrew/AUR package metadata as needed.
+- [NEXT] v0.9 planning:
+  choose the next product direction from real user feedback after the v0.8.1
+  recommendation and adaptive-transfer release line has shipped.
 
 ## Completed Release History
 


### PR DESCRIPTION
## Summary
- mark package-channel verification as complete after the v0.8.1 publish
- move the visible upcoming item to v0.9 planning

## Validation
- go test -count=1 ./...
- make lint
- scripts/check-docs-drift.sh
- git diff --check
- go run ./cmd/modfetch recommend "tiny gpt2" --provider huggingface --limit 1 --no-learn --json
- go run ./cmd/modfetch tui --snapshot --json
- verified Homebrew install/test at v0.8.1
- verified AUR remote metadata at pkgver 0.8.1