### PR TITLE
chore: update v0.9.0 package metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,10 @@ jobs:
             modfetch_darwin_amd64/modfetch_darwin_amd64 \
             modfetch_darwin_arm64/modfetch_darwin_arm64 \
             -output modfetch_darwin_universal/modfetch_darwin_universal
-          shasum -a 256 modfetch_darwin_universal/modfetch_darwin_universal > modfetch_darwin_universal/modfetch_darwin_universal.sha256
+          (
+            cd modfetch_darwin_universal
+            shasum -a 256 modfetch_darwin_universal > modfetch_darwin_universal.sha256
+          )
       - name: Upload universal artifact
         uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+Fixes
+- Fixed future macOS universal release checksum generation in
+  `.github/workflows/release.yml` so the published `.sha256` file validates
+  beside the downloaded asset.
+
+Changed
+- Updated checked AUR `modfetch-bin` metadata for the v0.9.0 release assets.
+
 ## v0.9.0 — 2026-05-21
 
 Added

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = modfetch-bin
 	pkgdesc = Robust CLI/TUI downloader for LLM and Stable Diffusion assets
-	pkgver = 0.8.1
+	pkgver = 0.9.0
 	pkgrel = 1
 	url = https://github.com/jxwalker/modfetch
 	arch = x86_64
@@ -8,11 +8,11 @@ pkgbase = modfetch-bin
 	license = MIT
 	provides = modfetch
 	conflicts = modfetch
-	source = LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v0.8.1/LICENSE
+	source = LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v0.9.0/LICENSE
 	sha256sums = 73be8e0a20ff3b0a6991d6405d4d485e5ffc8dfb07a13a1f1b7afb081f57ee54
-	source_x86_64 = modfetch-0.8.1-linux-amd64::https://github.com/jxwalker/modfetch/releases/download/v0.8.1/modfetch_linux_amd64
-	sha256sums_x86_64 = 09f8bede51811fa5e4e61a5437b2654058ef96f0ee6db231178d03186e8f9201
-	source_aarch64 = modfetch-0.8.1-linux-arm64::https://github.com/jxwalker/modfetch/releases/download/v0.8.1/modfetch_linux_arm64
-	sha256sums_aarch64 = a8de023093967cc6b5c6c6ac61faddb687bc6d1eb6635bb1163f79fbd5cb83d7
+	source_x86_64 = modfetch-0.9.0-linux-amd64::https://github.com/jxwalker/modfetch/releases/download/v0.9.0/modfetch_linux_amd64
+	sha256sums_x86_64 = 7e9854541455317e7db188a43b5df78f4b1f633cb3cd14c4b5ef39984d2ec27c
+	source_aarch64 = modfetch-0.9.0-linux-arm64::https://github.com/jxwalker/modfetch/releases/download/v0.9.0/modfetch_linux_arm64
+	sha256sums_aarch64 = 5e6859b2eda89063304dccbf2ffeebaf8dd0d69c58cd7f65a03b4d4eb0aaac98
 
 pkgname = modfetch-bin

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: James Walker <james@jameswalker.org.uk>
 pkgname=modfetch-bin
 _pkgname=modfetch
-pkgver=0.8.1
+pkgver=0.9.0
 pkgrel=1
 pkgdesc="Robust CLI/TUI downloader for LLM and Stable Diffusion assets"
 arch=('x86_64' 'aarch64')
@@ -14,10 +14,10 @@ source=("LICENSE::https://raw.githubusercontent.com/jxwalker/modfetch/v${pkgver}
 sha256sums=('73be8e0a20ff3b0a6991d6405d4d485e5ffc8dfb07a13a1f1b7afb081f57ee54')
 
 source_x86_64=("${_pkgname}-${pkgver}-linux-amd64::https://github.com/jxwalker/modfetch/releases/download/v${pkgver}/${_pkgname}_linux_amd64")
-sha256sums_x86_64=('09f8bede51811fa5e4e61a5437b2654058ef96f0ee6db231178d03186e8f9201')
+sha256sums_x86_64=('7e9854541455317e7db188a43b5df78f4b1f633cb3cd14c4b5ef39984d2ec27c')
 
 source_aarch64=("${_pkgname}-${pkgver}-linux-arm64::https://github.com/jxwalker/modfetch/releases/download/v${pkgver}/${_pkgname}_linux_arm64")
-sha256sums_aarch64=('a8de023093967cc6b5c6c6ac61faddb687bc6d1eb6635bb1163f79fbd5cb83d7')
+sha256sums_aarch64=('5e6859b2eda89063304dccbf2ffeebaf8dd0d69c58cd7f65a03b4d4eb0aaac98')
 
 package() {
   local binary


### PR DESCRIPTION
## Summary
- update checked AUR metadata to v0.9.0 release assets and checksums
- fix future macOS universal release checksum generation so .sha256 validates beside the downloaded asset
- record the post-release package maintenance in Unreleased

## Validation
- scripts/check-aur-package.sh v0.9.0
- scripts/check-docs-drift.sh v0.9.0
- ruby YAML parse of .github/workflows/release.yml
- git diff --check