### PR TITLE
feat: add beginner get command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+Added
+- Added `modfetch get` as a beginner-friendly task preset command for coding,
+  chat, embeddings, image, and starter workflows. The command delegates to the
+  existing recommendation, starter, and download paths so history, dry-run,
+  resume, placement, and adaptive transfer behavior stay shared.
+
 ## v0.8.1 — 2026-05-14
 
 Added

--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ mkdir -p ~/.config/modfetch
 modfetch config wizard --out ~/.config/modfetch/config.yml
 export MODFETCH_CONFIG=~/.config/modfetch/config.yml
 
-# Pick a model that fits this machine.
-modfetch recommend --task coding
+# Beginner path: choose a small coding model that fits this machine.
+modfetch get coding --small
 
 # Preview the exact selected download without writing files.
-modfetch recommend --task coding --download --select 1 --dry-run --summary-json
+modfetch get coding --small --dry-run --summary-json
 
 # Download the top result through the resumable transfer pipeline.
-modfetch recommend --task coding --download --select 1
+modfetch get coding --small --download
 ```
 
 If you already know the source:
@@ -111,13 +111,16 @@ history before starting a large download.
 ### Find and Download a Real Model
 
 ```bash
+modfetch get coding --small
+modfetch get coding --small --download
 modfetch discover search "tiny gpt2"
 modfetch discover download "sshleifer/tiny-gpt2" --select 1
 ```
 
-`discover` searches real providers, selects a concrete downloadable artifact,
-and delegates to `download`, so resume, auth, placement, dry-run, and JSON
-summary flags still work.
+`get` is the beginner path: task and size presets feed the recommendation
+engine, then optional `--download` delegates to the normal transfer pipeline.
+Use `discover` when you want to search a provider by name and select a concrete
+artifact yourself.
 
 ### Download a Huge GGUF Without Hand-Tuning
 
@@ -272,6 +275,7 @@ config      validate, print, or generate YAML config
 download    fetch one URL/resolver URI or a batch file
 bench       compare modfetch and aria2, or inspect transfer history
 discover    search providers and download a selected result
+get         beginner task presets for choosing and downloading models
 recommend   rank model files for task, hardware, runtime, and memory fit
 starter     list or download beginner-safe starter artifacts
 status      show persisted download status

--- a/cmd/modfetch/completion.go
+++ b/cmd/modfetch/completion.go
@@ -35,7 +35,7 @@ _modfetch_completions()
     local cur prev words cword
     _init_completion || return
     local presets="automatic1111 comfyui forge hf-cache ollama"
-    local cmds="config download bench discover recommend starter place verify status tui library batch dedupe clean hostcaps version help completion"
+    local cmds="config download bench discover get recommend starter place verify status tui library batch dedupe clean hostcaps version help completion"
     if [[ ${cword} -eq 1 ]]; then
         COMPREPLY=( $(compgen -W "${cmds}" -- "$cur") )
         return
@@ -71,6 +71,8 @@ _modfetch_completions()
                     COMPREPLY=( $(compgen -W "--config --log-level --json --provider --limit --select --dest --place --summary-json --dry-run --quiet --no-resume huggingface civitai modelscope all" -- "$cur") ) ;;
                 *) ;;
             esac ;;
+        get)
+            COMPREPLY=( $(compgen -W "--config --log-level --json --provider --query --limit --select --download --dest --place --summary-json --dry-run --quiet --no-resume --ram-gb --vram-gb --unified-memory --small --medium --large --size --starter-id --no-learn coding chat embedding embeddings image starter huggingface civitai modelscope all" -- "$cur") ) ;;
         recommend)
             COMPREPLY=( $(compgen -W "--config --log-level --json --provider --task --limit --ram-gb --vram-gb --unified-memory --select --download --dest --place --summary-json --dry-run --quiet --no-resume --history --history-limit --no-learn chat coding embedding image huggingface civitai modelscope all" -- "$cur") ) ;;
         starter)
@@ -145,7 +147,7 @@ const zshCompletion = `#compdef modfetch
 # zsh completion for modfetch (basic)
 _modfetch() {
   local -a cmds
-  cmds=(config download bench discover recommend starter place verify status tui library batch dedupe clean hostcaps version help completion)
+  cmds=(config download bench discover get recommend starter place verify status tui library batch dedupe clean hostcaps version help completion)
   if (( CURRENT == 2 )); then
     _describe 'command' cmds
     return
@@ -187,6 +189,9 @@ _modfetch() {
             ;;
         esac
       fi
+      ;;
+    get)
+      _arguments '*:options:(--config --log-level --json --provider --query --limit --select --download --dest --place --summary-json --dry-run --quiet --no-resume --ram-gb --vram-gb --unified-memory --small --medium --large --size --starter-id --no-learn coding chat embedding embeddings image starter huggingface civitai modelscope all)'
       ;;
     recommend)
       _arguments '*:options:(--config --log-level --json --provider --task --limit --ram-gb --vram-gb --unified-memory --select --download --dest --place --summary-json --dry-run --quiet --no-resume --history --history-limit --no-learn chat coding embedding image huggingface civitai modelscope all)'
@@ -274,6 +279,7 @@ complete -c modfetch -f -n "__fish_use_subcommand" -a "config" -d "config ops"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "download" -d "download assets"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "bench" -d "benchmark download tools"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "discover" -d "search real model providers"
+complete -c modfetch -f -n "__fish_use_subcommand" -a "get" -d "beginner task presets"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "recommend" -d "recommend models for hardware"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "starter" -d "beginner starter downloads"
 complete -c modfetch -f -n "__fish_use_subcommand" -a "dedupe" -d "dedupe duplicate downloads"
@@ -299,7 +305,7 @@ complete -c modfetch -n "__fish_seen_subcommand_from clean" -l include-next-to-d
 complete -c modfetch -n "__fish_seen_subcommand_from clean" -l sidecars -d "Remove orphan .sha256"
 
 # Common flags
-for cmd in download bench recommend place verify status tui library dedupe clean
+for cmd in download bench get recommend place verify status tui library dedupe clean
   complete -c modfetch -n "__fish_seen_subcommand_from $cmd" -l config -d "Path to config"
   complete -c modfetch -n "__fish_seen_subcommand_from $cmd" -l log-level -d "Log level"
   complete -c modfetch -n "__fish_seen_subcommand_from $cmd" -l json -d "JSON output"
@@ -362,6 +368,27 @@ complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_s
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l dry-run -d "Plan without downloading"
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l quiet -d "Suppress progress and info logs"
 complete -c modfetch -n "__fish_seen_subcommand_from discover; and __fish_seen_subcommand_from download" -l no-resume -d "Start fresh instead of resuming"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -a "coding chat embedding embeddings image starter" -d "Task preset"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l provider -a "huggingface civitai modelscope all" -d "Provider"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l query -d "Override curated query"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l limit -d "Recommendation limit"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l select -d "Selected recommendation index"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l download -d "Download selected recommendation"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l dest -d "Destination path"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l place -d "Place after download"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l summary-json -d "Print completion summary as JSON"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l dry-run -d "Plan without downloading"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l quiet -d "Suppress progress and info logs"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l no-resume -d "Start fresh instead of resuming"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l ram-gb -d "Override RAM in GiB"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l vram-gb -d "Override VRAM in GiB"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l unified-memory -d "Treat RAM as unified memory"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l small -d "Prefer a small first download"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l medium -d "Prefer a balanced local model"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l large -d "Prefer larger candidates"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l size -a "small medium large" -d "Size preset"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l starter-id -a "gpt2-config gpt2-tokenizer public-1mb" -d "Starter ID"
+complete -c modfetch -n "__fish_seen_subcommand_from get" -l no-learn -d "Disable recommendation history"
 complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l provider -a "huggingface civitai modelscope all" -d "Provider"
 complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l task -a "chat coding embedding image" -d "Use case"
 complete -c modfetch -n "__fish_seen_subcommand_from recommend" -l limit -d "Recommendation limit"

--- a/cmd/modfetch/completion_test.go
+++ b/cmd/modfetch/completion_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCompletionTopLevelCommands(t *testing.T) {
 	for name, script := range completionScripts() {
-		for _, command := range []string{"config", "download", "bench", "discover", "recommend", "starter", "place", "verify", "status", "tui", "library", "batch", "dedupe", "clean", "hostcaps", "version", "help", "completion"} {
+		for _, command := range []string{"config", "download", "bench", "discover", "get", "recommend", "starter", "place", "verify", "status", "tui", "library", "batch", "dedupe", "clean", "hostcaps", "version", "help", "completion"} {
 			want := completionCommandToken(name, command)
 			if !strings.Contains(script, want) {
 				t.Fatalf("%s completion missing top-level command %q", name, command)
@@ -18,10 +18,18 @@ func TestCompletionTopLevelCommands(t *testing.T) {
 
 func TestCompletionCurrentFlags(t *testing.T) {
 	tests := map[string][]string{
-		"config":    {"--strict", "--out"},
-		"download":  {"--no-resume", "--summary-json", "--batch-parallel", "--profile", "--connections", "--chunk-size-mb", "--dry-run", "--force", "--no-auth-preflight", "--quant", "--list-quants"},
-		"bench":     {"--url", "--tools", "--duration", "--profile", "--connections", "--chunk-size-mb", "--keep", "--history"},
-		"discover":  {"--provider", "--limit", "--select", "--summary-json", "--dry-run"},
+		"config":   {"--strict", "--out"},
+		"download": {"--no-resume", "--summary-json", "--batch-parallel", "--profile", "--connections", "--chunk-size-mb", "--dry-run", "--force", "--no-auth-preflight", "--quant", "--list-quants"},
+		"bench":    {"--url", "--tools", "--duration", "--profile", "--connections", "--chunk-size-mb", "--keep", "--history"},
+		"discover": {"--provider", "--limit", "--select", "--summary-json", "--dry-run"},
+		"get": {
+			"--provider", "--query", "--limit", "--select",
+			"--small", "--medium", "--large", "--size",
+			"--download", "--dry-run", "--dest", "--place",
+			"--summary-json", "--quiet", "--no-resume",
+			"--ram-gb", "--vram-gb", "--unified-memory",
+			"--starter-id", "--no-learn",
+		},
 		"recommend": {"--provider", "--task", "--ram-gb", "--vram-gb", "--unified-memory", "--download", "--select", "--dry-run", "--history", "--history-limit", "--no-learn"},
 		"starter":   {"--id", "--summary-json", "--dry-run"},
 		"place":     {"--dry-run", "--preset", "--list-presets"},

--- a/cmd/modfetch/get_cmd.go
+++ b/cmd/modfetch/get_cmd.go
@@ -1,0 +1,349 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"strings"
+)
+
+type getProfile struct {
+	Name        string
+	Task        string
+	Provider    string
+	Query       string
+	Limit       int
+	StarterID   string
+	Description string
+}
+
+func handleGet(ctx context.Context, args []string) error {
+	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
+		printGetUsage()
+		if len(args) == 0 {
+			return errors.New("usage: modfetch get TASK [flags]")
+		}
+		return nil
+	}
+
+	fs := flag.NewFlagSet("get", flag.ContinueOnError)
+	common := addCommonConfigLogFlags(fs, "print command output as JSON")
+	provider := fs.String("provider", "", "provider: huggingface|civitai|modelscope|all")
+	query := fs.String("query", "", "override the curated search query")
+	limit := fs.Int("limit", 5, "maximum recommendations to inspect")
+	selectIndex := fs.Int("select", 1, "1-based recommendation to use with --download")
+	download := fs.Bool("download", false, "download the selected recommendation")
+	dest := fs.String("dest", "", "destination path when downloading")
+	placeFlag := fs.Bool("place", false, "place after successful download")
+	summaryJSON := fs.Bool("summary-json", false, "print download completion summary as JSON")
+	dryRun := fs.Bool("dry-run", false, "plan selected download without downloading")
+	quiet := fs.Bool("quiet", false, "suppress progress and info logs")
+	noResume := fs.Bool("no-resume", false, "start selected download fresh instead of resuming")
+	ramGB := fs.Float64("ram-gb", 0, "override detected system RAM in GiB")
+	vramGB := fs.Float64("vram-gb", 0, "override detected dedicated VRAM in GiB")
+	unified := fs.Bool("unified-memory", false, "treat RAM as unified CPU/GPU memory")
+	small := fs.Bool("small", false, "prefer a small first download")
+	medium := fs.Bool("medium", false, "prefer a balanced local model")
+	large := fs.Bool("large", false, "prefer larger/high-quality candidates")
+	size := fs.String("size", "", "size preset: small|medium|large")
+	starterID := fs.String("starter-id", "", "starter artifact ID when TASK is starter")
+	noLearn := fs.Bool("no-learn", false, "do not use or write recommendation history")
+	flagArgs, positional := splitDiscoverArgs(args, map[string]bool{
+		"json": true, "download": true, "place": true, "summary-json": true, "dry-run": true, "quiet": true,
+		"no-resume": true, "unified-memory": true, "small": true, "medium": true, "large": true, "no-learn": true,
+	})
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	positional = append(positional, fs.Args()...)
+	if len(positional) == 0 {
+		printGetUsage()
+		return errors.New("usage: modfetch get TASK [flags]")
+	}
+	task := strings.TrimSpace(positional[0])
+	queryWords := strings.TrimSpace(strings.Join(positional[1:], " "))
+	sizePreset, err := getSizePreset(*size, *small, *medium, *large)
+	if err != nil {
+		return err
+	}
+	profile, err := resolveGetProfile(task, sizePreset)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(*provider) != "" {
+		profile.Provider = strings.TrimSpace(*provider)
+	}
+	if *limit > 0 {
+		profile.Limit = *limit
+	}
+	if strings.TrimSpace(*query) != "" {
+		profile.Query = strings.TrimSpace(*query)
+	} else if queryWords != "" {
+		profile.Query = queryWords
+	}
+	if profile.StarterID != "" {
+		if queryWords != "" || strings.TrimSpace(*query) != "" {
+			return errors.New("starter does not accept free-form query terms; use --starter-id")
+		}
+		id := profile.StarterID
+		if strings.TrimSpace(*starterID) != "" {
+			id = strings.TrimSpace(*starterID)
+		}
+		return starterDownload(ctx, buildGetStarterArgs(getRunOptions{
+			configPath:  *common.configPath,
+			logLevel:    *common.logLevel,
+			jsonOut:     *common.jsonOut,
+			id:          id,
+			dest:        *dest,
+			place:       *placeFlag,
+			summaryJSON: *summaryJSON,
+			dryRun:      *dryRun,
+			quiet:       *quiet,
+			noResume:    *noResume,
+		}))
+	}
+	return handleRecommend(ctx, buildGetRecommendArgs(getRunOptions{
+		configPath:  *common.configPath,
+		logLevel:    *common.logLevel,
+		jsonOut:     *common.jsonOut,
+		task:        profile.Task,
+		provider:    profile.Provider,
+		query:       profile.Query,
+		limit:       profile.Limit,
+		selectIndex: *selectIndex,
+		download:    *download || *dryRun || strings.TrimSpace(*dest) != "" || *placeFlag || *summaryJSON,
+		dest:        *dest,
+		place:       *placeFlag,
+		summaryJSON: *summaryJSON,
+		dryRun:      *dryRun,
+		quiet:       *quiet,
+		noResume:    *noResume,
+		ramGB:       *ramGB,
+		vramGB:      *vramGB,
+		unified:     *unified,
+		noLearn:     *noLearn,
+	}))
+}
+
+func printGetUsage() {
+	fmt.Println(strings.TrimSpace(`Usage:
+  modfetch get TASK [--small|--medium|--large] [--download|--dry-run] [download flags]
+
+Tasks:
+  coding       coding assistant GGUF recommendations
+  chat         general chat/instruct GGUF recommendations
+  embedding    embedding model recommendations
+  image        Stable Diffusion / ComfyUI checkpoint recommendations
+  starter      download a beginner-safe starter artifact
+
+Examples:
+  modfetch get coding --small
+  modfetch get coding --small --download
+  modfetch get embedding --download --summary-json
+  modfetch get image --small --dry-run
+  modfetch get starter --dry-run`))
+}
+
+type getRunOptions struct {
+	configPath  string
+	logLevel    string
+	jsonOut     bool
+	task        string
+	provider    string
+	query       string
+	limit       int
+	selectIndex int
+	download    bool
+	id          string
+	dest        string
+	place       bool
+	summaryJSON bool
+	dryRun      bool
+	quiet       bool
+	noResume    bool
+	ramGB       float64
+	vramGB      float64
+	unified     bool
+	noLearn     bool
+}
+
+func buildGetRecommendArgs(opts getRunOptions) []string {
+	args := []string{
+		"--config", opts.configPath,
+		"--log-level", opts.logLevel,
+		"--provider", opts.provider,
+		"--task", opts.task,
+		"--limit", fmt.Sprint(opts.limit),
+		"--select", fmt.Sprint(opts.selectIndex),
+	}
+	if opts.jsonOut {
+		args = append(args, "--json")
+	}
+	if opts.download {
+		args = append(args, "--download")
+	}
+	if opts.dest != "" {
+		args = append(args, "--dest", opts.dest)
+	}
+	if opts.place {
+		args = append(args, "--place")
+	}
+	if opts.summaryJSON {
+		args = append(args, "--summary-json")
+	}
+	if opts.dryRun {
+		args = append(args, "--dry-run")
+	}
+	if opts.quiet {
+		args = append(args, "--quiet")
+	}
+	if opts.noResume {
+		args = append(args, "--no-resume")
+	}
+	if opts.ramGB > 0 {
+		args = append(args, "--ram-gb", fmt.Sprint(opts.ramGB))
+	}
+	if opts.vramGB > 0 {
+		args = append(args, "--vram-gb", fmt.Sprint(opts.vramGB))
+	}
+	if opts.unified {
+		args = append(args, "--unified-memory")
+	}
+	if opts.noLearn {
+		args = append(args, "--no-learn")
+	}
+	if opts.query != "" {
+		args = append(args, "--", opts.query)
+	}
+	return args
+}
+
+func buildGetStarterArgs(opts getRunOptions) []string {
+	args := []string{
+		"--config", opts.configPath,
+		"--log-level", opts.logLevel,
+		"--id", opts.id,
+	}
+	if opts.jsonOut {
+		args = append(args, "--json")
+	}
+	if opts.dest != "" {
+		args = append(args, "--dest", opts.dest)
+	}
+	if opts.place {
+		args = append(args, "--place")
+	}
+	if opts.summaryJSON {
+		args = append(args, "--summary-json")
+	}
+	if opts.dryRun {
+		args = append(args, "--dry-run")
+	}
+	if opts.quiet {
+		args = append(args, "--quiet")
+	}
+	if opts.noResume {
+		args = append(args, "--no-resume")
+	}
+	return args
+}
+
+func getSizePreset(explicit string, small, medium, large bool) (string, error) {
+	selected := strings.ToLower(strings.TrimSpace(explicit))
+	count := 0
+	if selected != "" {
+		count++
+	}
+	for _, enabled := range []bool{small, medium, large} {
+		if enabled {
+			count++
+		}
+	}
+	if count > 1 {
+		return "", errors.New("choose only one size preset: --small, --medium, --large, or --size")
+	}
+	if small {
+		selected = "small"
+	}
+	if medium {
+		selected = "medium"
+	}
+	if large {
+		selected = "large"
+	}
+	switch selected {
+	case "", "small", "medium", "large":
+		return selected, nil
+	default:
+		return "", fmt.Errorf("unknown size preset %q (valid: small, medium, large)", explicit)
+	}
+}
+
+func resolveGetProfile(task, size string) (getProfile, error) {
+	task = strings.ToLower(strings.TrimSpace(task))
+	size = strings.ToLower(strings.TrimSpace(size))
+	if size == "" {
+		size = "medium"
+	}
+	switch task {
+	case "starter", "start", "smoke":
+		return getProfile{
+			Name:        "starter",
+			StarterID:   "gpt2-tokenizer",
+			Description: "beginner-safe Hugging Face tokenizer smoke download",
+		}, nil
+	case "coding", "code", "developer", "programming":
+		return getProfile{
+			Name:        "coding-" + size,
+			Task:        "coding",
+			Provider:    "huggingface",
+			Query:       sizedQuery(size, "qwen2.5 coder 1.5b gguf", "qwen coder gguf", "deepseek coder qwen gguf"),
+			Limit:       5,
+			Description: "coding assistant GGUF recommendation",
+		}, nil
+	case "chat", "assistant", "general":
+		return getProfile{
+			Name:        "chat-" + size,
+			Task:        "chat",
+			Provider:    "huggingface",
+			Query:       sizedQuery(size, "qwen2.5 1.5b instruct gguf", "llama instruct gguf", "large instruct gguf"),
+			Limit:       5,
+			Description: "general chat/instruct GGUF recommendation",
+		}, nil
+	case "embedding", "embeddings", "embed", "search":
+		return getProfile{
+			Name:        "embedding-" + size,
+			Task:        "embedding",
+			Provider:    "huggingface",
+			Query:       sizedQuery(size, "bge small embedding", "embedding model", "bge large embedding"),
+			Limit:       5,
+			Description: "embedding model recommendation",
+		}, nil
+	case "image", "sd", "stable-diffusion", "comfyui":
+		return getProfile{
+			Name:        "image-" + size,
+			Task:        "image",
+			Provider:    "huggingface",
+			Query:       sizedQuery(size, "sd 1.5 safetensors", "stable diffusion safetensors", "sdxl safetensors"),
+			Limit:       5,
+			Description: "Stable Diffusion / ComfyUI checkpoint recommendation",
+		}, nil
+	default:
+		return getProfile{}, fmt.Errorf("unknown get task %q (valid: coding, chat, embedding, image, starter)", task)
+	}
+}
+
+func sizedQuery(size, small, medium, large string) string {
+	switch size {
+	case "small":
+		return small
+	case "large":
+		return large
+	default:
+		return medium
+	}
+}

--- a/cmd/modfetch/get_cmd_test.go
+++ b/cmd/modfetch/get_cmd_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestGetSizePreset(t *testing.T) {
+	tests := []struct {
+		name    string
+		size    string
+		small   bool
+		medium  bool
+		large   bool
+		want    string
+		wantErr bool
+	}{
+		{name: "default", want: ""},
+		{name: "explicit", size: "small", want: "small"},
+		{name: "flag", large: true, want: "large"},
+		{name: "duplicate", size: "small", medium: true, wantErr: true},
+		{name: "unknown", size: "huge", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getSizePreset(tt.size, tt.small, tt.medium, tt.large)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("getSizePreset err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("getSizePreset = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveGetProfile(t *testing.T) {
+	tests := []struct {
+		task     string
+		size     string
+		wantTask string
+		wantQ    string
+		wantID   string
+	}{
+		{task: "coding", size: "small", wantTask: "coding", wantQ: "qwen2.5 coder 1.5b gguf"},
+		{task: "embeddings", size: "large", wantTask: "embedding", wantQ: "bge large embedding"},
+		{task: "comfyui", size: "medium", wantTask: "image", wantQ: "stable diffusion safetensors"},
+		{task: "starter", wantID: "gpt2-tokenizer"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.task+"/"+tt.size, func(t *testing.T) {
+			got, err := resolveGetProfile(tt.task, tt.size)
+			if err != nil {
+				t.Fatalf("resolveGetProfile: %v", err)
+			}
+			if got.Task != tt.wantTask {
+				t.Fatalf("task = %q, want %q", got.Task, tt.wantTask)
+			}
+			if got.Query != tt.wantQ {
+				t.Fatalf("query = %q, want %q", got.Query, tt.wantQ)
+			}
+			if got.StarterID != tt.wantID {
+				t.Fatalf("starter = %q, want %q", got.StarterID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestBuildGetRecommendArgs(t *testing.T) {
+	args := buildGetRecommendArgs(getRunOptions{
+		configPath:  "/tmp/config.yml",
+		logLevel:    "debug",
+		jsonOut:     true,
+		task:        "coding",
+		provider:    "huggingface",
+		query:       "qwen2.5 coder 1.5b gguf",
+		limit:       3,
+		selectIndex: 2,
+		download:    true,
+		dryRun:      true,
+		noLearn:     true,
+	})
+	got := strings.Join(args, "\x00")
+	for _, want := range []string{
+		"--config\x00/tmp/config.yml",
+		"--log-level\x00debug",
+		"--provider\x00huggingface",
+		"--task\x00coding",
+		"--limit\x003",
+		"--select\x002",
+		"--json",
+		"--download",
+		"--dry-run",
+		"--no-learn",
+		"--\x00qwen2.5 coder 1.5b gguf",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("recommend args missing %q in %#v", want, args)
+		}
+	}
+	if strings.Index(got, "--download") > strings.Index(got, "--\x00") {
+		t.Fatalf("query delimiter must come after flags: %#v", args)
+	}
+}
+
+func TestGetHelp(t *testing.T) {
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = handleGet(context.Background(), []string{"help"})
+	})
+	if runErr != nil {
+		t.Fatalf("get help: %v", runErr)
+	}
+	for _, want := range []string{"modfetch get TASK", "coding", "embedding", "starter"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("get help missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestGetStarterRejectsFreeformQuery(t *testing.T) {
+	err := handleGet(context.Background(), []string{"starter", "extra words"})
+	if err == nil || !strings.Contains(err.Error(), "starter does not accept free-form query terms") {
+		t.Fatalf("starter query error = %v", err)
+	}
+}

--- a/cmd/modfetch/main.go
+++ b/cmd/modfetch/main.go
@@ -52,6 +52,8 @@ func run(ctx context.Context, args []string) error {
 		return handleBench(ctx, args[1:])
 	case "discover":
 		return handleDiscover(ctx, args[1:])
+	case "get":
+		return handleGet(ctx, args[1:])
 	case "recommend":
 		return handleRecommend(ctx, args[1:])
 	case "starter":
@@ -99,6 +101,7 @@ Commands:
   download          Download a file via direct URL or resolver URI (starter://, hf://, civitai://)
   bench             Benchmark modfetch against aria2 on the same URL
   discover          Search real model providers and download a selected result
+  get               Beginner task presets for choosing and downloading models
   recommend         Recommend model files for your task and hardware
   starter           List or download beginner-safe starter artifacts
   status            Show download status (table or JSON)

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -12,6 +12,7 @@ Complete command-line reference for modfetch. For a product overview, see
   - [download](#download)
   - [bench](#bench)
   - [discover](#discover)
+  - [get](#get)
   - [recommend](#recommend)
   - [starter](#starter)
   - [status](#status)
@@ -56,6 +57,7 @@ modfetch download --url URL       # Download a file
 modfetch starter list             # Beginner-safe starter artifacts
 modfetch discover search "tiny gpt2"
 modfetch discover download "sshleifer/tiny-gpt2" --select 1
+modfetch get coding --small        # Beginner preset over recommend/download
 modfetch recommend --task coding   # Pick a model that fits this machine
 modfetch bench --history           # Show learned transfer history
 modfetch verify --all              # Verify all downloads
@@ -216,6 +218,49 @@ files, or the TUI new-download modal. `discover download` searches first, picks
 the `--select` result number, and then delegates to `download`, so normal flags
 such as `--config`, `--dest`, `--place`, `--dry-run`, `--quiet`, and
 `--summary-json` still apply.
+
+### get
+
+Use task presets when you want a good first command instead of deciding provider
+queries, task flags, and download handoff yourself. `get` delegates to
+`recommend` for model tasks and to `starter download` for the starter task, so
+history, runtime hints, adaptive transfer tuning, resume, dry-run, placement,
+and JSON behavior stay on the existing code paths.
+
+```bash
+modfetch get TASK [--small|--medium|--large] [OPTIONS]
+```
+
+**Tasks:**
+- `coding` - coding assistant GGUF recommendations
+- `chat` - general chat/instruct GGUF recommendations
+- `embedding` - embedding model recommendations. `embeddings` and `embed` are
+  accepted aliases.
+- `image` - Stable Diffusion / ComfyUI safetensors recommendations
+- `starter` - beginner-safe public starter artifact
+
+**Options:**
+- `--small`, `--medium`, `--large`, or `--size NAME` - choose the curated query
+  preset. The default is `medium`.
+- `--query TEXT` - override the curated query.
+- `--provider huggingface|civitai|modelscope|all` - override the provider.
+- `--limit N` - number of recommendations to inspect before selecting a result.
+- `--download` - download the selected recommendation.
+- `--dry-run` - plan the selected recommendation download without writing
+  files. This implies the download handoff.
+- `--select N`, `--dest PATH`, `--place`, `--summary-json`, `--quiet`,
+  `--no-resume`, `--ram-gb`, `--vram-gb`, `--unified-memory`, and `--no-learn`
+  forward to the underlying recommendation/download flow.
+- `--starter-id ID` - choose a specific starter artifact for `get starter`.
+
+**Examples:**
+```bash
+modfetch get coding --small
+modfetch get coding --small --download
+modfetch get embedding --download --summary-json
+modfetch get image --small --dry-run
+modfetch get starter --dry-run
+```
 
 ### recommend
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -6,7 +6,7 @@ library view.
 
 If you already know the exact URL, use `modfetch download --url ...`. If you do
 not know which repo, file, or quantization to choose, start with
-`modfetch recommend` or press `G` in the TUI.
+`modfetch get`, `modfetch recommend`, or press `G` in the TUI.
 
 ## Table of Contents
 
@@ -119,17 +119,18 @@ export CIVITAI_TOKEN="your_civitai_token"      # For CivitAI
 
 ## Step 3: Your First Download
 
-Start by letting modfetch choose a model for the current machine:
+Start with a beginner task preset. It chooses the recommendation query for you,
+then hands off to the same resumable download path when you add `--download`:
 
 ```bash
-modfetch recommend --task chat
-modfetch recommend --task chat --download --select 1 --dry-run --summary-json
+modfetch get chat --small
+modfetch get chat --small --dry-run --summary-json
 ```
 
 When the plan looks right, remove `--dry-run`:
 
 ```bash
-modfetch recommend --task chat --download --select 1
+modfetch get chat --small --download
 ```
 
 If you want a tiny public test file instead, use this:

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ automating, troubleshooting, or maintaining a release.
 
 - [Quick Start](QUICKSTART.md): install, configure, run a first download, and
   open the TUI.
-- [User Guide](USER_GUIDE.md): end-to-end workflows for recommendations,
+- [User Guide](USER_GUIDE.md): end-to-end workflows for `get`, recommendations,
   downloads, verification, placement, library management, and snapshots.
 - [CLI Guide](CLI_GUIDE.md): command and flag reference.
 - [TUI Guide](TUI_GUIDE.md): dashboard layout, keyboard controls, guided

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -199,9 +199,12 @@ These are useful, but not required for the first v0.7.0 release:
 - [DONE] Package channel verification:
   after v0.8.1 assets publish, verify release artifacts and refresh downstream
   Homebrew/AUR package metadata as needed.
-- [NEXT] v0.9 planning:
-  choose the next product direction from real user feedback after the v0.8.1
-  recommendation and adaptive-transfer release line has shipped.
+- [IN PROGRESS] v0.9 beginner acquisition path:
+  add `modfetch get` task presets as the beginner-friendly layer above
+  recommendations, starter artifacts, and the normal resumable download path.
+- [NEXT] v0.9 follow-up:
+  expand from single-file task presets into curated task packs, multi-file
+  snapshot manifests, and stronger post-download "run it locally" guidance.
 
 ## Completed Release History
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -82,6 +82,26 @@ modfetch download --config ~/.config/modfetch/config.yml \
   --url 'civitai://model/123456?file=myfile.safetensors'
 ```
 
+### Get a model with beginner presets
+
+If you want a beginner-friendly path, start with `get`. It applies task and size
+presets, then delegates to `recommend` and `download` so the normal history,
+runtime hints, resume, dry-run, placement, and JSON behavior still apply.
+
+```bash
+modfetch get coding --small
+modfetch get coding --small --dry-run --summary-json
+modfetch get coding --small --download
+modfetch get embedding --download
+modfetch get starter --dry-run
+```
+
+Use `--query` when the preset is close but you want to steer the search:
+
+```bash
+modfetch get coding --small --query "qwen2.5 coder gguf"
+```
+
 ### Recommend a model for your hardware
 
 If you do not know which repo or quantization to choose, start with


### PR DESCRIPTION
## Summary
- add `modfetch get` task presets for coding, chat, embeddings, image, and starter workflows
- delegate get flows to existing recommend, starter, and download paths so history, dry-run, resume, placement, and adaptive transfer behavior stay shared
- document the v0.9 beginner acquisition slice in README, CLI guide, quickstart, user guide, roadmap, and changelog

## Validation
- `scripts/check-docs-drift.sh`
- `git diff --check`
- local markdown link scan
- `go test -count=1 ./...`
- `make lint`
- live smoke: `go run ./cmd/modfetch get coding --small --limit 1 --no-learn`
- live smoke: `go run ./cmd/modfetch get coding --small --limit 1 --dry-run --summary-json --no-learn`
- live smoke: `go run ./cmd/modfetch get starter --config ~/.config/modfetch/config.yml --dry-run --summary-json`