### PR TITLE
docs: mark v0.9 roadmap complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,8 +382,8 @@ Shipped highlights:
 - v0.7.0: Homebrew distribution, portable catalogs, TUI bulk operations,
   placement presets, scanner repair, and docs drift validation.
 
-The v0.8.x release line is closed. The next roadmap item is v0.9 planning based
-on real user feedback.
+The v0.9 feature roadmap is complete on `main`; the next operational step is
+cutting v0.9.0 and then planning the next feedback-driven improvement slice.
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,8 @@ automating, troubleshooting, or maintaining a release.
 
 - [Release Checklist](RELEASE.md): changelog, artifacts, package channels, docs
   drift, and post-publish verification.
-- [Roadmap](ROADMAP.md): shipped baseline and next planning area.
+- [Roadmap](ROADMAP.md): shipped baseline, completed v0.9 work, and next
+  release step.
 - [TUI Wireframes](TUI_WIREFRAMES.md): visual interaction reference.
 - [TUI Analysis Summary](TUI_ANALYSIS_SUMMARY.txt): current TUI architecture and
   maintenance notes.
@@ -57,5 +58,6 @@ The v0.8.x line shipped hardware-aware recommendations, runtime hints, learned
 recommendation history, benchmark-driven adaptive transfer tuning, guided TUI
 recommendations, recommendation inspection, and live transfer metadata probes.
 
-Unreleased main adds beginner `get`, `--run-help`, curated multi-file task
-packs, and Hugging Face snapshot manifests.
+Unreleased main contains the completed v0.9 feature set: beginner `get`,
+`--run-help`, curated multi-file task packs, and Hugging Face snapshot
+manifests.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,6 +13,10 @@ Status key:
 
 Current release: v0.8.1, tagged 2026-05-14.
 
+Current main has the completed v0.9 feature set staged in `CHANGELOG.md` under
+`Unreleased`. The next operational step is cutting v0.9.0 and refreshing package
+channels from the published assets.
+
 Shipped baseline:
 - Reliable direct, Hugging Face, and CivitAI downloads with resume, retries,
   SHA256 verification, auth preflight, rate-limit handling, archive extraction,


### PR DESCRIPTION
## Summary
- update README and docs index status wording now that v0.9 roadmap work is on main
- call out v0.9.0 release/package refresh as the next operational step

## Validation
- scripts/check-docs-drift.sh
- git diff --check